### PR TITLE
not need to specify Content-Type header during POST requests

### DIFF
--- a/src/http_api_handler.erl
+++ b/src/http_api_handler.erl
@@ -24,7 +24,7 @@ content_types_provided(Req, State) ->
     {[{<<"application/json">>, handle_request}], Req, State}.
 
 content_types_accepted(Req, State) ->
-    {[{<<"application/json">>, handle_request}], Req, State}.
+    {[{'*', handle_request}], Req, State}.
 
 handle_request(Req, State) ->
     Path = cowboy_req:path(Req),


### PR DESCRIPTION
as we actually have POST requests without body and there is no
sense to send Content-Type header.