### PR TITLE
Serve Prometheus metrics

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -195,18 +195,18 @@ Counters for the following GTPv2-C Messages types exist:
  * update\_pdn\_connection\_set\_response
  * version\_not\_supported
 
-If the HTTP API has been enable the metrics can be read at `/api/v1/metrics`.
+If the HTTP API has been enable the metrics can be read at `/metrics`.
 Stepping into the result is also possible, e.g.:
 
-    curl -X GET "http://localhost:8080/api/v1/metrics/socket/gtp-c/irx/rx/v1" -H  "accept: application/json"
+    curl -X GET "http://localhost:8080/metrics/socket/gtp-c/irx/rx/v1" -H  "accept: application/json"
 
 Also, erGW can provide metrics in Prometheus format:
 
-    curl -X GET "http://localhost:8080/api/v1/metrics" -H  "accept: text/plain;version=0.0.4"
+    curl -X GET "http://localhost:8080/metrics" -H  "accept: text/plain;version=0.0.4"
 
 or more specific:
 
-    curl -X GET "http://localhost:8080/api/v1/metrics/socket/" -H  "accept: text/plain;version=0.0.4"
+    curl -X GET "http://localhost:8080/metrics/socket/" -H  "accept: text/plain;version=0.0.4"
     # TYPE socket_gtp_c_irx_tx_v2_mbms_session_start_response_retransmit gauge
     socket_gtp_c_irx_tx_v2_mbms_session_start_response_retransmit 0
 

--- a/METRICS.md
+++ b/METRICS.md
@@ -199,3 +199,19 @@ If the HTTP API has been enable the metrics can be read at `/api/v1/metrics`.
 Stepping into the result is also possible, e.g.:
 
     curl -X GET "http://localhost:8080/api/v1/metrics/socket/gtp-c/irx/rx/v1" -H  "accept: application/json"
+
+Also, erGW can provide metrics in Prometheus format:
+
+    curl -X GET "http://localhost:8080/api/v1/metrics" -H  "accept: text/plain;version=0.0.4"
+
+or more specific:
+
+    curl -X GET "http://localhost:8080/api/v1/metrics/socket/" -H  "accept: text/plain;version=0.0.4"
+    # TYPE socket_gtp_c_irx_tx_v2_mbms_session_start_response_retransmit gauge
+    socket_gtp_c_irx_tx_v2_mbms_session_start_response_retransmit 0
+
+    # TYPE socket_gtp_c_irx_tx_v2_mbms_session_start_response_count gauge
+    socket_gtp_c_irx_tx_v2_mbms_session_start_response_count 0
+
+Please read Prometheus [Metric names and labels](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels)
+that means all '.' and '-' in metric names which presented above will be replaced by '_'.

--- a/src/ergw_api.erl
+++ b/src/ergw_api.erl
@@ -8,7 +8,7 @@
 -module(ergw_api).
 
 %% API
--export([peer/1, tunnel/1, metrics/1]).
+-export([peer/1, tunnel/1]).
 
 %%%===================================================================
 %%% API
@@ -30,22 +30,9 @@ tunnel({_,_,_,_} = IP) ->
 tunnel(Port) when is_atom(Port) ->
     lists:foldl(fun collext_path_contexts/2, [], gtp_path_reg:all(Port)).
 
-metrics(Path) ->
-    Metrics = lists:foldl(fun fmt_exo_entries/2, #{}, exometer:get_values(Path)),
-    lists:foldl(fun(M, A) -> maps:get(M, A) end, Metrics, Path).
-
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================
-
-fmt_exo_entries({Path, Value}, Metrics) ->
-    fmt_exo_entries(Path, Value, Metrics).
-
-fmt_exo_entries([Path], Value, Metrics) ->
-    Metrics#{Path => maps:from_list(Value)};
-fmt_exo_entries([H|T], Value, Metrics) ->
-    Entry = maps:get(H, Metrics, #{}),
-    Metrics#{H => fmt_exo_entries(T, Value, Entry)}.
 
 collect_peer_info(Peers) ->
     lists:map(fun gtp_path:info/1, Peers).

--- a/src/ergw_http_api.erl
+++ b/src/ergw_http_api.erl
@@ -39,8 +39,8 @@ start_http_listener(HttpOpts) ->
                                         {"/api/v1/status", http_api_handler, []},
                                         {"/api/v1/status/accept-new", http_api_handler, []},
                                         {"/api/v1/status/accept-new/:value", http_api_handler, []},
-                                        {"/api/v1/metrics", http_api_handler, []},
-                                        {"/api/v1/metrics/[...]", http_api_handler, []},
+                                        {"/metrics", http_api_handler, []},
+                                        {"/metrics/[...]", http_api_handler, []},
                                         % serves static files for swagger UI
                                         {"/api/v1/spec/ui", swagger_ui_handler, []},
                                         {"/api/v1/spec/ui/[...]", cowboy_static, {priv_dir, ergw, "static"}}]}

--- a/src/gtp_socket.erl
+++ b/src/gtp_socket.erl
@@ -248,7 +248,7 @@ make_seq_id(#gtp{version = Version, seq_no = SeqNo}) ->
     {Version, SeqNo}.
 
 make_request(ArrivalTS, IP, Port,
-	     Msg = #gtp{type = Type},
+	     Msg = #gtp{version = Version, type = Type},
 	     #state{gtp_port = GtpPort}) ->
     SeqId = make_seq_id(Msg),
     #request{
@@ -256,6 +256,7 @@ make_request(ArrivalTS, IP, Port,
        gtp_port = GtpPort,
        ip = IP,
        port = Port,
+       version = Version,
        type = Type,
        arrival_ts = ArrivalTS}.
 

--- a/src/http_api_handler.erl
+++ b/src/http_api_handler.erl
@@ -64,11 +64,11 @@ handle_request(<<"GET">>, <<"/api/v1/status/accept-new">>, json, Req, State) ->
     Response = jsx:encode(#{acceptNewRequests => AcceptNew}),
     {Response, Req, State};
 
-handle_request(<<"GET">>, <<"/api/v1/metrics">>, Format, Req, State) ->
+handle_request(<<"GET">>, <<"/metrics">>, Format, Req, State) ->
     Metrics = metrics([], Format),
     {Metrics, Req, State};
 
-handle_request(<<"GET">>, <<"/api/v1/metrics/", _/binary>>, Format, Req, State) ->
+handle_request(<<"GET">>, <<"/metrics/", _/binary>>, Format, Req, State) ->
     Path = path_to_metric(cowboy_req:path_info(Req)),
     Metrics = metrics(Path, Format),
     {Metrics, Req, State};

--- a/src/http_api_handler.erl
+++ b/src/http_api_handler.erl
@@ -8,7 +8,8 @@
 -module(http_api_handler).
 
 -export([init/2, content_types_provided/2,
-         handle_request/2, allowed_methods/2,
+         handle_request_json/2, handle_request_text/2,
+         allowed_methods/2,
          content_types_accepted/2]).
 
 -define(FIELDS_MAPPING, [{accept_new, 'acceptNewRequests'},
@@ -21,22 +22,29 @@ allowed_methods(Req, State) ->
     {[<<"GET">>, <<"POST">>], Req, State}.
 
 content_types_provided(Req, State) ->
-    {[{<<"application/json">>, handle_request}], Req, State}.
+    {[{<<"application/json">>, handle_request_json},
+      {{<<"text">>, <<"plain">>, '*'} , handle_request_text}
+     ], Req, State}.
 
 content_types_accepted(Req, State) ->
-    {[{'*', handle_request}], Req, State}.
+    {[{'*', handle_request_json}], Req, State}.
 
-handle_request(Req, State) ->
+handle_request_json(Req, State) ->
     Path = cowboy_req:path(Req),
     Method = cowboy_req:method(Req),
-    handle_request(Method, Path, Req, State).
+    handle_request(Method, Path, json, Req, State).
 
-handle_request(<<"GET">>, <<"/api/v1/version">>, Req, State) ->
+handle_request_text(Req, State) ->
+    Path = cowboy_req:path(Req),
+    Method = cowboy_req:method(Req),
+    handle_request(Method, Path, prometheus, Req, State).
+
+handle_request(<<"GET">>, <<"/api/v1/version">>, json, Req, State) ->
     {ok, Vsn} = application:get_key(ergw, vsn),
     Response = jsx:encode(#{version => list_to_binary(Vsn)}),
     {Response, Req, State};
 
-handle_request(<<"GET">>, <<"/api/v1/status">>, Req, State) ->
+handle_request(<<"GET">>, <<"/api/v1/status">>, json, Req, State) ->
     Response = ergw:system_info(),
     MappedResponse = lists:map(fun({Key, Value}) ->
 					  {_, K} = lists:keyfind(Key, 1, ?FIELDS_MAPPING),
@@ -51,23 +59,21 @@ handle_request(<<"GET">>, <<"/api/v1/status">>, Req, State) ->
     end,
     {jsx:encode(Result), Req, State};
 
-handle_request(<<"GET">>, <<"/api/v1/status/accept-new">>, Req, State) ->
+handle_request(<<"GET">>, <<"/api/v1/status/accept-new">>, json, Req, State) ->
     AcceptNew = ergw:system_info(accept_new),
     Response = jsx:encode(#{acceptNewRequests => AcceptNew}),
     {Response, Req, State};
 
-handle_request(<<"GET">>, <<"/api/v1/metrics">>, Req, State) ->
-    Metrics = ergw_api:metrics([]),
-    Response = jsx:encode(Metrics),
-    {Response, Req, State};
+handle_request(<<"GET">>, <<"/api/v1/metrics">>, Format, Req, State) ->
+    Metrics = metrics([], Format),
+    {Metrics, Req, State};
 
-handle_request(<<"GET">>, <<"/api/v1/metrics/", _/binary>>, Req, State) ->
+handle_request(<<"GET">>, <<"/api/v1/metrics/", _/binary>>, Format, Req, State) ->
     Path = path_to_metric(cowboy_req:path_info(Req)),
-    Metrics = ergw_api:metrics(Path),
-    Response = jsx:encode(Metrics),
-    {Response, Req, State};
+    Metrics = metrics(Path, Format),
+    {Metrics, Req, State};
 
-handle_request(<<"POST">>, _, Req, State) ->
+handle_request(<<"POST">>, _, json, Req, State) ->
     Value = cowboy_req:binding(value, Req),
     Res = case Value of
               <<"true">> ->
@@ -87,7 +93,7 @@ handle_request(<<"POST">>, _, Req, State) ->
             {true, Req2, State}
     end;
 
-handle_request(_, _, Req, State) ->
+handle_request(_, _, Req, _, State) ->
     {false, Req, State}.
 
 %%%===================================================================
@@ -109,3 +115,99 @@ p2m(Bin) ->
 		    Bin
 	    end
     end.
+
+exo_get_value(Name, Fun, AccIn) ->
+    case exometer:get_value(Name) of
+	{ok, Value} ->
+	    Fun(Value, AccIn);
+	{error,not_found} ->
+	    AccIn
+    end.
+
+exo_entry_to_map({Name, Type, enabled}, Metrics) ->
+    exo_entry_to_map(Name, {Name, Type}, Metrics).
+
+exo_entry_to_map([Path], {Name, Type}, Metrics) ->
+    exo_get_value(Name, fun(V, Acc) ->
+				Entry = maps:from_list(V),
+				Acc#{Path => Entry#{type => Type}}
+			end, Metrics);
+exo_entry_to_map([H|T], Metric, Metrics) ->
+    Entry = maps:get(H, Metrics, #{}),
+    Metrics#{H => exo_entry_to_map(T, Metric, Entry)}.
+
+exo_entry_to_list({Name, Type, enabled}, Metrics) ->
+    exo_get_value(Name, fun(V, Acc) -> [{Name, Type, V}|Acc] end, Metrics).
+
+metrics(Path, json) ->
+    Entries = lists:foldl(fun exo_entry_to_map/2, #{}, exometer:find_entries(Path)),
+    Metrics = lists:foldl(fun(M, A) -> maps:get(M, A) end, Entries, Path),
+    jsx:encode(Metrics);
+metrics(Path, prometheus) ->
+    Metrics = lists:foldl(fun exo_entry_to_list/2, [], exometer:find_entries(Path)),
+    prometheus_encode(Metrics).
+
+prometheus_encode(Metrics) ->
+    lists:foldl(fun prometheus_encode/2, [], Metrics).
+
+prometheus_encode(V= {Path, Type, DataPoints}, Acc) ->
+    Name = make_metric_name(Path),
+    Payload = [[<<"# TYPE ">>, Name, <<" ">>, map_type(Type), <<"\n">>] |
+               [[Name, map_datapoint(DPName), <<" ">>, ioize(Value), <<"\n">>]
+                || {DPName, Value} <- DataPoints, is_valid_datapoint(DPName)]],
+    Payload1 = maybe_add_sum(Name, DataPoints, Type, Payload),
+    [Payload1, <<"\n">> | Acc].
+
+ioize(Atom) when is_atom(Atom) ->
+    atom_to_binary(Atom, utf8);
+ioize(Number) when is_float(Number) ->
+    float_to_binary(Number, [{decimals, 4}]);
+ioize(Number) when is_integer(Number) ->
+    integer_to_binary(Number);
+ioize(Something) ->
+    Something.
+
+make_metric_name(Path) ->
+    NameList = lists:join($_, lists:map(fun ioize/1, Path)),
+    NameBin = iolist_to_binary(NameList),
+    re:replace(NameBin, "-|\\.", "_", [global, {return,binary}]).
+
+map_type(undefined)     -> <<"untyped">>;
+map_type(counter)       -> <<"counter">>;
+map_type(gauge)         -> <<"gauge">>;
+map_type(spiral)        -> <<"gauge">>;
+map_type(histogram)     -> <<"summary">>;
+map_type(function)      -> <<"gauge">>;
+map_type(Tuple) when is_tuple(Tuple) ->
+    case element(1, Tuple) of
+        function -> <<"gauge">>;
+        _Else    -> <<"untyped">>
+    end.
+
+map_datapoint(value)    -> <<"">>;
+map_datapoint(one)      -> <<"">>;
+map_datapoint(n)        -> <<"_count">>;
+map_datapoint(50)       -> <<"{quantile=\"0.5\"}">>;
+map_datapoint(90)       -> <<"{quantile=\"0.9\"}">>;
+map_datapoint(Integer) when is_integer(Integer)  ->
+    Bin = integer_to_binary(Integer),
+    <<"{quantile=\"0.", Bin/binary, "\"}">>;
+map_datapoint(Something)  ->
+    %% this is for functions with alternative datapoints
+    Bin = ioize(Something),
+    <<"{datapoint=\"", Bin/binary, "\"}">>.
+
+is_valid_datapoint(count) -> false;
+is_valid_datapoint(mean) -> false;
+is_valid_datapoint(min) -> false;
+is_valid_datapoint(max) -> false;
+is_valid_datapoint(median) -> false;
+is_valid_datapoint(ms_since_reset) -> false;
+is_valid_datapoint(_Else) -> true.
+
+maybe_add_sum(Name, DataPoints, histogram, Payload) ->
+    Mean = proplists:get_value(mean, DataPoints),
+    N = proplists:get_value(n, DataPoints),
+    [Payload | [Name, <<"_sum ">>, ioize(Mean * N), <<"\n">>]];
+maybe_add_sum(_Name, _DataPoints, _Type, Payload) ->
+    Payload.

--- a/test/ergw_http_api_SUITE.erl
+++ b/test/ergw_http_api_SUITE.erl
@@ -186,7 +186,7 @@ http_api_status_accept_new_post_req(_Config) ->
 http_api_prometheus_metrics_req() ->
     [{doc, "Check Prometheus API Endpoint"}].
 http_api_prometheus_metrics_req(_Config) ->
-    URL = get_test_url("/api/v1/metrics"),
+    URL = get_test_url("/metrics"),
     Accept = "application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.7,"
              ++ "text/plain;version=0.0.4;q=0.3,*/*;q=0.1",
     {ok, {_, _, Body}} = httpc:request(get, {URL, [{"Accept", Accept}]},
@@ -201,9 +201,9 @@ http_api_prometheus_metrics_req(_Config) ->
     ok.
 
 http_api_prometheus_metrics_sub_req() ->
-    [{doc, "Check /api/v1/metrics/... Prometheus API endpoint"}].
+    [{doc, "Check /metrics/... Prometheus API endpoint"}].
 http_api_prometheus_metrics_sub_req(_Config) ->
-    URL = get_test_url("/api/v1/metrics/socket/gtp-c/irx/tx/v2/mbms_session_start_response"),
+    URL = get_test_url("/metrics/socket/gtp-c/irx/tx/v2/mbms_session_start_response"),
     Accept = "application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.7,"
              ++ "text/plain;version=0.0.4;q=0.3,*/*;q=0.1",
     {ok, {_, _, Body}} = httpc:request(get, {URL, [{"Accept", Accept}]},
@@ -218,9 +218,9 @@ http_api_prometheus_metrics_sub_req(_Config) ->
     ok.
 
 http_api_metrics_req() ->
-    [{doc, "Check /api/v1/metrics API"}].
+    [{doc, "Check /metrics API"}].
 http_api_metrics_req(_Config) ->
-    URL = get_test_url("/api/v1/metrics"),
+    URL = get_test_url("/metrics"),
     {ok, {_, _, Body}} = httpc:request(get, {URL, []},
 				       [], [{body_format, binary}]),
     Res = jsx:decode(Body, [return_maps]),
@@ -228,9 +228,9 @@ http_api_metrics_req(_Config) ->
     ok.
 
 http_api_metrics_sub_req() ->
-    [{doc, "Check /api/v1/metrics/... API"}].
+    [{doc, "Check /metrics/... API"}].
 http_api_metrics_sub_req(_Config) ->
-    URL = get_test_url("/api/v1/metrics/socket/gtp-c/irx/rx"),
+    URL = get_test_url("/metrics/socket/gtp-c/irx/rx"),
     {ok, {_, _, Body}} = httpc:request(get, {URL, []},
 				       [], [{body_format, binary}]),
     Res = jsx:decode(Body, [return_maps]),


### PR DESCRIPTION
This is an alternative version of PR #37.

There are two main problems with that PR:

1. ergw_api should not implement data conversion and certainly nothing front end specific. The code in there is for Erlang internal API's only. Therefore move the encoding specific code into the API handler.
2. exometer:get_values/1 call find_values/1 and then get_value/1 on each one, doing a exometer_get_info/1 for each value again duplicates work that was done before in find_values/1. Instead, use find_values together with get_value and avoid the get_info.

Also, do the re:replace on the metric name only once. Regex are expensive, doing to each component in the name is wasteful.