### PR TITLE
validate rcvbuf socket option

### DIFF
--- a/src/ergw_config.erl
+++ b/src/ergw_config.erl
@@ -97,6 +97,8 @@ validate_socket_option(netns, Value)
     Value;
 validate_socket_option(freebind, true) ->
     freebind;
+validate_socket_option(rcvbuf, Value) when is_integer(Value) ->
+    Value;
 validate_socket_option(Opt, Value) ->
     throw({error, {options, {Opt, Value}}}).
 


### PR DESCRIPTION
Add the missing configuration validation of the rcfbuf socket option.