### PR TITLE
refactor proxy code and fix error reply handling

### DIFF
--- a/include/ergw.hrl
+++ b/include/ergw.hrl
@@ -66,6 +66,7 @@
 
 -record(proxy_request, {
 	  key		:: term(),
+	  direction     :: atom(),
 	  request	:: #request{},
 	  seq_no	:: gtp_socket:sequence_id(),
 	  new_peer	:: boolean()

--- a/src/ergw_proxy_lib.erl
+++ b/src/ergw_proxy_lib.erl
@@ -8,7 +8,7 @@
 -module(ergw_proxy_lib).
 
 -export([validate_options/3, validate_option/2,
-	 forward_request/5]).
+	 forward_request/6]).
 
 -include("include/ergw.hrl").
 
@@ -16,9 +16,11 @@
 %%% API
 %%%===================================================================
 
-forward_request(#context{control_port = GtpPort, remote_control_ip = RemoteCntlIP},
+forward_request(Direction,
+		#context{control_port = GtpPort,
+			 remote_control_ip = RemoteCntlIP},
 		Request, ReqKey, SeqNo, NewPeer) ->
-    ReqInfo = make_proxy_request(ReqKey, SeqNo, NewPeer),
+    ReqInfo = make_proxy_request(Direction, ReqKey, SeqNo, NewPeer),
     lager:debug("Invoking Context Send Request: ~p", [Request]),
     gtp_context:forward_request(GtpPort, RemoteCntlIP, Request, ReqInfo).
 
@@ -73,9 +75,10 @@ validate_context(Name, Opts, _Acc) ->
 %%% Helper functions
 %%%===================================================================
 
-make_proxy_request(#request{key = ReqKey} = Request, SeqNo, NewPeer) ->
+make_proxy_request(Direction, #request{key = ReqKey} = Request, SeqNo, NewPeer) ->
     #proxy_request{
        key = {ReqKey, SeqNo},
+       direction = Direction,
        request = Request,
        seq_no = SeqNo,
        new_peer = NewPeer

--- a/src/ggsn_gn.erl
+++ b/src/ggsn_gn.erl
@@ -154,16 +154,14 @@ handle_request(_ReqKey,
     {reply, Reply, State#{context => Context}};
 
 handle_request(_ReqKey,
-	       #gtp{version = Version,
-		    type = update_pdp_context_request,
+	       #gtp{type = update_pdp_context_request,
 		    ie = #{?'Recovery' := Recovery,
 			   ?'Quality of Service Profile' := ReqQoSProfile
 			  } = IEs} = Request, _Resent,
 	       #{context := OldContext} = State0) ->
 
-    Context0 = OldContext#context{version = Version},
-    Context1 = update_context_from_gtp_req(IEs, Context0),
-    Context = gtp_path:bind(Request, Context1),
+    Context0 = update_context_from_gtp_req(IEs, OldContext),
+    Context = gtp_path:bind(Request, Context0),
 
     State1 = if Context /= OldContext ->
 		     gtp_context:update_remote_context(OldContext, Context),

--- a/src/ggsn_gn_proxy.erl
+++ b/src/ggsn_gn_proxy.erl
@@ -229,7 +229,7 @@ handle_request(ReqKey,
     {ProxyGtpPort, ProxyGtpDP} = get_proxy_sockets(ProxyInfo, State),
 
     ProxyContext0 = init_proxy_context(ProxyGtpPort, ProxyGtpDP, Context, ProxyInfo),
-    ProxyContext = gtp_path:bind(undefined, ProxyContext0),
+    ProxyContext = gtp_path:bind(ProxyContext0),
 
     StateNew = State#{context => Context, proxy_context => ProxyContext},
     forward_request(sgsn2ggsn, ReqKey, Request, StateNew),
@@ -253,7 +253,7 @@ handle_request(ReqKey,
     Context = apply_context_change(Context2, OldContext),
 
     ProxyContext0 = OldProxyContext#context{version = Version},
-    ProxyContext = gtp_path:bind(undefined, ProxyContext0),
+    ProxyContext = gtp_path:bind(ProxyContext0),
 
     StateNew = State#{context => Context, proxy_context => ProxyContext},
     forward_request(sgsn2ggsn, ReqKey, Request, StateNew),
@@ -270,7 +270,7 @@ handle_request(ReqKey,
 		 proxy_context := ProxyContext0} = State)
   when ?IS_REQUEST_CONTEXT(ReqKey, Request, ProxyContext0) ->
 
-    Context = gtp_path:bind(undefined, Context0),
+    Context = gtp_path:bind(Context0),
     ProxyContext = gtp_path:bind(Recovery, ProxyContext0),
 
     StateNew = State#{context => Context, proxy_context => ProxyContext},
@@ -286,7 +286,7 @@ handle_request(ReqKey,
 		 proxy_context := ProxyContext0} = State) ->
 
     Context = gtp_path:bind(Recovery, Context0),
-    ProxyContext = gtp_path:bind(undefined, ProxyContext0),
+    ProxyContext = gtp_path:bind(ProxyContext0),
 
     StateNew = State#{context => Context, proxy_context => ProxyContext},
     forward_request(sgsn2ggsn, ReqKey, Request, StateNew),

--- a/src/ggsn_gn_proxy.erl
+++ b/src/ggsn_gn_proxy.erl
@@ -220,7 +220,7 @@ handle_request(ReqKey,
     lager:debug("Invoking CONTROL: ~p", [Session1]),
     %% ergw_control:authenticate(Session1),
 
-    #proxy_info{ggsn = GGSN, restrictions = Restrictions} =
+    #proxy_info{restrictions = Restrictions} =
 	ProxyInfo = handle_proxy_info(ContextPreProxy, Recovery, State),
 
     Context = ContextPreProxy#context{restrictions = Restrictions},
@@ -228,7 +228,7 @@ handle_request(ReqKey,
 
     {ProxyGtpPort, ProxyGtpDP} = get_proxy_sockets(ProxyInfo, State),
 
-    ProxyContext0 = init_proxy_context(GGSN, ProxyGtpPort, ProxyGtpDP, Context, ProxyInfo),
+    ProxyContext0 = init_proxy_context(ProxyGtpPort, ProxyGtpDP, Context, ProxyInfo),
     ProxyContext = gtp_path:bind(undefined, ProxyContext0),
 
     StateNew = State#{context => Context, proxy_context => ProxyContext},
@@ -478,10 +478,10 @@ copy_to_session(_K, #selection_mode{mode = Mode}, Session) ->
 copy_to_session(_K, _V, Session) ->
     Session.
 
-init_proxy_context(GGSN, CntlPort, DataPort,
+init_proxy_context(CntlPort, DataPort,
 		   #context{imei = IMEI, version = Version,
 			    control_interface = Interface, state = State},
-		   #proxy_info{apn = APN, imsi = IMSI, msisdn = MSISDN}) ->
+		   #proxy_info{ggsn = GGSN, apn = APN, imsi = IMSI, msisdn = MSISDN}) ->
 
     {ok, CntlTEI} = gtp_c_lib:alloc_tei(CntlPort),
     {ok, DataTEI} = gtp_c_lib:alloc_tei(DataPort),

--- a/src/ggsn_gn_proxy.erl
+++ b/src/ggsn_gn_proxy.erl
@@ -209,7 +209,7 @@ handle_request(_ReqKey, _Msg, true, State) ->
 
 handle_request(ReqKey,
 	       #gtp{type = create_pdp_context_request,
-		    ie = #{?'Recovery' := Recovery} = IEs} = Request, _Resent,
+		    ie = IEs} = Request, _Resent,
 	       #{context := Context0} = State) ->
 
     Context1 = update_context_from_gtp_req(Request, Context0#context{state = #context_state{}}),
@@ -221,7 +221,7 @@ handle_request(ReqKey,
     %% ergw_control:authenticate(Session1),
 
     #proxy_info{restrictions = Restrictions} =
-	ProxyInfo = handle_proxy_info(ContextPreProxy, Recovery, State),
+	ProxyInfo = handle_proxy_info(Request, ContextPreProxy, State),
 
     Context = ContextPreProxy#context{restrictions = Restrictions},
     gtp_context:enforce_restrictions(Request, Context),
@@ -418,8 +418,9 @@ terminate(_Reason, _State) ->
 %%% Internal functions
 %%%===================================================================
 
-handle_proxy_info(Context, Recovery, #{default_gw := DefaultGGSN,
-				       proxy_ds := ProxyDS}) ->
+handle_proxy_info(#gtp{ie = #{?'Recovery' := Recovery}},
+		  Context,
+		  #{default_gw := DefaultGGSN, proxy_ds := ProxyDS}) ->
     ProxyInfo0 = proxy_info(DefaultGGSN, Context),
     case ProxyDS:map(ProxyInfo0) of
 	{ok, #proxy_info{} = ProxyInfo} ->

--- a/src/ggsn_gn_proxy.erl
+++ b/src/ggsn_gn_proxy.erl
@@ -237,22 +237,20 @@ handle_request(ReqKey,
     {noreply, StateNew};
 
 handle_request(ReqKey,
-	       #gtp{version = Version,
-		    type = update_pdp_context_request} = Request, _Resent,
+	       #gtp{type = update_pdp_context_request} = Request, _Resent,
 	       #{context := OldContext,
 		 proxy_context := OldProxyContext} = State)
   when ?IS_REQUEST_CONTEXT(ReqKey, Request, OldContext) ->
 
-    Context0 = OldContext#context{version = Version},
-    Context1 = update_context_from_gtp_req(Request, Context0),
+    Context0 = update_context_from_gtp_req(Request, OldContext),
+    Context1 = gtp_path:bind(Request, Context0),
+
     gtp_context:enforce_restrictions(Request, Context1),
+    gtp_context:update_remote_context(OldContext, Context1),
 
-    Context2 = gtp_path:bind(Request, Context1),
-    gtp_context:update_remote_context(OldContext, Context2),
-    Context = apply_context_change(Context2, OldContext),
+    Context = apply_context_change(Context1, OldContext),
 
-    ProxyContext0 = OldProxyContext#context{version = Version},
-    ProxyContext = gtp_path:bind(ProxyContext0),
+    ProxyContext = gtp_path:bind(OldProxyContext),
 
     StateNew = State#{context => Context, proxy_context => ProxyContext},
     forward_request(sgsn2ggsn, ReqKey, Request, StateNew),

--- a/src/gtp_path.erl
+++ b/src/gtp_path.erl
@@ -65,10 +65,14 @@ handle_request(#request{gtp_port = GtpPort, ip = IP} = ReqKey, #gtp{version = Ve
 bind(#context{remote_restart_counter = RestartCounter} = Context) ->
     path_recovery(RestartCounter, bind_path(Context)).
 
-bind(Recovery, #context{version = v1} = Context) ->
-    path_recovery(gtp_v1_c:restart_counter(Recovery), bind_path(Context));
-bind(Recovery, #context{version = v2} = Context) ->
-    path_recovery(gtp_v2_c:restart_counter(Recovery), bind_path(Context)).
+bind(#gtp{ie = #{{recovery, 0} :=
+		     #recovery{restart_counter = RestartCounter}}}, Context) ->
+    path_recovery(RestartCounter, bind_path(Context));
+bind(#gtp{ie = #{{v2_recovery, 0} :=
+		     #v2_recovery{restart_counter = RestartCounter}}}, Context) ->
+    path_recovery(RestartCounter, bind_path(Context));
+bind(_Request, Context) ->
+    path_recovery(undefined, bind_path(Context)).
 
 unbind(#context{version = Version, control_port = GtpPort, remote_control_ip = RemoteIP}) ->
     case get(GtpPort, Version, RemoteIP) of

--- a/src/gtp_path.erl
+++ b/src/gtp_path.erl
@@ -66,13 +66,15 @@ bind(#context{remote_restart_counter = RestartCounter} = Context) ->
     path_recovery(RestartCounter, bind_path(Context)).
 
 bind(#gtp{ie = #{{recovery, 0} :=
-		     #recovery{restart_counter = RestartCounter}}}, Context) ->
-    path_recovery(RestartCounter, bind_path(Context));
+		     #recovery{restart_counter = RestartCounter}}
+	 } = Request, Context) ->
+    path_recovery(RestartCounter, bind_path(Request, Context));
 bind(#gtp{ie = #{{v2_recovery, 0} :=
-		     #v2_recovery{restart_counter = RestartCounter}}}, Context) ->
-    path_recovery(RestartCounter, bind_path(Context));
-bind(_Request, Context) ->
-    path_recovery(undefined, bind_path(Context)).
+		     #v2_recovery{restart_counter = RestartCounter}}
+	 } = Request, Context) ->
+    path_recovery(RestartCounter, bind_path(Request, Context));
+bind(Request, Context) ->
+    path_recovery(undefined, bind_path(Request, Context)).
 
 unbind(#context{version = Version, control_port = GtpPort, remote_control_ip = RemoteIP}) ->
     case get(GtpPort, Version, RemoteIP) of
@@ -311,6 +313,8 @@ unregister(Pid, #state{table = TID} = State0) ->
     ets:delete(TID, Pid),
     dec_path_counter(State0).
 
+bind_path(#gtp{version = Version}, Context) ->
+    bind_path(Context#context{version = Version}).
 
 bind_path(#context{version = Version, control_port = CntlGtpPort,
 		   remote_control_ip = RemoteCntlIP} = Context) ->

--- a/src/gtp_v1_c.erl
+++ b/src/gtp_v1_c.erl
@@ -20,7 +20,7 @@
 	 get_cause/1]).
 
 %% support functions
--export([restart_counter/1, build_recovery/3]).
+-export([build_recovery/3]).
 
 -include_lib("gtplib/include/gtp_packet.hrl").
 -include("include/ergw.hrl").
@@ -34,11 +34,6 @@
 %%====================================================================
 %% API
 %%====================================================================
-
-restart_counter(#recovery{restart_counter = RestartCounter}) ->
-    RestartCounter;
-restart_counter(_) ->
-    undefined.
 
 build_recovery(#gtp_port{} = GtpPort, NewPeer, IEs) when NewPeer == true ->
     add_recovery(GtpPort, IEs);

--- a/src/gtp_v2_c.erl
+++ b/src/gtp_v2_c.erl
@@ -20,7 +20,7 @@
 	 get_cause/1]).
 
 %% support functions
--export([restart_counter/1, build_recovery/3]).
+-export([build_recovery/3]).
 
 -include_lib("gtplib/include/gtp_packet.hrl").
 -include("include/ergw.hrl").
@@ -36,10 +36,6 @@
 %%====================================================================
 %% API
 %%====================================================================
-restart_counter(#v2_recovery{restart_counter = RestartCounter}) ->
-    RestartCounter;
-restart_counter(_) ->
-    undefined.
 
 build_recovery(GtpPort = #gtp_port{}, NewPeer, IEs) when NewPeer == true ->
     add_recovery(GtpPort, IEs);

--- a/src/pgw_s5s8.erl
+++ b/src/pgw_s5s8.erl
@@ -184,8 +184,7 @@ handle_request(_ReqKey,
     {reply, Response, State#{context => Context}};
 
 handle_request(_ReqKey,
-	       #gtp{version = Version,
-		    type = modify_bearer_request,
+	       #gtp{type = modify_bearer_request,
 		    ie = #{?'Recovery' := Recovery,
 			   ?'Bearer Contexts to be modified' :=
 			       #v2_bearer_context{
@@ -202,10 +201,9 @@ handle_request(_ReqKey,
 
     FqCntlTEID = maps:get(?'Sender F-TEID for Control Plane', IEs, undefined),
 
-    Context0 = OldContext#context{version = Version},
-    Context1 = update_context_tunnel_ids(FqCntlTEID, FqDataTEID, Context0),
-    Context2 = update_context_from_gtp_req(IEs, Context1),
-    Context = gtp_path:bind(Request, Context2),
+    Context0 = update_context_tunnel_ids(FqCntlTEID, FqDataTEID, OldContext),
+    Context1 = update_context_from_gtp_req(IEs, Context0),
+    Context = gtp_path:bind(Request, Context1),
 
     State1 = if Context /= OldContext ->
 		     gtp_context:update_remote_context(OldContext, Context),

--- a/src/pgw_s5s8_proxy.erl
+++ b/src/pgw_s5s8_proxy.erl
@@ -214,7 +214,7 @@ handle_request(ReqKey,
     ContextPreProxy = gtp_path:bind(Recovery, Context1),
     gtp_context:register_remote_context(ContextPreProxy),
 
-    #proxy_info{ggsn = PGW, restrictions = Restrictions} = ProxyInfo =
+    #proxy_info{restrictions = Restrictions} = ProxyInfo =
 	handle_proxy_info(ContextPreProxy, Recovery, State),
 
     Context = ContextPreProxy#context{restrictions = Restrictions},
@@ -222,7 +222,7 @@ handle_request(ReqKey,
 
     {ProxyGtpPort, ProxyGtpDP} = get_proxy_sockets(ProxyInfo, State),
 
-    ProxyContext0 = init_proxy_context(PGW, ProxyGtpPort, ProxyGtpDP, Context, ProxyInfo),
+    ProxyContext0 = init_proxy_context(ProxyGtpPort, ProxyGtpDP, Context, ProxyInfo),
     ProxyContext = gtp_path:bind(undefined, ProxyContext0),
 
     StateNew = State#{context => Context, proxy_context => ProxyContext},
@@ -522,10 +522,10 @@ apply_context_change(NewContext0, OldContext)
 apply_context_change(NewContext, _OldContext) ->
     NewContext.
 
-init_proxy_context(PGW, CntlPort, DataPort,
+init_proxy_context(CntlPort, DataPort,
 		   #context{imei = IMEI, version = Version,
 			    control_interface = Interface, state = State},
-		   #proxy_info{apn = APN, imsi = IMSI, msisdn = MSISDN}) ->
+		   #proxy_info{ggsn = PGW, apn = APN, imsi = IMSI, msisdn = MSISDN}) ->
 
     {ok, CntlTEI} = gtp_c_lib:alloc_tei(CntlPort),
     {ok, DataTEI} = gtp_c_lib:alloc_tei(DataPort),

--- a/src/pgw_s5s8_proxy.erl
+++ b/src/pgw_s5s8_proxy.erl
@@ -223,7 +223,7 @@ handle_request(ReqKey,
     {ProxyGtpPort, ProxyGtpDP} = get_proxy_sockets(ProxyInfo, State),
 
     ProxyContext0 = init_proxy_context(ProxyGtpPort, ProxyGtpDP, Context, ProxyInfo),
-    ProxyContext = gtp_path:bind(undefined, ProxyContext0),
+    ProxyContext = gtp_path:bind(ProxyContext0),
 
     StateNew = State#{context => Context, proxy_context => ProxyContext},
     forward_request(sgw2pgw, ReqKey, Request, StateNew),
@@ -248,7 +248,7 @@ handle_request(ReqKey,
     Context = apply_context_change(Context2, OldContext),
 
     ProxyContext0 = OldProxyContext#context{version = Version},
-    ProxyContext = gtp_path:bind(undefined, ProxyContext0),
+    ProxyContext = gtp_path:bind(ProxyContext0),
 
     StateNew = State#{context => Context, proxy_context => ProxyContext},
     forward_request(sgw2pgw, ReqKey, Request, StateNew),
@@ -264,7 +264,7 @@ handle_request(ReqKey,
   when ?IS_REQUEST_CONTEXT(ReqKey, Request, Context0) ->
 
     Context = gtp_path:bind(Recovery, Context0),
-    ProxyContext = gtp_path:bind(undefined, ProxyContext0),
+    ProxyContext = gtp_path:bind(ProxyContext0),
 
     StateNew = State#{context => Context, proxy_context => ProxyContext},
     forward_request(sgw2pgw, ReqKey, Request, StateNew),
@@ -283,7 +283,7 @@ handle_request(ReqKey,
   when ?IS_REQUEST_CONTEXT_OPTIONAL_TEI(ReqKey, Request, Context0) ->
 
     Context = gtp_path:bind(Recovery, Context0),
-    ProxyContext = gtp_path:bind(undefined, ProxyContext0),
+    ProxyContext = gtp_path:bind(ProxyContext0),
 
     StateNew = State#{context => Context, proxy_context => ProxyContext},
     forward_request(sgw2pgw, ReqKey, Request, StateNew),
@@ -304,7 +304,7 @@ handle_request(ReqKey,
        ?IS_REQUEST_CONTEXT(ReqKey, Request, Context0) ->
 
     Context = gtp_path:bind(Recovery, Context0),
-    ProxyContext = gtp_path:bind(undefined, ProxyContext0),
+    ProxyContext = gtp_path:bind(ProxyContext0),
 
     StateNew = State#{context => Context, proxy_context => ProxyContext},
     forward_request(sgw2pgw, ReqKey, Request, StateNew),
@@ -323,7 +323,7 @@ handle_request(ReqKey,
   when ?IS_REQUEST_CONTEXT(ReqKey, Request, ProxyContext0) ->
 
     ProxyContext = gtp_path:bind(Recovery, ProxyContext0),
-    Context = gtp_path:bind(undefined, Context0),
+    Context = gtp_path:bind(Context0),
 
     StateNew = State#{context => Context, proxy_context => ProxyContext},
     forward_request(pgw2sgw, ReqKey, Request, StateNew),

--- a/src/pgw_s5s8_proxy.erl
+++ b/src/pgw_s5s8_proxy.erl
@@ -205,8 +205,7 @@ handle_request(ReqKey, #gtp{version = v1} = Msg, Resent, State) ->
     ?GTP_v1_Interface:handle_request(ReqKey, Msg, Resent, State);
 
 handle_request(ReqKey,
-	       #gtp{type = create_session_request,
-		    ie = #{?'Recovery' := Recovery}} = Request,
+	       #gtp{type = create_session_request} = Request,
 	       _Resent,
 	       #{context := Context0} = State) ->
 
@@ -215,7 +214,7 @@ handle_request(ReqKey,
     gtp_context:register_remote_context(ContextPreProxy),
 
     #proxy_info{restrictions = Restrictions} = ProxyInfo =
-	handle_proxy_info(ContextPreProxy, Recovery, State),
+	handle_proxy_info(Request, ContextPreProxy, State),
 
     Context = ContextPreProxy#context{restrictions = Restrictions},
     gtp_context:enforce_restrictions(Request, Context),
@@ -486,8 +485,9 @@ terminate(_Reason, _State) ->
 %%% Helper functions
 %%%===================================================================
 
-handle_proxy_info(Context, Recovery, #{default_gw := DefaultPGW,
-				       proxy_ds := ProxyDS}) ->
+handle_proxy_info(#gtp{ie = #{?'Recovery' := Recovery}},
+		  Context,
+		  #{default_gw := DefaultPGW, proxy_ds := ProxyDS}) ->
     ProxyInfo0 = proxy_info(DefaultPGW, Context),
     case ProxyDS:map(ProxyInfo0) of
 	{ok, #proxy_info{} = ProxyInfo} ->

--- a/test/ergw_ggsn_test_lib.erl
+++ b/test/ergw_ggsn_test_lib.erl
@@ -267,6 +267,15 @@ make_response(#gtp{type = update_pdp_context_request, seq_no = SeqNo},
 	 tei = RemoteCntlTEI, seq_no = SeqNo, ie = IEs};
 
 make_response(#gtp{type = delete_pdp_context_request, seq_no = SeqNo},
+	      invalid_teid,
+	      #gtpc{restart_counter = RCnt,
+		    remote_control_tei = RemoteCntlTEI}) ->
+    IEs = [#recovery{restart_counter = RCnt},
+	   #cause{value = context_not_found}],
+    #gtp{version = v1, type = delete_pdp_context_response,
+	 tei = 0, seq_no = SeqNo, ie = IEs};
+
+make_response(#gtp{type = delete_pdp_context_request, seq_no = SeqNo},
 	      _SubType,
 	      #gtpc{restart_counter = RCnt,
 		    remote_control_tei = RemoteCntlTEI}) ->

--- a/test/ergw_pgw_test_lib.erl
+++ b/test/ergw_pgw_test_lib.erl
@@ -377,6 +377,15 @@ make_response(#gtp{type = update_bearer_request, seq_no = SeqNo},
 	 tei = RemoteCntlTEI, seq_no = SeqNo, ie = IEs};
 
 make_response(#gtp{type = delete_bearer_request, seq_no = SeqNo},
+	      invalid_teid,
+	      #gtpc{restart_counter = RCnt,
+		    remote_control_tei = RemoteCntlTEI}) ->
+    IEs = [#v2_recovery{restart_counter = RCnt},
+	   #v2_cause{v2_cause = context_not_found}],
+    #gtp{version = v2, type = delete_bearer_response,
+	 tei = 0, seq_no = SeqNo, ie = IEs};
+
+make_response(#gtp{type = delete_bearer_request, seq_no = SeqNo},
 	      _SubType,
 	      #gtpc{restart_counter = RCnt,
 		    remote_control_tei = RemoteCntlTEI}) ->


### PR DESCRIPTION
Refactor the proxy code to make the error reply handling fix simpler.

Replies with cause = "Context not found" are send with TEID of zero. The reply context selection logic could not deal with that and dropped the reply.

Test case and fix added.