### PR TITLE
ensure all pending requests are removed from the request table

### DIFF
--- a/src/ggsn_gn.erl
+++ b/src/ggsn_gn.erl
@@ -189,7 +189,8 @@ handle_request(_ReqKey,
     Reply = response(delete_pdp_context_response, Context, request_accepted),
     {stop, Reply, State};
 
-handle_request(_ReqKey, _Msg, _Resent, State) ->
+handle_request(ReqKey, _Msg, _Resent, State) ->
+    gtp_context:request_finished(ReqKey),
     {noreply, State}.
 
 handle_response(From, timeout, #gtp{type = delete_pdp_context_request},

--- a/src/ggsn_gn_proxy.erl
+++ b/src/ggsn_gn_proxy.erl
@@ -319,8 +319,9 @@ handle_request(ReqKey,
     forward_request(ggsn2sgsn, ReqKey, Request, State),
     {noreply, State};
 
-handle_request(#request{gtp_port = GtpPort}, Msg, _Resent, State) ->
+handle_request(#request{gtp_port = GtpPort} = ReqKey, Msg, _Resent, State) ->
     lager:warning("Unknown Proxy Message on ~p: ~p", [GtpPort, lager:pr(Msg, ?MODULE)]),
+    gtp_context:request_finished(ReqKey),
     {noreply, State}.
 
 handle_response(#proxy_request{direction = sgsn2ggsn} = ProxyRequest,

--- a/src/gtp_context.erl
+++ b/src/gtp_context.erl
@@ -14,6 +14,7 @@
 	 start_link/5,
 	 send_request/4, send_request/6, send_response/2,
 	 send_request/5, resend_request/2,
+	 request_finished/1,
 	 path_restart/2,
 	 delete_context/1,
 	 register_remote_context/1, update_remote_context/2,
@@ -404,7 +405,7 @@ handle_request(#request{gtp_port = GtpPort} = Request,
 send_response(Request, #gtp{seq_no = SeqNo} = Msg) ->
     %% TODO: handle encode errors
     try
-	unregister_request(Request),
+	request_finished(Request),
 	gtp_socket:send_response(Request, Msg, SeqNo /= 0)
     catch
 	Class:Error ->
@@ -412,6 +413,9 @@ send_response(Request, #gtp{seq_no = SeqNo} = Msg) ->
 	    lager:error("gtp send failed with ~p:~p (~p) for ~p",
 			[Class, Error, Stack, gtp_c_lib:fmt_gtp(Msg)])
     end.
+
+request_finished(Request) ->
+    unregister_request(Request).
 
 %%%===================================================================
 %%% Internal functions

--- a/src/pgw_s5s8.erl
+++ b/src/pgw_s5s8.erl
@@ -233,11 +233,13 @@ handle_request(_ReqKey,
     Response = response(modify_bearer_response, Context, ResponseIEs, Request),
     {reply, Response, State#{context => Context}};
 
-handle_request(_ReqKey,
+handle_request(ReqKey,
 	       #gtp{type = modify_bearer_command,
 		    ie = _IEs},
 	       _Resent, #{context := _Context} = State) ->
     %% TODO: adjust QoS
+
+    gtp_context:request_finished(ReqKey),
     {noreply, State};
 
 handle_request(_ReqKey,
@@ -295,7 +297,8 @@ handle_request(_ReqKey,
 	    {reply, Response, State0}
     end;
 
-handle_request(_ReqKey, _Msg, _Resent, State) ->
+handle_request(ReqKey, _Msg, _Resent, State) ->
+    gtp_context:request_finished(ReqKey),
     {noreply, State}.
 
 handle_response(ReqInfo, #gtp{version = v1} = Msg, Request, State) ->

--- a/test/ergw_ggsn_test_lib.erl
+++ b/test/ergw_ggsn_test_lib.erl
@@ -254,7 +254,12 @@ make_request(delete_pdp_context_request, _SubType,
 	   #teardown_ind{value=1}],
 
     #gtp{version = v1, type = delete_pdp_context_request,
-	 tei = RemoteCntlTEI, seq_no = SeqNo, ie = IEs}.
+	 tei = RemoteCntlTEI, seq_no = SeqNo, ie = IEs};
+
+make_request(unsupported, _SubType,
+	     #gtpc{seq_no = SeqNo, remote_control_tei = RemoteCntlTEI}) ->
+    #gtp{version = v1, type = data_record_transfer_request,
+	 tei = RemoteCntlTEI, seq_no = SeqNo, ie = []}.
 
 %%%-------------------------------------------------------------------
 

--- a/test/ergw_pgw_test_lib.erl
+++ b/test/ergw_pgw_test_lib.erl
@@ -298,7 +298,12 @@ make_request(delete_session_request, _SubType,
 					 ecgi = <<3,2,22,8,71,9,92>>}],
 
     #gtp{version = v2, type = delete_session_request,
-	 tei = RemoteCntlTEI, seq_no = SeqNo, ie = IEs}.
+	 tei = RemoteCntlTEI, seq_no = SeqNo, ie = IEs};
+
+make_request(unsupported, _SubType,
+	     #gtpc{seq_no = SeqNo, remote_control_tei = RemoteCntlTEI}) ->
+    #gtp{version = v2, type = mbms_session_stop_request,
+	 tei = RemoteCntlTEI, seq_no = SeqNo, ie = []}.
 
 %%%-------------------------------------------------------------------
 

--- a/test/ergw_test_lib.hrl
+++ b/test/ergw_test_lib.hrl
@@ -20,9 +20,10 @@
 			  gtp_context_new_teids/1]).
 -import('ergw_test_lib', [make_gtp_socket/1,
 			  send_pdu/2,
-			  send_recv_pdu/2, send_recv_pdu/3,
+			  send_recv_pdu/2, send_recv_pdu/3, send_recv_pdu/4,
 			  recv_pdu/2, recv_pdu/3, recv_pdu/4]).
 -import('ergw_test_lib', [set_cfg_value/3, add_cfg_value/3]).
+-import('ergw_test_lib', [outstanding_requests/0, hexstr2bin/1]).
 
 -endif.
 


### PR DESCRIPTION
We register the pending requests in the context registry. Unlike,
TEID's, IMSI's and so, these are transient events and need to be
remove once a request is finished. It doesn't mater if the request
was abort or completed, it was to be removed when processing it is
done.

Command have to clean up immediately, requests should wait for a
response to be finished.