### PR TITLE
Serve Prometheus metrics on `/api/v1/metrics`

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -199,3 +199,19 @@ If the HTTP API has been enable the metrics can be read at `/api/v1/metrics`.
 Stepping into the result is also possible, e.g.:
 
     curl -X GET "http://localhost:8080/api/v1/metrics/socket/gtp-c/irx/rx/v1" -H  "accept: application/json"
+
+Also, ergw can provide metrics in Prometheus format:
+
+    curl -X GET "http://localhost:8080/api/v1/metrics" -H  "accept: text/plain;version=0.0.4"
+
+or more specific:
+
+    curl -X GET "http://localhost:8080/api/v1/metrics/socket/" -H  "accept: text/plain;version=0.0.4"
+    # TYPE socket_gtp_c_irx_tx_v2_mbms_session_start_response_retransmit gauge
+    socket_gtp_c_irx_tx_v2_mbms_session_start_response_retransmit 0
+
+    # TYPE socket_gtp_c_irx_tx_v2_mbms_session_start_response_count gauge
+    socket_gtp_c_irx_tx_v2_mbms_session_start_response_count 0
+
+Please read Prometheus [Metric names and labels](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels)
+that means all '.' and '-' in metric names which presented above will be replated by '_'.

--- a/src/ergw_api.erl
+++ b/src/ergw_api.erl
@@ -8,7 +8,7 @@
 -module(ergw_api).
 
 %% API
--export([peer/1, tunnel/1, metrics/1]).
+-export([peer/1, tunnel/1, metrics/1, metrics/2]).
 
 %%%===================================================================
 %%% API
@@ -30,14 +30,22 @@ tunnel({_,_,_,_} = IP) ->
 tunnel(Port) when is_atom(Port) ->
     lists:foldl(fun collext_path_contexts/2, [], gtp_path_reg:all(Port)).
 
-metrics(Path) ->
-    Metrics = lists:foldl(fun fmt_exo_entries/2, #{}, exometer:get_values(Path)),
-    lists:foldl(fun(M, A) -> maps:get(M, A) end, Metrics, Path).
+metrics(Path) -> metrics(Path, json).
+
+metrics(Path, prometheus) ->
+    Metrics = exometer:get_values(Path),
+    Formatted = format_metrics(Metrics, []),
+    iolist_to_binary(Formatted);
+metrics(Path, json) ->
+    Metrics0 = lists:foldl(fun fmt_exo_entries/2, #{}, exometer:get_values(Path)),
+    Metrics = lists:foldl(fun(M, A) -> maps:get(M, A) end, Metrics0, Path),
+    jsx:encode(Metrics);
+metrics(Path, _Format) -> metrics(Path, json).
+
 
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================
-
 fmt_exo_entries({Path, Value}, Metrics) ->
     fmt_exo_entries(Path, Value, Metrics).
 
@@ -57,3 +65,76 @@ collect_contexts(Context, Tunnels) ->
     io:format("Context: ~p~n", [Context]),
     Info = gtp_context:info(Context),
     [Info | Tunnels].
+
+% converts metrics to Prometheus format
+% based on github.com/GalaxyGorilla/exometer_prometheus
+format_metrics([], Acc) -> Acc;
+format_metrics([{Metric, DataPoints} | Metrics], Acc) ->
+    Name = make_metric_name(Metric),
+    Info = exometer:info(Metric),
+    Type = map_type(proplists:get_value(type, Info, undefined)),
+    Payload = [[<<"# TYPE ">>, Name, <<" ">>, Type, <<"\n">>] |
+               [[Name, map_datapoint(DPName), <<" ">>, ioize(Value), <<"\n">>]
+                || {DPName, Value} <- DataPoints, is_valid_datapoint(DPName)]],
+    Payload1 = maybe_add_sum(Payload, Name, Metric, Type),
+    format_metrics(Metrics, [Payload1, <<"\n">> | Acc]).
+
+ioize(Atom) when is_atom(Atom) ->
+    atom_to_binary(Atom, utf8);
+ioize(Number) when is_float(Number) ->
+    float_to_binary(Number, [{decimals, 4}]);
+ioize(Number) when is_integer(Number) ->
+    integer_to_binary(Number);
+ioize(Something) ->
+    Something.
+
+maybe_add_sum(Payload, MetricName, Metric, <<"summary">>) ->
+    {ok, [{mean, Mean}, {n, N}]} = exometer:get_value(Metric, [mean, n]),
+    [Payload | [MetricName, <<"_sum ">>, ioize(Mean * N), <<"\n">>]];
+maybe_add_sum(Payload, _MetricName, _Metric, _Else) ->
+    Payload.
+
+make_metric_name(Metric) ->
+    lists:reverse(make_metric_name(Metric, [])).
+
+make_metric_name([], Acc) -> Acc;
+make_metric_name([Elem], Acc) ->
+    [normalize(Elem) | Acc];
+make_metric_name([Elem | Metric], Acc) ->
+    make_metric_name(Metric, [<<"_">>, normalize(Elem) | Acc]).
+
+normalize(Something) ->
+    re:replace(ioize(Something), "-|\\.", "_", [global, {return,binary}]).
+
+map_type(undefined)     -> <<"untyped">>;
+map_type(counter)       -> <<"gauge">>;
+map_type(gauge)         -> <<"gauge">>;
+map_type(spiral)        -> <<"gauge">>;
+map_type(histogram)     -> <<"summary">>;
+map_type(function)      -> <<"gauge">>;
+map_type(Tuple) when is_tuple(Tuple) ->
+    case element(1, Tuple) of
+        function -> <<"gauge">>;
+        _Else    -> <<"untyped">>
+    end.
+
+map_datapoint(value)    -> <<"">>;
+map_datapoint(one)      -> <<"">>;
+map_datapoint(n)        -> <<"_count">>;
+map_datapoint(50)       -> <<"{quantile=\"0.5\"}">>;
+map_datapoint(90)       -> <<"{quantile=\"0.9\"}">>;
+map_datapoint(Integer) when is_integer(Integer)  ->
+    Bin = integer_to_binary(Integer),
+    <<"{quantile=\"0.", Bin/binary, "\"}">>;
+map_datapoint(Something)  ->
+    %% this is for functions with alternative datapoints
+    Bin = ioize(Something),
+    <<"{datapoint=\"", Bin/binary, "\"}">>.
+
+is_valid_datapoint(count) -> false;
+is_valid_datapoint(mean) -> false;
+is_valid_datapoint(min) -> false;
+is_valid_datapoint(max) -> false;
+is_valid_datapoint(median) -> false;
+is_valid_datapoint(ms_since_reset) -> false;
+is_valid_datapoint(_Else) -> true.


### PR DESCRIPTION
Now ergw can provide metrics in Prometheus format on `/api/v1/metrics` endpoint. To configure Prometheus to scape them we should specify`metrics_path`. See example:

    scrape_configs:
        - job_name: 'ergw'
          metrics_path: "api/v1/metrics"
          scrape_interval: 5s
          static_configs:
              - targets: ['localhost:8080']

Depends on ergw configuration `api/v1/metrics` may provide big amount of data. However, it is possible to scrap selective by setting `metrics_path`. Examples:

    metrics_path: "api/v1/metrics/socket"
    metrics_path: "api/v1/metrics/socket/gtp-c"
    metrics_path: "api/v1/metrics/eradius"
    ...

Formatter from exometer to prometheus based on @GalaxyGorilla's [exometer_prometheus](https://github.com/GalaxyGorilla/exometer_prometheus)