### PR TITLE
fix the GTP path context counter and all statistics that use it

### DIFF
--- a/test/ggsn_SUITE.erl
+++ b/test/ggsn_SUITE.erl
@@ -291,6 +291,8 @@ path_restart(Config) ->
     send_recv_pdu(S, Echo),
 
     ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
+    ct:sleep(1000),
+    [?match(#{tunnels := 0}, X) || X <- ergw_api:peer(all)],
     meck_validate(Config),
     ok.
 
@@ -305,6 +307,8 @@ path_restart_recovery(Config) ->
 
     %% create 2nd session with new restart_counter (simulate SGSN restart)
     {GtpC2, _, _} = create_pdp_context(S, gtp_context_inc_restart_counter(GtpC1)),
+
+    [?match(#{tunnels := 1}, X) || X <- ergw_api:peer(all)],
 
     delete_pdp_context(S, GtpC2),
 

--- a/test/ggsn_proxy_SUITE.erl
+++ b/test/ggsn_proxy_SUITE.erl
@@ -404,6 +404,8 @@ path_restart(Config) ->
     send_recv_pdu(S, Echo),
 
     ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
+    ct:sleep(1000),
+    [?match(#{tunnels := 0}, X) || X <- ergw_api:peer(all)],
     meck_validate(Config),
     ok.
 
@@ -418,6 +420,8 @@ path_restart_recovery(Config) ->
 
     %% create 2nd session with new restart_counter (simulate SGSN restart)
     {GtpC2, _, _} = create_pdp_context(S, gtp_context_inc_restart_counter(GtpC1)),
+
+    [?match(#{tunnels := 1}, X) || X <- ergw_api:peer(all)],
 
     delete_pdp_context(S, GtpC2),
 

--- a/test/pgw_SUITE.erl
+++ b/test/pgw_SUITE.erl
@@ -306,6 +306,8 @@ path_restart(Config) ->
     send_recv_pdu(S, Echo),
 
     ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
+    ct:sleep(1000),
+    [?match(#{tunnels := 0}, X) || X <- ergw_api:peer(all)],
     meck_validate(Config),
     ok.
 
@@ -320,6 +322,8 @@ path_restart_recovery(Config) ->
 
     %% create 2nd session with new restart_counter (simulate SGW restart)
     {GtpC2, _, _} = create_session(S, gtp_context_inc_restart_counter(GtpC1)),
+
+    [?match(#{tunnels := 1}, X) || X <- ergw_api:peer(all)],
 
     delete_session(S, GtpC2),
 
@@ -346,6 +350,8 @@ path_restart_multi(Config) ->
     send_recv_pdu(S, Echo),
 
     ok = meck:wait(5, ?HUT, terminate, '_', ?TIMEOUT),
+    ct:sleep(1000),
+    [?match(#{tunnels := 0}, X) || X <- ergw_api:peer(all)],
     meck_validate(Config),
     ok.
 

--- a/test/pgw_proxy_SUITE.erl
+++ b/test/pgw_proxy_SUITE.erl
@@ -457,6 +457,8 @@ path_restart(Config) ->
     send_recv_pdu(S, Echo),
 
     ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
+    ct:sleep(1000),
+    [?match(#{tunnels := 0}, X) || X <- ergw_api:peer(all)],
     meck_validate(Config),
     ok.
 
@@ -472,6 +474,8 @@ path_restart_recovery(Config) ->
 
     %% create 2nd session with new restart_counter (simulate SGW restart)
     {GtpC2, _, _} = create_session(S, gtp_context_inc_restart_counter(GtpC1)),
+
+    [?match(#{tunnels := 1}, X) || X <- ergw_api:peer(all)],
 
     delete_session(S, GtpC2),
 


### PR DESCRIPTION
The gtp_path process keeps and internal counter. This counter was
not reset properly when a path_restart happends.