### PR TITLE
rework the socket logic to en/decode IEs in the message handler process

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -48,7 +48,7 @@
   1},
  {<<"gtplib">>,
   {git,"https://github.com/travelping/gtplib.git",
-       {ref,"ddbd3e59f0925738f2b975185c8532800922aeec"}},
+       {ref,"497bf3c40cf6bb39a0667e4acb66f3095ab44eb6"}},
   0},
  {<<"hut">>,
   {git,"git://github.com/tolbrino/hut.git",


### PR DESCRIPTION
the GTP socket logic only needs to access the GTP message header, not
the content of the message element. Therefore, move the encoding and
decoding of the message elements into the processing thread.

This prevents failures from invalid message elements in the socket
handler process.