### PR TITLE
proxy and path restart fixes

### DIFF
--- a/src/ergw_config.erl
+++ b/src/ergw_config.erl
@@ -89,12 +89,6 @@ validate_socket_option(ip, Value)
   when is_tuple(Value) andalso
        (tuple_size(Value) == 4 orelse tuple_size(Value) == 8) ->
     Value;
-validate_socket_option('$local_port', Value)
-  when is_integer(Value) ->
-    Value;
-validate_socket_option('$remote_port', Value)
-  when is_integer(Value) ->
-    Value;
 validate_socket_option(netdev, Value)
   when is_list(Value); is_binary(Value) ->
     Value;

--- a/src/gtp_path.erl
+++ b/src/gtp_path.erl
@@ -309,8 +309,9 @@ ets_foreach(TID, Fun) ->
 
 ets_foreach(_TID, _Fun, '$end_of_table') ->
     ok;
-ets_foreach(TID, Fun, {[Pids], Continuation}) ->
-    lists:foreach(Fun, Pids),
+ets_foreach(TID, Fun, {Pids, Continuation})
+  when is_list(Pids) ->
+    lists:foreach(fun([Pid]) -> Fun(Pid) end, Pids),
     ets_foreach(TID, Fun, ets:match_object(Continuation)).
 
 register(Pid, #state{table = TID} = State0) ->

--- a/test/ergw_ggsn_test_lib.erl
+++ b/test/ergw_ggsn_test_lib.erl
@@ -133,8 +133,8 @@ make_request(create_pdp_context_request, SubType,
     IEs0 =
 	[#recovery{restart_counter = RCnt},
 	 #access_point_name{apn = ?'APN-EXAMPLE'},
-	 #gsn_address{instance = 0, address = gtp_c_lib:ip2bin(?LOCALHOST)},
-	 #gsn_address{instance = 1, address = gtp_c_lib:ip2bin(?LOCALHOST)},
+	 #gsn_address{instance = 0, address = gtp_c_lib:ip2bin(?CLIENT_IP)},
+	 #gsn_address{instance = 1, address = gtp_c_lib:ip2bin(?CLIENT_IP)},
 	 #imei{imei = <<"1234567890123456">>},
 	 #international_mobile_subscriber_identity{imsi = ?IMSI},
 	 #ms_international_pstn_isdn_number{
@@ -165,8 +165,8 @@ make_request(update_pdp_context_request, _SubType,
 		   local_data_tei = LocalDataTEI,
 		   remote_control_tei = RemoteCntlTEI}) ->
     IEs = [#recovery{restart_counter = RCnt},
-	   #gsn_address{instance = 0, address = gtp_c_lib:ip2bin(?LOCALHOST)},
-	   #gsn_address{instance = 1, address = gtp_c_lib:ip2bin(?LOCALHOST)},
+	   #gsn_address{instance = 0, address = gtp_c_lib:ip2bin(?CLIENT_IP)},
+	   #gsn_address{instance = 1, address = gtp_c_lib:ip2bin(?CLIENT_IP)},
 	   #international_mobile_subscriber_identity{imsi = ?IMSI},
 	   #nsapi{nsapi = 5},
 	   #quality_of_service_profile{

--- a/test/ergw_pgw_test_lib.erl
+++ b/test/ergw_pgw_test_lib.erl
@@ -295,6 +295,59 @@ make_request(delete_session_request, _SubType,
 
 %%%-------------------------------------------------------------------
 
+make_response(#gtp{type = create_session_request, seq_no = SeqNo},
+	      _SubType,
+	      #gtpc{restart_counter = RCnt,
+		    local_control_tei = LocalCntlTEI,
+		    local_data_tei = LocalDataTEI,
+		    remote_control_tei = RemoteCntlTEI}) ->
+    IEs = #{{v2_cause,0} => #v2_cause{v2_cause = request_accepted},
+	    {v2_apn_restriction, 0} =>
+		#v2_apn_restriction{restriction_type_value = 0},
+	    {v2_bearer_context, 0} =>
+		#v2_bearer_context{
+		   group =
+		       #{{v2_cause, 0} =>
+			     #v2_cause{v2_cause = request_accepted},
+			 {v2_charging_id, 0} =>
+			     #v2_charging_id{id = <<0,0,0,1>>},
+			 {v2_bearer_level_quality_of_service, 0} =>
+			     #v2_bearer_level_quality_of_service{
+				pci = 1, pl = 10, pvi = 0, label = 8,
+				maximum_bit_rate_for_uplink      = 0,
+				maximum_bit_rate_for_downlink    = 0,
+				guaranteed_bit_rate_for_uplink   = 0,
+				guaranteed_bit_rate_for_downlink = 0},
+			 {v2_eps_bearer_id, 0} =>
+			     #v2_eps_bearer_id{eps_bearer_id = 5},
+			 {v2_fully_qualified_tunnel_endpoint_identifier, 2} =>
+			     #v2_fully_qualified_tunnel_endpoint_identifier{
+				instance = 2,
+				interface_type = ?'S5/S8-U PGW',
+				key = LocalDataTEI,
+				ipv4 = gtp_c_lib:ip2bin(?TEST_GSN)}
+			}},
+	    {v2_fully_qualified_tunnel_endpoint_identifier, 1} =>
+		#v2_fully_qualified_tunnel_endpoint_identifier{
+		   instance = 1,
+		   interface_type = ?'S5/S8-C PGW',
+		   key = LocalCntlTEI,
+		   ipv4 = gtp_c_lib:ip2bin(?TEST_GSN)},
+	    {v2_pdn_address_allocation, 0} =>
+		#v2_pdn_address_allocation{
+		   type = ipv4,
+		   address = gtp_c_lib:ip2bin(?LOCALHOST)},
+	    {v2_protocol_configuration_options, 0} =>
+		#v2_protocol_configuration_options{
+		   config = {0, [{ipcp,'CP-Configure-Nak',0,
+				  [{ms_dns1, gtp_c_lib:ip2bin({8,8,8,8})},
+				   {ms_dns2, gtp_c_lib:ip2bin({8,8,4,4})}]},
+				 {13, gtp_c_lib:ip2bin({8,8,4,4})},
+				 {13, gtp_c_lib:ip2bin({8,8,8,8})}]}},
+	    {v2_recovery, 0} => #v2_recovery{restart_counter = RCnt}},
+    #gtp{version = v2, type = create_session_response,
+	 tei = RemoteCntlTEI, seq_no = SeqNo, ie = IEs};
+
 make_response(#gtp{type = delete_bearer_request, seq_no = SeqNo},
 	      _SubType,
 	      #gtpc{restart_counter = RCnt,

--- a/test/ergw_pgw_test_lib.erl
+++ b/test/ergw_pgw_test_lib.erl
@@ -141,12 +141,12 @@ make_request(create_session_request, SubType,
 			instance = 2,
 			interface_type = ?'S5/S8-U SGW',
 			key = LocalDataTEI,
-			ipv4 = gtp_c_lib:ip2bin(?LOCALHOST)}
+			ipv4 = gtp_c_lib:ip2bin(?CLIENT_IP)}
 		    ]},
 	 #v2_fully_qualified_tunnel_endpoint_identifier{
 	    interface_type = ?'S5/S8-C SGW',
 	    key = LocalCntlTEI,
-	    ipv4 = gtp_c_lib:ip2bin(?LOCALHOST)},
+	    ipv4 = gtp_c_lib:ip2bin(?CLIENT_IP)},
 	 #v2_international_mobile_subscriber_identity{
 	    imsi = ?'IMSI'},
 	 #v2_mobile_equipment_identity{mei = <<"AAAAAAAA">>},
@@ -174,12 +174,12 @@ make_request(modify_bearer_request, tei_update,
 			  instance = 1,
 			  interface_type = ?'S5/S8-U SGW',
 			  key = LocalDataTEI,
-			  ipv4 = gtp_c_lib:ip2bin(?LOCALHOST)}
+			  ipv4 = gtp_c_lib:ip2bin(?CLIENT_IP)}
 		      ]},
 	   #v2_fully_qualified_tunnel_endpoint_identifier{
 	      interface_type = ?'S5/S8-C SGW',
 	      key = LocalCntlTEI,
-	      ipv4 = gtp_c_lib:ip2bin(?LOCALHOST)}
+	      ipv4 = gtp_c_lib:ip2bin(?CLIENT_IP)}
 	  ],
 
     #gtp{version = v2, type = modify_bearer_request, tei = RemoteCntlTEI,
@@ -197,7 +197,7 @@ make_request(modify_bearer_request, SubType,
 	   #v2_fully_qualified_tunnel_endpoint_identifier{
 	      interface_type = ?'S5/S8-C SGW',
 	      key = LocalCntlTEI,
-	      ipv4 = gtp_c_lib:ip2bin(?LOCALHOST)}
+	      ipv4 = gtp_c_lib:ip2bin(?CLIENT_IP)}
 	  ],
 
     #gtp{version = v2, type = modify_bearer_request, tei = RemoteCntlTEI,
@@ -217,7 +217,7 @@ make_request(modify_bearer_command, SubType,
 	   #v2_fully_qualified_tunnel_endpoint_identifier{
 	      interface_type = ?'S5/S8-C SGW',
 	      key = LocalCntlTEI,
-	      ipv4 = gtp_c_lib:ip2bin(?LOCALHOST)}
+	      ipv4 = gtp_c_lib:ip2bin(?CLIENT_IP)}
 	  ],
     #gtp{version = v2, type = modify_bearer_command, tei = RemoteCntlTEI,
 	 seq_no = SeqNo, ie = IEs};
@@ -286,7 +286,7 @@ make_request(delete_session_request, _SubType,
 	   #v2_fully_qualified_tunnel_endpoint_identifier{
 	      interface_type = ?'S5/S8-C SGW',
 	      key = LocalCntlTEI,
-	      ipv4 = gtp_c_lib:ip2bin(?LOCALHOST)},
+	      ipv4 = gtp_c_lib:ip2bin(?CLIENT_IP)},
 	   #v2_user_location_information{tai = <<3,2,22,214,217>>,
 					 ecgi = <<3,2,22,8,71,9,92>>}],
 

--- a/test/ergw_test_lib.erl
+++ b/test/ergw_test_lib.erl
@@ -157,16 +157,14 @@ gtp_context_new_teids(GtpC) ->
 %%% I/O and socket functions
 %%%===================================================================
 
-make_gtp_socket(Config) ->
-    {_, Port} = lists:keyfind(gtp_port, 1, Config),   %% let it crash if undefined
-
-    {ok, S} = gen_udp:open(Port, [{ip, ?LOCALHOST}, {active, false},
-				  binary, {reuseaddr, true}]),
+make_gtp_socket(_Config) ->
+    {ok, S} = gen_udp:open(?GTP2c_PORT, [{ip, ?CLIENT_IP}, {active, false},
+					 binary, {reuseaddr, true}]),
     S.
 
 send_pdu(S, Msg) ->
     Data = gtp_packet:encode(Msg),
-    ok = gen_udp:send(S, ?LOCALHOST, ?GTP2c_PORT, Data).
+    ok = gen_udp:send(S, ?TEST_GSN, ?GTP2c_PORT, Data).
 
 send_recv_pdu(S, Msg) ->
     send_recv_pdu(S, Msg, ?TIMEOUT).
@@ -186,7 +184,7 @@ recv_pdu(_, _SeqNo, Timeout, Fail) when Timeout =< 0 ->
 recv_pdu(S, SeqNo, Timeout, Fail) ->
     Now = erlang:monotonic_time(millisecond),
     case gen_udp:recv(S, 4096, Timeout) of
-	{ok, {?LOCALHOST, _, Response}} ->
+	{ok, {?TEST_GSN, _, Response}} ->
 	    recv_pdu_msg(Response, Now, S, SeqNo, Timeout, Fail);
 	{error, Error} ->
 	    recv_pdu_fail(Fail, Error);

--- a/test/ergw_test_lib.hrl
+++ b/test/ergw_test_lib.hrl
@@ -26,6 +26,10 @@
 -endif.
 
 -define(LOCALHOST, {127,0,0,1}).
+-define(CLIENT_IP, {127,127,127,127}).
+-define(TEST_GSN, ?LOCALHOST).
+-define(PROXY_GSN, {127,0,100,1}).
+-define(FINAL_GSN, {127,0,200,1}).
 
 -define('APN-EXAMPLE', [<<"example">>, <<"net">>]).
 -define('IMSI', <<"111111111111111">>).

--- a/test/ggsn_SUITE.erl
+++ b/test/ggsn_SUITE.erl
@@ -33,9 +33,8 @@
 
 		      {ergw, [{sockets,
 			       [{irx, [{type, 'gtp-c'},
-				       {ip,  {127,0,0,1}},
-				       {reuseaddr, true},
-				       {'$remote_port', ?GTP1c_PORT * 4}
+				       {ip,  ?TEST_GSN},
+				       {reuseaddr, true}
 				      ]},
 				{grx, [{type, 'gtp-u'},
 				       {node, 'gtp-u-node@localhost'},
@@ -82,8 +81,7 @@ suite() ->
 
 init_per_suite(Config0) ->
     Config = [{handler_under_test, ?HUT},
-	      {app_cfg, ?TEST_CONFIG},
-	      {gtp_port, ?GTP1c_PORT * 4}
+	      {app_cfg, ?TEST_CONFIG}
 	      | Config0],
 
     lib_init_per_suite(Config).
@@ -157,7 +155,7 @@ invalid_gtp_pdu() ->
       " and that the GTP socket is not crashing"}].
 invalid_gtp_pdu(Config) ->
     S = make_gtp_socket(Config),
-    gen_udp:send(S, ?LOCALHOST, ?GTP1c_PORT, <<"TESTDATA">>),
+    gen_udp:send(S, ?TEST_GSN, ?GTP1c_PORT, <<"TESTDATA">>),
 
     ?equal({error,timeout}, gen_udp:recv(S, 4096, ?TIMEOUT)),
     meck_validate(Config),

--- a/test/ggsn_SUITE.erl
+++ b/test/ggsn_SUITE.erl
@@ -22,58 +22,60 @@
 %%% API
 %%%===================================================================
 
--define(TEST_CONFIG, [
-		      {lager, [{colored, true},
-			       {error_logger_redirect, false},
-			       %% force lager into async logging, otherwise
-			       %% the test will timeout randomly
-			       {async_threshold, undefined},
-			       {handlers, [{lager_console_backend, debug}]}
-			      ]},
+-define(TEST_CONFIG,
+	[
+	 {lager, [{colored, true},
+		  {error_logger_redirect, false},
+		  %% force lager into async logging, otherwise
+		  %% the test will timeout randomly
+		  {async_threshold, undefined},
+		  {handlers, [{lager_console_backend, debug}]}
+		 ]},
 
-		      {ergw, [{sockets,
-			       [{irx, [{type, 'gtp-c'},
-				       {ip,  ?TEST_GSN},
-				       {reuseaddr, true}
-				      ]},
-				{grx, [{type, 'gtp-u'},
-				       {node, 'gtp-u-node@localhost'},
-				       {name, 'grx'}]}
-			       ]},
+	 {ergw, [{sockets,
+		  [{irx, [{type, 'gtp-c'},
+			  {ip,  ?TEST_GSN},
+			  {reuseaddr, true}
+			 ]},
+		   {grx, [{type, 'gtp-u'},
+			  {node, 'gtp-u-node@localhost'},
+			  {name, 'grx'}]}
+		  ]},
 
-			      {vrfs,
-			       [{upstream, [{pools,  [{{10, 180, 0, 1}, {10, 180, 255, 254}, 32},
-						      {{16#8001, 0, 0, 0, 0, 0, 0, 0}, {16#8001, 0, 0, 16#FFFF, 0, 0, 0, 0}, 64}
-						     ]},
-					    {'MS-Primary-DNS-Server', {8,8,8,8}},
-					    {'MS-Secondary-DNS-Server', {8,8,4,4}},
-					    {'MS-Primary-NBNS-Server', {127,0,0,1}},
-					    {'MS-Secondary-NBNS-Server', {127,0,0,1}}
-					   ]}
-			       ]},
+		 {vrfs,
+		  [{upstream, [{pools,  [{{10, 180, 0, 1}, {10, 180, 255, 254}, 32},
+					 {{16#8001, 0, 0, 0, 0, 0, 0, 0},
+					  {16#8001, 0, 0, 16#FFFF, 0, 0, 0, 0}, 64}
+					]},
+			       {'MS-Primary-DNS-Server', {8,8,8,8}},
+			       {'MS-Secondary-DNS-Server', {8,8,4,4}},
+			       {'MS-Primary-NBNS-Server', {127,0,0,1}},
+			       {'MS-Secondary-NBNS-Server', {127,0,0,1}}
+			      ]}
+		  ]},
 
-			      {handlers,
-			       [{gn, [{handler, ggsn_gn},
-				      {sockets, [irx]},
-				      {data_paths, [grx]},
-				      {aaa, [{'Username',
-					      [{default, ['IMSI',   <<"/">>,
-							  'IMEI',   <<"/">>,
-							  'MSISDN', <<"/">>,
-							  'ATOM',   <<"/">>,
-							  "TEXT",   <<"/">>,
-							  12345,
-							  <<"@">>, 'APN']}]}]}
-				     ]}
-			       ]},
+		 {handlers,
+		  [{gn, [{handler, ggsn_gn},
+			 {sockets, [irx]},
+			 {data_paths, [grx]},
+			 {aaa, [{'Username',
+				 [{default, ['IMSI',   <<"/">>,
+					     'IMEI',   <<"/">>,
+					     'MSISDN', <<"/">>,
+					     'ATOM',   <<"/">>,
+					     "TEXT",   <<"/">>,
+					     12345,
+					     <<"@">>, 'APN']}]}]}
+			]}
+		  ]},
 
-			      {apns,
-			       [{?'APN-EXAMPLE', [{vrf, upstream}]},
-				{[<<"APN1">>], [{vrf, upstream}]}
-			       ]}
-			     ]},
-		      {ergw_aaa, [{ergw_aaa_provider, {ergw_aaa_mock, [{secret, <<"MySecret">>}]}}]}
-		     ]).
+		 {apns,
+		  [{?'APN-EXAMPLE', [{vrf, upstream}]},
+		   {[<<"APN1">>], [{vrf, upstream}]}
+		  ]}
+		]},
+	 {ergw_aaa, [{ergw_aaa_provider, {ergw_aaa_mock, [{secret, <<"MySecret">>}]}}]}
+	]).
 
 
 suite() ->

--- a/test/ggsn_SUITE.erl
+++ b/test/ggsn_SUITE.erl
@@ -29,7 +29,7 @@
 		  %% force lager into async logging, otherwise
 		  %% the test will timeout randomly
 		  {async_threshold, undefined},
-		  {handlers, [{lager_console_backend, debug}]}
+		  {handlers, [{lager_console_backend, info}]}
 		 ]},
 
 	 {ergw, [{sockets,

--- a/test/ggsn_proxy_SUITE.erl
+++ b/test/ggsn_proxy_SUITE.erl
@@ -30,7 +30,7 @@
 		  %% force lager into async logging, otherwise
 		  %% the test will timeout randomly
 		  {async_threshold, undefined},
-		  {handlers, [{lager_console_backend, debug}]}
+		  {handlers, [{lager_console_backend, info}]}
 		 ]},
 
 	 {ergw, [{sockets,
@@ -113,7 +113,7 @@
 		  %% force lager into async logging, otherwise
 		  %% the test will timeout randomly
 		  {async_threshold, undefined},
-		  {handlers, [{lager_console_backend, debug}]}
+		  {handlers, [{lager_console_backend, info}]}
 		 ]},
 
 	 {ergw, [{sockets,

--- a/test/ggsn_proxy_SUITE.erl
+++ b/test/ggsn_proxy_SUITE.erl
@@ -34,29 +34,24 @@
 
 		      {ergw, [{sockets,
 			       [{irx, [{type, 'gtp-c'},
-				       {ip,  {127,0,0,1}},
-				       {reuseaddr, true},
-				       {'$remote_port', ?GTP1c_PORT * 4}
+				       {ip,  ?TEST_GSN},
+				       {reuseaddr, true}
 				      ]},
 				{grx, [{type, 'gtp-u'},
 				       {node, 'gtp-u-node@localhost'},
 				       {name, 'grx'}
 				      ]},
 				{'proxy-irx', [{type, 'gtp-c'},
-					       {ip,  {127,0,0,1}},
-					       {reuseaddr, true},
-					       {'$local_port',  ?GTP1c_PORT * 2},
-					       {'$remote_port', ?GTP1c_PORT * 3}
+					       {ip,  ?PROXY_GSN},
+					       {reuseaddr, true}
 					      ]},
 				{'proxy-grx', [{type, 'gtp-u'},
 					       {node, 'gtp-u-proxy@vlx161-tpmd'},
 					       {name, 'proxy-grx'}
 					      ]},
 				{'remote-irx', [{type, 'gtp-c'},
-						{ip,  {127,0,0,1}},
-						{reuseaddr, true},
-						{'$local_port',  ?GTP1c_PORT * 3},
-						{'$remote_port', ?GTP1c_PORT * 2}
+						{ip,  ?FINAL_GSN},
+						{reuseaddr, true}
 					       ]},
 				{'remote-grx', [{type, 'gtp-u'},
 						{node, 'gtp-u-node@localhost'},
@@ -82,7 +77,7 @@
 				      {data_paths, [grx]},
 				      {proxy_sockets, ['proxy-irx']},
 				      {proxy_data_paths, ['proxy-grx']},
-				      {ggsn, {127,0,0,1}},
+				      {ggsn, ?FINAL_GSN},
 				      {contexts,
 				       [{<<"ams">>,
 					 [{proxy_sockets, ['proxy-irx']},
@@ -115,8 +110,7 @@ suite() ->
 
 init_per_suite(Config0) ->
     Config = [{handler_under_test, ?HUT},
-	      {app_cfg, ?TEST_CONFIG},
-	      {gtp_port, ?GTP1c_PORT * 4}
+	      {app_cfg, ?TEST_CONFIG}
 	      | Config0],
 
     lib_init_per_suite(Config).
@@ -190,7 +184,7 @@ invalid_gtp_pdu() ->
       " and that the GTP socket is not crashing"}].
 invalid_gtp_pdu(Config) ->
     S = make_gtp_socket(Config),
-    gen_udp:send(S, ?LOCALHOST, ?GTP1c_PORT, <<"TESTDATA">>),
+    gen_udp:send(S, ?TEST_GSN, ?GTP1c_PORT, <<"TESTDATA">>),
 
     ?equal({error,timeout}, gen_udp:recv(S, 4096, ?TIMEOUT)),
     meck_validate(Config),

--- a/test/ggsn_proxy_SUITE.erl
+++ b/test/ggsn_proxy_SUITE.erl
@@ -23,86 +23,88 @@
 %%% API
 %%%===================================================================
 
--define(TEST_CONFIG, [
-		      {lager, [{colored, true},
-			       {error_logger_redirect, true},
-			       %% force lager into async logging, otherwise
-			       %% the test will timeout randomly
-			       {async_threshold, undefined},
-			       {handlers, [{lager_console_backend, debug}]}
-			      ]},
+-define(TEST_CONFIG,
+	[
+	 {lager, [{colored, true},
+		  {error_logger_redirect, true},
+		  %% force lager into async logging, otherwise
+		  %% the test will timeout randomly
+		  {async_threshold, undefined},
+		  {handlers, [{lager_console_backend, debug}]}
+		 ]},
 
-		      {ergw, [{sockets,
-			       [{irx, [{type, 'gtp-c'},
-				       {ip,  ?TEST_GSN},
-				       {reuseaddr, true}
-				      ]},
-				{grx, [{type, 'gtp-u'},
-				       {node, 'gtp-u-node@localhost'},
-				       {name, 'grx'}
-				      ]},
-				{'proxy-irx', [{type, 'gtp-c'},
-					       {ip,  ?PROXY_GSN},
-					       {reuseaddr, true}
-					      ]},
-				{'proxy-grx', [{type, 'gtp-u'},
-					       {node, 'gtp-u-proxy@vlx161-tpmd'},
-					       {name, 'proxy-grx'}
-					      ]},
-				{'remote-irx', [{type, 'gtp-c'},
-						{ip,  ?FINAL_GSN},
-						{reuseaddr, true}
-					       ]},
-				{'remote-grx', [{type, 'gtp-u'},
-						{node, 'gtp-u-node@localhost'},
-						{name, 'remote-grx'}
-					       ]}
-			       ]},
+	 {ergw, [{sockets,
+		  [{irx, [{type, 'gtp-c'},
+			  {ip,  ?TEST_GSN},
+			  {reuseaddr, true}
+			 ]},
+		   {grx, [{type, 'gtp-u'},
+			  {node, 'gtp-u-node@localhost'},
+			  {name, 'grx'}
+			 ]},
+		   {'proxy-irx', [{type, 'gtp-c'},
+				  {ip,  ?PROXY_GSN},
+				  {reuseaddr, true}
+				 ]},
+		   {'proxy-grx', [{type, 'gtp-u'},
+				  {node, 'gtp-u-proxy@vlx161-tpmd'},
+				  {name, 'proxy-grx'}
+				 ]},
+		   {'remote-irx', [{type, 'gtp-c'},
+				   {ip,  ?FINAL_GSN},
+				   {reuseaddr, true}
+				  ]},
+		   {'remote-grx', [{type, 'gtp-u'},
+				   {node, 'gtp-u-node@localhost'},
+				   {name, 'remote-grx'}
+				  ]}
+		  ]},
 
-			      {vrfs,
-			       [{example, [{pools,  [{{10, 180, 0, 1}, {10, 180, 255, 254}, 32},
-						     {{16#8001, 0, 0, 0, 0, 0, 0, 0}, {16#8001, 0, 0, 16#FFFF, 0, 0, 0, 0}, 64}
-						    ]},
-					   {'MS-Primary-DNS-Server', {8,8,8,8}},
-					   {'MS-Secondary-DNS-Server', {8,8,4,4}},
-					   {'MS-Primary-NBNS-Server', {127,0,0,1}},
-					   {'MS-Secondary-NBNS-Server', {127,0,0,1}}
-					  ]}
-			       ]},
+		 {vrfs,
+		  [{example, [{pools,  [{{10, 180, 0, 1}, {10, 180, 255, 254}, 32},
+					{{16#8001, 0, 0, 0, 0, 0, 0, 0},
+					 {16#8001, 0, 0, 16#FFFF, 0, 0, 0, 0}, 64}
+				       ]},
+			      {'MS-Primary-DNS-Server', {8,8,8,8}},
+			      {'MS-Secondary-DNS-Server', {8,8,4,4}},
+			      {'MS-Primary-NBNS-Server', {127,0,0,1}},
+			      {'MS-Secondary-NBNS-Server', {127,0,0,1}}
+			     ]}
+		  ]},
 
-			      {handlers,
-			       %% proxy handler
-			       [{gn, [{handler, ?HUT},
-				      {sockets, [irx]},
-				      {data_paths, [grx]},
-				      {proxy_sockets, ['proxy-irx']},
-				      {proxy_data_paths, ['proxy-grx']},
-				      {ggsn, ?FINAL_GSN},
-				      {contexts,
-				       [{<<"ams">>,
-					 [{proxy_sockets, ['proxy-irx']},
-					  {proxy_data_paths, ['proxy-grx']}]}]}
-				     ]},
-				%% remote GGSN handler
-				{gn, [{handler, ggsn_gn},
-				      {sockets, ['remote-irx']},
-				      {data_paths, ['remote-grx']},
-				      {aaa, [{'Username',
-					      [{default, ['IMSI', <<"@">>, 'APN']}]}]}
-				     ]}
-			       ]},
+		 {handlers,
+		  %% proxy handler
+		  [{gn, [{handler, ?HUT},
+			 {sockets, [irx]},
+			 {data_paths, [grx]},
+			 {proxy_sockets, ['proxy-irx']},
+			 {proxy_data_paths, ['proxy-grx']},
+			 {ggsn, ?FINAL_GSN},
+			 {contexts,
+			  [{<<"ams">>,
+			    [{proxy_sockets, ['proxy-irx']},
+			     {proxy_data_paths, ['proxy-grx']}]}]}
+			]},
+		   %% remote GGSN handler
+		   {gn, [{handler, ggsn_gn},
+			 {sockets, ['remote-irx']},
+			 {data_paths, ['remote-grx']},
+			 {aaa, [{'Username',
+				 [{default, ['IMSI', <<"@">>, 'APN']}]}]}
+			]}
+		  ]},
 
-			      {apns,
-			       [{?'APN-PROXY', [{vrf, example}]}
-			       ]},
+		 {apns,
+		  [{?'APN-PROXY', [{vrf, example}]}
+		  ]},
 
-			      {proxy_map,
-			       [{apn,  [{?'APN-EXAMPLE', ?'APN-PROXY'}]},
-				{imsi, [{?'IMSI', {?'PROXY-IMSI', ?'PROXY-MSISDN'}}
-				       ]}
-			       ]}			     ]},
-		      {ergw_aaa, [{ergw_aaa_provider, {ergw_aaa_mock, [{secret, <<"MySecret">>}]}}]}
-		     ]).
+		 {proxy_map,
+		  [{apn,  [{?'APN-EXAMPLE', ?'APN-PROXY'}]},
+		   {imsi, [{?'IMSI', {?'PROXY-IMSI', ?'PROXY-MSISDN'}}
+			  ]}
+		  ]}			     ]},
+	 {ergw_aaa, [{ergw_aaa_provider, {ergw_aaa_mock, [{secret, <<"MySecret">>}]}}]}
+	]).
 
 
 suite() ->

--- a/test/ggsn_proxy_SUITE.erl
+++ b/test/ggsn_proxy_SUITE.erl
@@ -23,7 +23,7 @@
 %%% API
 %%%===================================================================
 
--define(TEST_CONFIG,
+-define(TEST_CONFIG_MULTIPLE_PROXY_SOCKETS,
 	[
 	 {lager, [{colored, true},
 		  {error_logger_redirect, true},
@@ -106,22 +106,118 @@
 	 {ergw_aaa, [{ergw_aaa_provider, {ergw_aaa_mock, [{secret, <<"MySecret">>}]}}]}
 	]).
 
+-define(TEST_CONFIG_SINGLE_PROXY_SOCKET,
+	[
+	 {lager, [{colored, true},
+		  {error_logger_redirect, true},
+		  %% force lager into async logging, otherwise
+		  %% the test will timeout randomly
+		  {async_threshold, undefined},
+		  {handlers, [{lager_console_backend, debug}]}
+		 ]},
+
+	 {ergw, [{sockets,
+		  [{irx, [{type, 'gtp-c'},
+			  {ip,  ?TEST_GSN},
+			  {reuseaddr, true}
+			 ]},
+		   {grx, [{type, 'gtp-u'},
+			  {node, 'gtp-u-node@localhost'},
+			  {name, 'grx'}
+			 ]},
+		   {'remote-irx', [{type, 'gtp-c'},
+				   {ip,  ?FINAL_GSN},
+				   {reuseaddr, true}
+				  ]},
+		   {'remote-grx', [{type, 'gtp-u'},
+				   {node, 'gtp-u-node@localhost'},
+				   {name, 'remote-grx'}
+				  ]}
+		  ]},
+
+		 {vrfs,
+		  [{example, [{pools,  [{{10, 180, 0, 1}, {10, 180, 255, 254}, 32},
+					{{16#8001, 0, 0, 0, 0, 0, 0, 0},
+					 {16#8001, 0, 0, 16#FFFF, 0, 0, 0, 0}, 64}
+				       ]},
+			      {'MS-Primary-DNS-Server', {8,8,8,8}},
+			      {'MS-Secondary-DNS-Server', {8,8,4,4}},
+			      {'MS-Primary-NBNS-Server', {127,0,0,1}},
+			      {'MS-Secondary-NBNS-Server', {127,0,0,1}}
+			     ]}
+		  ]},
+
+		 {handlers,
+		  %% proxy handler
+		  [{gn, [{handler, ?HUT},
+			 {sockets, [irx]},
+			 {data_paths, [grx]},
+			 {proxy_sockets, ['irx']},
+			 {proxy_data_paths, ['grx']},
+			 {ggsn, ?FINAL_GSN},
+			 {contexts,
+			  [{<<"ams">>,
+			    [{proxy_sockets, ['irx']},
+			     {proxy_data_paths, ['grx']}]}]}
+			]},
+		   %% remote GGSN handler
+		   {gn, [{handler, ggsn_gn},
+			 {sockets, ['remote-irx']},
+			 {data_paths, ['remote-grx']},
+			 {aaa, [{'Username',
+				 [{default, ['IMSI', <<"@">>, 'APN']}]}]}
+			]}
+		  ]},
+
+		 {apns,
+		  [{?'APN-PROXY', [{vrf, example}]}
+		  ]},
+
+		 {proxy_map,
+		  [{apn,  [{?'APN-EXAMPLE', ?'APN-PROXY'}]},
+		   {imsi, [{?'IMSI', {?'PROXY-IMSI', ?'PROXY-MSISDN'}}
+			  ]}
+		  ]}			     ]},
+	 {ergw_aaa, [{ergw_aaa_provider, {ergw_aaa_mock, [{secret, <<"MySecret">>}]}}]}
+	]).
 
 suite() ->
     [{timetrap,{seconds,30}}].
 
 init_per_suite(Config0) ->
-    Config = [{handler_under_test, ?HUT},
-	      {app_cfg, ?TEST_CONFIG}
-	      | Config0],
+    [{handler_under_test, ?HUT} | Config0].
 
+end_per_suite(_Config) ->
+    ok.
+
+init_per_group(single_proxy_interface, Config0) ->
+    Config = lists:keystore(app_cfg, 1, Config0,
+			    {app_cfg, ?TEST_CONFIG_SINGLE_PROXY_SOCKET}),
+    lib_init_per_suite(Config);
+init_per_group(_Group, Config0) ->
+    Config = lists:keystore(app_cfg, 1, Config0,
+			    {app_cfg, ?TEST_CONFIG_MULTIPLE_PROXY_SOCKETS}),
     lib_init_per_suite(Config).
 
-end_per_suite(Config) ->
+end_per_group(_Group, Config) ->
     ok = lib_end_per_suite(Config),
     ok.
 
+%% groups() ->
+%%     [{single_proxy_interface, [], [path_restart]}].
+
+%% all() ->
+%%     [{group, single_proxy_interface}].
+
+groups() ->
+    [{single_proxy_interface, [], all_tests()},
+     {multiple_proxy_interface, [], all_tests()}].
+
 all() ->
+    [{group, single_proxy_interface},
+     {group, multiple_proxy_interface}].
+
+all_tests() ->
     [invalid_gtp_pdu,
      create_pdp_context_request_missing_ie,
      path_restart, path_restart_recovery,

--- a/test/pgw_SUITE.erl
+++ b/test/pgw_SUITE.erl
@@ -22,70 +22,71 @@
 %%% API
 %%%===================================================================
 
--define(TEST_CONFIG, [
-		      {lager, [{colored, true},
-			       {error_logger_redirect, true},
-			       %% force lager into async logging, otherwise
-			       %% the test will timeout randomly
-			       {async_threshold, undefined},
-			       {handlers, [{lager_console_backend, debug}]}
-			      ]},
+-define(TEST_CONFIG,
+	[
+	 {lager, [{colored, true},
+		  {error_logger_redirect, true},
+		  %% force lager into async logging, otherwise
+		  %% the test will timeout randomly
+		  {async_threshold, undefined},
+		  {handlers, [{lager_console_backend, debug}]}
+		 ]},
 
-		      {ergw, [{sockets,
-			       [{irx, [{type, 'gtp-c'},
-				       {ip,  ?TEST_GSN},
-				       {reuseaddr, true}
-				      ]},
-				{grx, [{type, 'gtp-u'},
-				       {node, 'gtp-u-node@localhost'},
-				       {name, 'grx'}]}
-			       ]},
+	 {ergw, [{sockets,
+		  [{irx, [{type, 'gtp-c'},
+			  {ip,  ?TEST_GSN},
+			  {reuseaddr, true}
+			 ]},
+		   {grx, [{type, 'gtp-u'},
+			  {node, 'gtp-u-node@localhost'},
+			  {name, 'grx'}]}
+		  ]},
 
-			      {vrfs,
-			       [{upstream, [{pools,  [{{10, 180, 0, 1}, {10, 180, 255, 254}, 32},
-						      {{16#8001, 0, 0, 0, 0, 0, 0, 0}, {16#8001, 0, 0, 16#FFFF, 0, 0, 0, 0}, 64}
-						     ]},
-					    {'MS-Primary-DNS-Server', {8,8,8,8}},
-					    {'MS-Secondary-DNS-Server', {8,8,4,4}},
-					    {'MS-Primary-NBNS-Server', {127,0,0,1}},
-					    {'MS-Secondary-NBNS-Server', {127,0,0,1}}
-					   ]}
-			       ]},
+		 {vrfs,
+		  [{upstream, [{pools,  [{{10, 180, 0, 1}, {10, 180, 255, 254}, 32},
+					 {{16#8001, 0, 0, 0, 0, 0, 0, 0}, {16#8001, 0, 0, 16#FFFF, 0, 0, 0, 0}, 64}
+					]},
+			       {'MS-Primary-DNS-Server', {8,8,8,8}},
+			       {'MS-Secondary-DNS-Server', {8,8,4,4}},
+			       {'MS-Primary-NBNS-Server', {127,0,0,1}},
+			       {'MS-Secondary-NBNS-Server', {127,0,0,1}}
+			      ]}
+		  ]},
 
-			      {handlers,
-			       [{gn, [{handler, ?HUT},
-				      {sockets, [irx]},
-				      {data_paths, [grx]},
-				      {aaa, [{'Username',
-					      [{default, ['IMSI',   <<"/">>,
-							  'IMEI',   <<"/">>,
-							  'MSISDN', <<"/">>,
-							  'ATOM',   <<"/">>,
-							  "TEXT",   <<"/">>,
-							  12345,
-							  <<"@">>, 'APN']}]}]}
-				     ]},
-				{s5s8, [{handler, ?HUT},
-					{sockets, [irx]},
-					{data_paths, [grx]},
-					{aaa, [{'Username',
-						[{default, ['IMSI',   <<"/">>,
-							    'IMEI',   <<"/">>,
-							    'MSISDN', <<"/">>,
-							    'ATOM',   <<"/">>,
-							    "TEXT",   <<"/">>,
-							    12345,
-							    <<"@">>, 'APN']}]}]}
-				       ]}
-			       ]},
+		 {handlers,
+		  [{gn, [{handler, ?HUT},
+			 {sockets, [irx]},
+			 {data_paths, [grx]},
+			 {aaa, [{'Username',
+				 [{default, ['IMSI',   <<"/">>,
+					     'IMEI',   <<"/">>,
+					     'MSISDN', <<"/">>,
+					     'ATOM',   <<"/">>,
+					     "TEXT",   <<"/">>,
+					     12345,
+					     <<"@">>, 'APN']}]}]}
+			]},
+		   {s5s8, [{handler, ?HUT},
+			   {sockets, [irx]},
+			   {data_paths, [grx]},
+			   {aaa, [{'Username',
+				   [{default, ['IMSI',   <<"/">>,
+					       'IMEI',   <<"/">>,
+					       'MSISDN', <<"/">>,
+					       'ATOM',   <<"/">>,
+					       "TEXT",   <<"/">>,
+					       12345,
+					       <<"@">>, 'APN']}]}]}
+			  ]}
+		  ]},
 
-			      {apns,
-			       [{?'APN-EXAMPLE', [{vrf, upstream}]},
-				{[<<"APN1">>], [{vrf, upstream}]}
-			       ]}
-			     ]},
-		      {ergw_aaa, [{ergw_aaa_provider, {ergw_aaa_mock, [{secret, <<"MySecret">>}]}}]}
-		     ]).
+		 {apns,
+		  [{?'APN-EXAMPLE', [{vrf, upstream}]},
+		   {[<<"APN1">>], [{vrf, upstream}]}
+		  ]}
+		]},
+	 {ergw_aaa, [{ergw_aaa_provider, {ergw_aaa_mock, [{secret, <<"MySecret">>}]}}]}
+	]).
 
 
 suite() ->

--- a/test/pgw_SUITE.erl
+++ b/test/pgw_SUITE.erl
@@ -18,7 +18,6 @@
 -define(TIMEOUT, 2000).
 -define(HUT, pgw_s5s8).				%% Handler Under Test
 
-
 %%%===================================================================
 %%% API
 %%%===================================================================
@@ -34,9 +33,8 @@
 
 		      {ergw, [{sockets,
 			       [{irx, [{type, 'gtp-c'},
-				       {ip,  {127,0,0,1}},
-				       {reuseaddr, true},
-				       {'$remote_port', ?GTP1c_PORT * 4}
+				       {ip,  ?TEST_GSN},
+				       {reuseaddr, true}
 				      ]},
 				{grx, [{type, 'gtp-u'},
 				       {node, 'gtp-u-node@localhost'},
@@ -95,8 +93,7 @@ suite() ->
 
 init_per_suite(Config0) ->
     Config = [{handler_under_test, ?HUT},
-	      {app_cfg, ?TEST_CONFIG},
-	      {gtp_port, ?GTP2c_PORT * 4}
+	      {app_cfg, ?TEST_CONFIG}
 	      | Config0],
 
     lib_init_per_suite(Config).
@@ -177,7 +174,7 @@ invalid_gtp_pdu() ->
       " and that the GTP socket is not crashing"}].
 invalid_gtp_pdu(Config) ->
     S = make_gtp_socket(Config),
-    gen_udp:send(S, ?LOCALHOST, ?GTP2c_PORT, <<"TESTDATA">>),
+    gen_udp:send(S, ?TEST_GSN, ?GTP2c_PORT, <<"TESTDATA">>),
 
     ?equal({error,timeout}, gen_udp:recv(S, 4096, ?TIMEOUT)),
     meck_validate(Config),

--- a/test/pgw_SUITE.erl
+++ b/test/pgw_SUITE.erl
@@ -7,7 +7,7 @@
 
 -module(pgw_SUITE).
 
--compile(export_all).
+-compile([export_all, {parse_transform, lager_transform}]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("gtplib/include/gtp_packet.hrl").
@@ -104,7 +104,8 @@ end_per_suite(Config) ->
     ok.
 
 all() ->
-    [invalid_gtp_pdu,
+    [lager_format_ies,
+     invalid_gtp_pdu,
      create_session_request_missing_ie,
      path_restart, path_restart_recovery, path_restart_multi,
      simple_session_request,
@@ -168,6 +169,19 @@ end_per_testcase(TestCase, Config)
     Config;
 end_per_testcase(_, Config) ->
     Config.
+
+%%--------------------------------------------------------------------
+lager_format_ies() ->
+    [{doc, "Check the lager formater for GTP IE's"}].
+lager_format_ies(_Config) ->
+    GtpC = gtp_context(),
+    Request = make_request(create_session_request, simple, GtpC),
+    Response = make_response(Request, simple, GtpC),
+
+    lager:info("Request: ~p, Response: ~p",
+	       [gtp_c_lib:fmt_gtp(Request), gtp_c_lib:fmt_gtp(Response)]),
+
+    ok.
 
 %%--------------------------------------------------------------------
 invalid_gtp_pdu() ->

--- a/test/pgw_SUITE.erl
+++ b/test/pgw_SUITE.erl
@@ -29,7 +29,7 @@
 		  %% force lager into async logging, otherwise
 		  %% the test will timeout randomly
 		  {async_threshold, undefined},
-		  {handlers, [{lager_console_backend, debug}]}
+		  {handlers, [{lager_console_backend, info}]}
 		 ]},
 
 	 {ergw, [{sockets,

--- a/test/pgw_proxy_SUITE.erl
+++ b/test/pgw_proxy_SUITE.erl
@@ -30,7 +30,7 @@
 		  %% force lager into async logging, otherwise
 		  %% the test will timeout randomly
 		  {async_threshold, undefined},
-		  {handlers, [{lager_console_backend, debug}]}
+		  {handlers, [{lager_console_backend, info}]}
 		 ]},
 
 	 {ergw, [{sockets,
@@ -125,7 +125,7 @@
 		  %% force lager into async logging, otherwise
 		  %% the test will timeout randomly
 		  {async_threshold, undefined},
-		  {handlers, [{lager_console_backend, debug}]}
+		  {handlers, [{lager_console_backend, info}]}
 		 ]},
 
 	 {ergw, [{sockets,

--- a/test/pgw_proxy_SUITE.erl
+++ b/test/pgw_proxy_SUITE.erl
@@ -34,29 +34,24 @@
 
 		      {ergw, [{sockets,
 			       [{irx, [{type, 'gtp-c'},
-				       {ip,  {127,0,0,1}},
-				       {reuseaddr, true},
-				       {'$remote_port', ?GTP1c_PORT * 4}
+				       {ip,  ?TEST_GSN},
+				       {reuseaddr, true}
 				      ]},
 				{grx, [{type, 'gtp-u'},
 				       {node, 'gtp-u-node@localhost'},
 				       {name, 'grx'}
 				      ]},
 				{'proxy-irx', [{type, 'gtp-c'},
-					       {ip,  {127,0,0,1}},
-					       {reuseaddr, true},
-					       {'$local_port',  ?GTP1c_PORT * 2},
-					       {'$remote_port', ?GTP1c_PORT * 3}
+					       {ip,  ?PROXY_GSN},
+					       {reuseaddr, true}
 					      ]},
 				{'proxy-grx', [{type, 'gtp-u'},
 					       {node, 'gtp-u-proxy@vlx161-tpmd'},
 					       {name, 'proxy-grx'}
 					      ]},
 				{'remote-irx', [{type, 'gtp-c'},
-						{ip,  {127,0,0,1}},
-						{reuseaddr, true},
-						{'$local_port',  ?GTP1c_PORT * 3},
-						{'$remote_port', ?GTP1c_PORT * 2}
+						{ip,  ?FINAL_GSN},
+						{reuseaddr, true}
 					       ]},
 				{'remote-grx', [{type, 'gtp-u'},
 						{node, 'gtp-u-node@localhost'},
@@ -82,14 +77,14 @@
 				      {data_paths, [grx]},
 				      {proxy_sockets, ['proxy-irx']},
 				      {proxy_data_paths, ['proxy-grx']},
-				      {pgw, {127,0,0,1}}
+				      {pgw, ?FINAL_GSN}
 				     ]},
 				{s5s8, [{handler, ?HUT},
 					{sockets, [irx]},
 					{data_paths, [grx]},
 					{proxy_sockets, ['proxy-irx']},
 					{proxy_data_paths, ['proxy-grx']},
-					{pgw, {127,0,0,1}},
+					{pgw, ?FINAL_GSN},
 					{contexts,
 					 [{<<"ams">>,
 					   [{proxy_sockets, ['proxy-irx']},
@@ -127,8 +122,7 @@ suite() ->
 
 init_per_suite(Config0) ->
     Config = [{handler_under_test, ?HUT},
-	      {app_cfg, ?TEST_CONFIG},
-	      {gtp_port, ?GTP2c_PORT * 4}
+	      {app_cfg, ?TEST_CONFIG}
 	      | Config0],
 
     lib_init_per_suite(Config).
@@ -206,7 +200,7 @@ invalid_gtp_pdu() ->
       " and that the GTP socket is not crashing"}].
 invalid_gtp_pdu(Config) ->
     S = make_gtp_socket(Config),
-    gen_udp:send(S, ?LOCALHOST, ?GTP2c_PORT, <<"TESTDATA">>),
+    gen_udp:send(S, ?TEST_GSN, ?GTP2c_PORT, <<"TESTDATA">>),
 
     ?equal({error,timeout}, gen_udp:recv(S, 4096, ?TIMEOUT)),
     meck_validate(Config),

--- a/test/pgw_proxy_SUITE.erl
+++ b/test/pgw_proxy_SUITE.erl
@@ -23,98 +23,100 @@
 %%% API
 %%%===================================================================
 
--define(TEST_CONFIG, [
-		      {lager, [{colored, true},
-			       {error_logger_redirect, true},
-			       %% force lager into async logging, otherwise
-			       %% the test will timeout randomly
-			       {async_threshold, undefined},
-			       {handlers, [{lager_console_backend, debug}]}
-			      ]},
+-define(TEST_CONFIG,
+	[
+	 {lager, [{colored, true},
+		  {error_logger_redirect, true},
+		  %% force lager into async logging, otherwise
+		  %% the test will timeout randomly
+		  {async_threshold, undefined},
+		  {handlers, [{lager_console_backend, debug}]}
+		 ]},
 
-		      {ergw, [{sockets,
-			       [{irx, [{type, 'gtp-c'},
-				       {ip,  ?TEST_GSN},
-				       {reuseaddr, true}
-				      ]},
-				{grx, [{type, 'gtp-u'},
-				       {node, 'gtp-u-node@localhost'},
-				       {name, 'grx'}
-				      ]},
-				{'proxy-irx', [{type, 'gtp-c'},
-					       {ip,  ?PROXY_GSN},
-					       {reuseaddr, true}
-					      ]},
-				{'proxy-grx', [{type, 'gtp-u'},
-					       {node, 'gtp-u-proxy@vlx161-tpmd'},
-					       {name, 'proxy-grx'}
-					      ]},
-				{'remote-irx', [{type, 'gtp-c'},
-						{ip,  ?FINAL_GSN},
-						{reuseaddr, true}
-					       ]},
-				{'remote-grx', [{type, 'gtp-u'},
-						{node, 'gtp-u-node@localhost'},
-						{name, 'remote-grx'}
-					       ]}
-			       ]},
+	 {ergw, [{sockets,
+		  [{irx, [{type, 'gtp-c'},
+			  {ip,  ?TEST_GSN},
+			  {reuseaddr, true}
+			 ]},
+		   {grx, [{type, 'gtp-u'},
+			  {node, 'gtp-u-node@localhost'},
+			  {name, 'grx'}
+			 ]},
+		   {'proxy-irx', [{type, 'gtp-c'},
+				  {ip,  ?PROXY_GSN},
+				  {reuseaddr, true}
+				 ]},
+		   {'proxy-grx', [{type, 'gtp-u'},
+				  {node, 'gtp-u-proxy@vlx161-tpmd'},
+				  {name, 'proxy-grx'}
+				 ]},
+		   {'remote-irx', [{type, 'gtp-c'},
+				   {ip,  ?FINAL_GSN},
+				   {reuseaddr, true}
+				  ]},
+		   {'remote-grx', [{type, 'gtp-u'},
+				   {node, 'gtp-u-node@localhost'},
+				   {name, 'remote-grx'}
+				  ]}
+		  ]},
 
-			      {vrfs,
-			       [{example, [{pools,  [{{10, 180, 0, 1}, {10, 180, 255, 254}, 32},
-						     {{16#8001, 0, 0, 0, 0, 0, 0, 0}, {16#8001, 0, 0, 16#FFFF, 0, 0, 0, 0}, 64}
-						    ]},
-					   {'MS-Primary-DNS-Server', {8,8,8,8}},
-					   {'MS-Secondary-DNS-Server', {8,8,4,4}},
-					   {'MS-Primary-NBNS-Server', {127,0,0,1}},
-					   {'MS-Secondary-NBNS-Server', {127,0,0,1}}
-					  ]}
-			       ]},
-
-			      {handlers,
-			       %% proxy handler
-			       [{gn, [{handler, ?HUT},
-				      {sockets, [irx]},
-				      {data_paths, [grx]},
-				      {proxy_sockets, ['proxy-irx']},
-				      {proxy_data_paths, ['proxy-grx']},
-				      {pgw, ?FINAL_GSN}
-				     ]},
-				{s5s8, [{handler, ?HUT},
-					{sockets, [irx]},
-					{data_paths, [grx]},
-					{proxy_sockets, ['proxy-irx']},
-					{proxy_data_paths, ['proxy-grx']},
-					{pgw, ?FINAL_GSN},
-					{contexts,
-					 [{<<"ams">>,
-					   [{proxy_sockets, ['proxy-irx']},
-					    {proxy_data_paths, ['proxy-grx']}]}]}
+		 {vrfs,
+		  [{example, [{pools,  [{{10, 180, 0, 1}, {10, 180, 255, 254}, 32},
+					{{16#8001, 0, 0, 0, 0, 0, 0, 0},
+					 {16#8001, 0, 0, 16#FFFF, 0, 0, 0, 0}, 64}
 				       ]},
-				%% remote PGW handler
-				{gn, [{handler, pgw_s5s8},
-				      {sockets, ['remote-irx']},
-				      {data_paths, ['remote-grx']},
-				      {aaa, [{'Username',
-					      [{default, ['IMSI', <<"@">>, 'APN']}]}]}
-				     ]},
-				{s5s8, [{handler, pgw_s5s8},
-					{sockets, ['remote-irx']},
-					{data_paths, ['remote-grx']}
-				       ]}
-			       ]},
+			      {'MS-Primary-DNS-Server', {8,8,8,8}},
+			      {'MS-Secondary-DNS-Server', {8,8,4,4}},
+			      {'MS-Primary-NBNS-Server', {127,0,0,1}},
+			      {'MS-Secondary-NBNS-Server', {127,0,0,1}}
+			     ]}
+		  ]},
 
-			      {apns,
-			       [{?'APN-PROXY', [{vrf, example}]}
-			       ]},
+		 {handlers,
+		  %% proxy handler
+		  [{gn, [{handler, ?HUT},
+			 {sockets, [irx]},
+			 {data_paths, [grx]},
+			 {proxy_sockets, ['proxy-irx']},
+			 {proxy_data_paths, ['proxy-grx']},
+			 {pgw, ?FINAL_GSN}
+			]},
+		   {s5s8, [{handler, ?HUT},
+			   {sockets, [irx]},
+			   {data_paths, [grx]},
+			   {proxy_sockets, ['proxy-irx']},
+			   {proxy_data_paths, ['proxy-grx']},
+			   {pgw, ?FINAL_GSN},
+			   {contexts,
+			    [{<<"ams">>,
+			      [{proxy_sockets, ['proxy-irx']},
+			       {proxy_data_paths, ['proxy-grx']}]}]}
+			  ]},
+		   %% remote PGW handler
+		   {gn, [{handler, pgw_s5s8},
+			 {sockets, ['remote-irx']},
+			 {data_paths, ['remote-grx']},
+			 {aaa, [{'Username',
+				 [{default, ['IMSI', <<"@">>, 'APN']}]}]}
+			]},
+		   {s5s8, [{handler, pgw_s5s8},
+			   {sockets, ['remote-irx']},
+			   {data_paths, ['remote-grx']}
+			  ]}
+		  ]},
 
-			      {proxy_map,
-			       [{apn,  [{?'APN-EXAMPLE', ?'APN-PROXY'}]},
-				{imsi, [{?'IMSI', {?'PROXY-IMSI', ?'PROXY-MSISDN'}}
-				       ]}
-			       ]}
-			     ]},
-		      {ergw_aaa, [{ergw_aaa_provider, {ergw_aaa_mock, [{secret, <<"MySecret">>}]}}]}
-		     ]).
+		 {apns,
+		  [{?'APN-PROXY', [{vrf, example}]}
+		  ]},
+
+		 {proxy_map,
+		  [{apn,  [{?'APN-EXAMPLE', ?'APN-PROXY'}]},
+		   {imsi, [{?'IMSI', {?'PROXY-IMSI', ?'PROXY-MSISDN'}}
+			  ]}
+		  ]}
+		]},
+	 {ergw_aaa, [{ergw_aaa_provider, {ergw_aaa_mock, [{secret, <<"MySecret">>}]}}]}
+	]).
 
 
 suite() ->


### PR DESCRIPTION
Most changes are just test case improvements to verify the fixes.

The two functional changes are:
 * the proxy is now better on picking the right direction for forwarding a packet
 * fix that a path restart with multiple active context would crash the path handler