### PR TITLE
update ergw_aaa and fix configuration for aaa_mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ This requires a suitable ergw.config, e.g.:
             ]},
     
      {ergw_aaa, [
-                 %% {ergw_aaa_provider, {ergw_aaa_mock, [{secret, <<"MySecret">>}]}}
+                 %% {ergw_aaa_provider, {ergw_aaa_mock, [{shared_secret, <<"MySecret">>}]}}
                  {ergw_aaa_provider,
                   {ergw_aaa_radius,
                    [{nas_identifier,<<"nas01.example.com">>},

--- a/priv/enit/ggsn/etc/enit/ergw/99-user.config
+++ b/priv/enit/ggsn/etc/enit/ergw/99-user.config
@@ -50,7 +50,7 @@
 
 
 {ergw_aaa, [
-	    %% {ergw_aaa_provider, {ergw_aaa_mock, [{secret, <<"MySecret">>}]}}
+	    %% {ergw_aaa_provider, {ergw_aaa_mock, [{shared_secret, <<"MySecret">>}]}}
 	    {ergw_aaa_provider,
 	     {ergw_aaa_radius,
 	      [{nas_identifier,<<"nas01.example.com">>},

--- a/rebar.lock
+++ b/rebar.lock
@@ -24,7 +24,7 @@
   1},
  {<<"ergw_aaa">>,
   {git,"git://github.com/travelping/ergw_aaa",
-       {ref,"22359a1992d265c4103a78a3155c6288f0b46382"}},
+       {ref,"260014045ce18ff63921407e86e6c7e40af01517"}},
   0},
  {<<"erlando">>,
   {git,"https://github.com/travelping/erlando.git",

--- a/test/ergw_http_api_SUITE.erl
+++ b/test/ergw_http_api_SUITE.erl
@@ -79,7 +79,7 @@
 
                  {http_api, [{port, 0}]}
                 ]},
-	 {ergw_aaa, [{ergw_aaa_provider, {ergw_aaa_mock, [{secret, <<"MySecret">>}]}}]}
+	 {ergw_aaa, [{ergw_aaa_provider, {ergw_aaa_mock, [{shared_secret, <<"MySecret">>}]}}]}
 	]).
 
 all() ->

--- a/test/ggsn_SUITE.erl
+++ b/test/ggsn_SUITE.erl
@@ -75,7 +75,7 @@
 		   {[<<"APN1">>], [{vrf, upstream}]}
 		  ]}
 		]},
-	 {ergw_aaa, [{ergw_aaa_provider, {ergw_aaa_mock, [{secret, <<"MySecret">>}]}}]}
+	 {ergw_aaa, [{ergw_aaa_provider, {ergw_aaa_mock, [{shared_secret, <<"MySecret">>}]}}]}
 	]).
 
 

--- a/test/ggsn_proxy_SUITE.erl
+++ b/test/ggsn_proxy_SUITE.erl
@@ -104,7 +104,7 @@
 		   {imsi, [{?'IMSI', {?'PROXY-IMSI', ?'PROXY-MSISDN'}}
 			  ]}
 		  ]}			     ]},
-	 {ergw_aaa, [{ergw_aaa_provider, {ergw_aaa_mock, [{secret, <<"MySecret">>}]}}]}
+	 {ergw_aaa, [{ergw_aaa_provider, {ergw_aaa_mock, [{shared_secret, <<"MySecret">>}]}}]}
 	]).
 
 -define(TEST_CONFIG_SINGLE_PROXY_SOCKET,
@@ -180,7 +180,7 @@
 		   {imsi, [{?'IMSI', {?'PROXY-IMSI', ?'PROXY-MSISDN'}}
 			  ]}
 		  ]}			     ]},
-	 {ergw_aaa, [{ergw_aaa_provider, {ergw_aaa_mock, [{secret, <<"MySecret">>}]}}]}
+	 {ergw_aaa, [{ergw_aaa_provider, {ergw_aaa_mock, [{shared_secret, <<"MySecret">>}]}}]}
 	]).
 
 suite() ->

--- a/test/pgw_SUITE.erl
+++ b/test/pgw_SUITE.erl
@@ -86,7 +86,7 @@
 		   {[<<"APN1">>], [{vrf, upstream}]}
 		  ]}
 		]},
-	 {ergw_aaa, [{ergw_aaa_provider, {ergw_aaa_mock, [{secret, <<"MySecret">>}]}}]}
+	 {ergw_aaa, [{ergw_aaa_provider, {ergw_aaa_mock, [{shared_secret, <<"MySecret">>}]}}]}
 	]).
 
 

--- a/test/pgw_proxy_SUITE.erl
+++ b/test/pgw_proxy_SUITE.erl
@@ -116,7 +116,7 @@
 			  ]}
 		  ]}
 		]},
-	 {ergw_aaa, [{ergw_aaa_provider, {ergw_aaa_mock, [{secret, <<"MySecret">>}]}}]}
+	 {ergw_aaa, [{ergw_aaa_provider, {ergw_aaa_mock, [{shared_secret, <<"MySecret">>}]}}]}
 	]).
 
 -define(TEST_CONFIG_SINGLE_PROXY_SOCKET,
@@ -204,7 +204,7 @@
 			  ]}
 		  ]}
 		]},
-	 {ergw_aaa, [{ergw_aaa_provider, {ergw_aaa_mock, [{secret, <<"MySecret">>}]}}]}
+	 {ergw_aaa, [{ergw_aaa_provider, {ergw_aaa_mock, [{shared_secret, <<"MySecret">>}]}}]}
 	]).
 
 

--- a/tetrapak/dev.config
+++ b/tetrapak/dev.config
@@ -46,7 +46,7 @@
 	]},
 
  {ergw_aaa, [
-	     %% {ergw_aaa_provider, {ergw_aaa_mock, [{secret, <<"MySecret">>}]}}
+	     %% {ergw_aaa_provider, {ergw_aaa_mock, [{shared_secret, <<"MySecret">>}]}}
 	     {ergw_aaa_provider,
 	      {ergw_aaa_radius,
 	       [{nas_identifier,<<"ac1.ac.tplab">>},


### PR DESCRIPTION
ergw_aaa_mock has always use a configuration parameter
`shared_secret`. With the new config validitioan in place in
ergw_aaa, the invalid secret parameter in many samples and
test will no longer work. Replace it with the proper setting.