### PR TITLE
rework context registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ From the above the following procedures as defined by 3GPP T 23.060 should work:
  * PDP Context Activation/Modification/Deactivation Procedure
  * PDP Context Activation/Modification/Deactivation Procedure using S4
  * Intersystem Change Procedures (handover 2G/3G/LTE)
- * 3GPP TS 23.401 Annex D, Interoperation with Gn/Gp SGSNs procedures
-   (see [CONFIG.md](CONFIG.md))
+ * 3GPP TS 23.401:
+   * Sect. 5.4.2.2, HSS Initiated Subscribed QoS Modification (without PCRF)
+   * Annex D, Interoperation with Gn/Gp SGSNs procedures (see [CONFIG.md](CONFIG.md))
 
 EXPERIMENTAL FEATURES
 ---------------------

--- a/rebar.lock
+++ b/rebar.lock
@@ -42,7 +42,7 @@
  {<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
  {<<"gtplib">>,
   {git,"https://github.com/travelping/gtplib.git",
-       {ref,"ebfec13c21c44e54e15ea6656f8cf6c275083c5f"}},
+       {ref,"91e8ff8575c9b001201f2763e48f9a0eaaf15eb3"}},
   0},
  {<<"hut">>,
   {git,"git://github.com/tolbrino/hut.git",

--- a/src/ergw_cache.erl
+++ b/src/ergw_cache.erl
@@ -1,0 +1,74 @@
+%% Copyright 2017, Travelping GmbH <info@travelping.com>
+
+%% This program is free software; you can redistribute it and/or
+%% modify it under the terms of the GNU General Public License
+%% as published by the Free Software Foundation; either version
+%% 2 of the License, or (at your option) any later version.
+
+-module(ergw_cache).
+
+-export([new/2, get/2, enter/4, expire/1, to_list/1]).
+
+%%%===================================================================
+%%% exometer functions
+%%%===================================================================
+
+-record(cache, {
+	  expire :: integer(),
+	  key    :: term(),
+	  timer  :: reference(),
+	  tree   :: gb_trees:tree(Key :: term(), {Expire :: integer(), Data :: term()}),
+	  queue  :: queue:queue({Expire :: integer(), Key :: term()})
+	 }).
+
+start_timer(#cache{expire = ExpireInterval, key = Key} = Cache) ->
+    Cache#cache{timer = erlang:start_timer(ExpireInterval, self(), Key)}.
+
+new(ExpireInterval, Key) ->
+    Cache = #cache{
+	       expire = ExpireInterval,
+	       key = Key,
+	       tree = gb_trees:empty(),
+	       queue = queue:new()
+	      },
+    start_timer(Cache).
+
+get(Key, #cache{tree = Tree}) ->
+    Now = erlang:monotonic_time(milli_seconds),
+    case gb_trees:lookup(Key, Tree) of
+	{value, {Expire, Data}}  when Expire > Now ->
+	    {value, Data};
+
+	_ ->
+	    none
+    end.
+
+enter(Key, Data, TimeOut, #cache{tree = Tree0, queue = Q0} = Cache) ->
+    Now = erlang:monotonic_time(milli_seconds),
+    Expire = Now + TimeOut,
+    Tree = gb_trees:enter(Key, {Expire, Data}, Tree0),
+    Q = queue:in({Expire, Key}, Q0),
+    expire(Now, Cache#cache{tree = Tree, queue = Q}).
+
+expire(Cache0) ->
+    Now = erlang:monotonic_time(milli_seconds),
+    Cache = expire(Now, Cache0),
+    start_timer(Cache).
+
+expire(Now, #cache{tree = Tree0, queue = Q0} = Cache) ->
+    case queue:peek(Q0) of
+	{value, {Expire, Key}} when Expire < Now ->
+	    Q = queue:drop(Q0),
+	    Tree = case gb_trees:lookup(Key, Tree0) of
+		       {value, {Expire, _}} ->
+			   gb_trees:delete(Key, Tree0);
+		       _ ->
+			   Tree0
+		   end,
+	    expire(Now, Cache#cache{tree = Tree, queue = Q});
+	_ ->
+	    Cache
+    end.
+
+to_list(#cache{tree = Tree, queue = Q}) ->
+    {gb_trees:to_list(Tree), queue:to_list(Q)}.

--- a/src/ggsn_gn_proxy.erl
+++ b/src/ggsn_gn_proxy.erl
@@ -471,8 +471,8 @@ init_proxy_context(CntlPort, DataPort,
 			    control_interface = Interface, state = State},
 		   #proxy_info{ggsn = GGSN, apn = APN, imsi = IMSI, msisdn = MSISDN}) ->
 
-    {ok, CntlTEI} = gtp_c_lib:alloc_tei(CntlPort),
-    {ok, DataTEI} = gtp_c_lib:alloc_tei(DataPort),
+    {ok, CntlTEI} = gtp_context_reg:alloc_tei(CntlPort),
+    {ok, DataTEI} = gtp_context_reg:alloc_tei(DataPort),
     #context{
        apn               = APN,
        imsi              = IMSI,

--- a/src/ggsn_gn_proxy.erl
+++ b/src/ggsn_gn_proxy.erl
@@ -159,6 +159,13 @@ handle_call(delete_context, _From, State) ->
     lager:warning("delete_context no handled(yet)"),
     {reply, ok, State};
 
+handle_call(terminate_context, _From,
+	    #{context := Context,
+	      proxy_context := ProxyContext} = State) ->
+    initiate_delete_pdp_context_request(ProxyContext),
+    dp_delete_pdp_context(Context, ProxyContext),
+    {stop, normal, ok, State};
+
 handle_call({path_restart, Path}, _From,
 	    #{context := #context{path = Path} = Context,
 	      proxy_context := ProxyContext
@@ -229,7 +236,9 @@ handle_request(ReqKey,
 
     Context1 = update_context_from_gtp_req(Request, Context0#context{state = #context_state{}}),
     ContextPreProxy = gtp_path:bind(Request, Context1),
-    gtp_context:register_remote_context(ContextPreProxy),
+
+    gtp_context:terminate_colliding_context(ContextPreProxy),
+    gtp_context:remote_context_register_new(ContextPreProxy),
 
     Session1 = init_session(IEs, ContextPreProxy),
     lager:debug("Invoking CONTROL: ~p", [Session1]),
@@ -261,7 +270,7 @@ handle_request(ReqKey,
     Context1 = gtp_path:bind(Request, Context0),
 
     gtp_context:enforce_restrictions(Request, Context1),
-    gtp_context:update_remote_context(OldContext, Context1),
+    gtp_context:remote_context_update(OldContext, Context1),
 
     Context = apply_context_change(Context1, OldContext),
 
@@ -333,7 +342,7 @@ handle_response(#proxy_request{direction = sgsn2ggsn} = ProxyRequest,
 
     ProxyContext1 = update_context_from_gtp_req(Response, ProxyContext0),
     ProxyContext = gtp_path:bind(Response, ProxyContext1),
-    gtp_context:register_remote_context(ProxyContext),
+    gtp_context:remote_context_register(ProxyContext),
 
     forward_response(ProxyRequest, Response, Context),
 
@@ -354,7 +363,7 @@ handle_response(#proxy_request{direction = sgsn2ggsn} = ProxyRequest,
     lager:warning("OK Proxy Response ~p", [lager:pr(Response, ?MODULE)]),
 
     ProxyContext0 = update_context_from_gtp_req(Response, OldProxyContext),
-    gtp_context:update_remote_context(OldProxyContext, ProxyContext0),
+    gtp_context:remote_context_update(OldProxyContext, ProxyContext0),
     ProxyContext = apply_context_change(ProxyContext0, OldProxyContext),
 
     forward_response(ProxyRequest, Response, Context),

--- a/src/gtp_c_lib.erl
+++ b/src/gtp_c_lib.erl
@@ -10,7 +10,6 @@
 -compile({parse_transform, cut}).
 
 -export([ip2bin/1, bin2ip/1]).
--export([alloc_tei/1]).
 -export([fmt_gtp/1]).
 
 -include_lib("gtplib/include/gtp_packet.hrl").
@@ -30,26 +29,6 @@ bin2ip(<<A, B, C, D>>) ->
     {A, B, C, D};
 bin2ip(<<A:16, B:16, C:16, D:16, E:16, F:16, G:16, H:16>>) ->
     {A, B, C, D, E, F, G, H}.
-
-%%====================================================================
-%% TEI registry
-%%====================================================================
-
--define(MAX_TRIES, 32).
-
-alloc_tei(GtpPort) ->
-    alloc_tei(GtpPort, ?MAX_TRIES).
-
-alloc_tei(_GtpPort, 0) ->
-    {error, no_tei};
-alloc_tei(GtpPort, Cnt) ->
-    TEI = erlang:unique_integer([positive]) rem 4294967296,    %% 32bit maxint + 1
-    case gtp_context_reg:register(GtpPort, TEI) of
-	ok ->
-	    {ok, TEI};
-	_Other ->
-	    alloc_tei(GtpPort, Cnt - 1)
-    end.
 
 %%%===================================================================
 %%% Helper functions

--- a/src/gtp_context.erl
+++ b/src/gtp_context.erl
@@ -12,7 +12,7 @@
 
 -export([handle_message/2, handle_packet_in/4, handle_response/4,
 	 start_link/5,
-	 send_request/4, send_request/6, send_response/2,
+	 send_request/6, send_response/2,
 	 send_request/5, resend_request/2,
 	 request_finished/1,
 	 path_restart/2,
@@ -115,10 +115,6 @@ handle_packet_in(GtpPort, IP, Port,
 
 handle_response(Context, ReqInfo, Request, Response) ->
     gen_server:cast(Context, {handle_response, ReqInfo, Request, Response}).
-
-send_request(GtpPort, RemoteIP, Msg, ReqInfo) ->
-    CbInfo = {?MODULE, handle_response, [self(), ReqInfo, Msg]},
-    gtp_socket:send_request(GtpPort, RemoteIP, Msg, CbInfo).
 
 send_request(GtpPort, RemoteIP, T3, N3, Msg, ReqInfo) ->
     CbInfo = {?MODULE, handle_response, [self(), ReqInfo, Msg]},

--- a/src/gtp_context_reg.erl
+++ b/src/gtp_context_reg.erl
@@ -7,15 +7,19 @@
 
 -module(gtp_context_reg).
 
--behaviour(regine_server).
+-behaviour(gen_server).
 
 %% API
 -export([start_link/0]).
--export([register/2, register/3, unregister/2, lookup/2]).
+-export([register/1, update/2, unregister/1,
+	 register/3, unregister/2,
+	 lookup_key/2, lookup_keys/2,
+	 lookup_teid/2, lookup_teid/3, lookup_teid/4]).
 -export([all/0]).
+-export([alloc_tei/1]).
 
-%% regine_server callbacks
--export([init/1, handle_register/4, handle_unregister/3, handle_pid_remove/3, handle_death/3, terminate/2]).
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
 
 %% --------------------------------------------------------------------
 %% Include files
@@ -24,69 +28,186 @@
 
 -define(SERVER, ?MODULE).
 
--record(state, {}).
-
 %%%===================================================================
 %%% API
 %%%===================================================================
 
 start_link() ->
-    regine_server:start_link({local, ?SERVER}, ?MODULE, []).
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
-register(GtpPort, Ident) ->
-    register(GtpPort, Ident, self()).
-
-register(#gtp_port{name = PortName}, Ident, Pid) ->
-    Key = {PortName, Ident},
-    regine_server:register(?SERVER, Pid, Key, undefined).
-
-unregister(#gtp_port{name = PortName}, Ident) ->
-    Key = {PortName, Ident},
-    regine_server:unregister(?SERVER, Key, undefined).
-
-lookup(#gtp_port{name = PortName}, Ident) ->
-    Key = {PortName, Ident},
-    case ets:lookup(?SERVER, Key) of
-	[{Key, Pid}] ->
+lookup_key(#gtp_port{name = Name}, Key) ->
+    RegKey = {Name, Key},
+    case ets:lookup(?SERVER, RegKey) of
+	[{RegKey, Pid}] ->
 	    Pid;
 	_ ->
 	    undefined
     end.
 
+lookup_keys(_, []) ->
+    throw({error, not_found});
+lookup_keys(Port, [H|T]) ->
+    case lookup_key(Port, H) of
+	Pid when is_pid(Pid) ->
+	    Pid;
+	_ ->
+	    lookup_keys(Port, T)
+    end.
+
+lookup_teid(#gtp_port{type = Type} = Port, TEI) ->
+    lookup_teid(Port, Type, TEI).
+
+lookup_teid(Port, Type, TEI)
+  when is_atom(Type) ->
+    lookup_key(Port, {teid, Type, TEI});
+lookup_teid(#gtp_port{type = Type} = Port, IP, TEI)
+  when is_tuple(IP) andalso (size(IP) == 4 orelse size(IP) == 8) ->
+    lookup_teid(Port, Type, IP, TEI).
+
+lookup_teid(Port, Type, IP, TEI) ->
+    lookup_key(Port, {teid, Type, IP, TEI}).
+
+register(#context{} = Context) ->
+    gen_server:call(?SERVER, {register, Context}).
+
+register(#gtp_port{name = Name}, Key, Context) when is_pid(Context) ->
+    gen_server:call(?SERVER, {register, {Name, Key}, Context}).
+
+update(#context{} = OldContext, #context{} = NewContext) ->
+    gen_server:call(?SERVER, {update, OldContext, NewContext}).
+
+unregister(#context{} = Context) ->
+    gen_server:call(?SERVER, {unregister, Context}).
+
+unregister(#gtp_port{name = Name}, Key) ->
+    gen_server:call(?SERVER, {unregister, {Name, Key}}).
+
 all() ->
     ets:tab2list(?SERVER).
+
+%%====================================================================
+%% TEI registry
+%%====================================================================
+
+-define(MAX_TRIES, 32).
+
+alloc_tei(Port) ->
+    alloc_tei(Port, ?MAX_TRIES).
+
+alloc_tei(_Port, 0) ->
+    {error, no_tei};
+alloc_tei(#gtp_port{name = Name} = Port, Cnt) ->
+    Key = {Name, tei},
+
+    %% 32bit maxint = 4294967295
+    TEI = ets:update_counter(?SERVER, Key, {2, 1, 4294967295, 1}, {Key, 0}),
+
+    case lookup_teid(Port, TEI) of
+	undefined ->
+	    {ok, TEI};
+	_ ->
+	    alloc_tei(Port, Cnt - 1)
+    end.
 
 %%%===================================================================
 %%% regine callbacks
 %%%===================================================================
 
 init([]) ->
+    process_flag(trap_exit, true),
+
     ets:new(?SERVER, [ordered_set, named_table, public, {keypos, 1}]),
-    {ok, #state{}}.
+    {ok, #{}}.
 
-handle_register(Pid, Key, _Value, State) ->
-    case ets:insert_new(?SERVER, {Key, Pid}) of
-	true ->  {ok, [Key], State};
-	false -> {error, duplicate}
-    end.
+handle_call({register, Context}, {Pid, _Ref}, State) ->
+    Keys = context2keys(Context),
+    handle_add_keys(Keys, Pid, State);
 
-handle_unregister(Key, _Value, State) ->
-    do_unregister(Key, State).
+handle_call({register, Key, Pid}, _From, State) ->
+    handle_add_keys([Key], Pid, State);
 
-handle_pid_remove(_Pid, Keys, State) ->
-    lists:foreach(fun(Key) -> ets:delete(?SERVER, Key) end, Keys),
-    State.
+handle_call({update, OldContext, NewContext}, {Pid, _Ref}, State) ->
+    DelKeys = context2keys(OldContext),
+    AddKeys = context2keys(NewContext),
+    Delete = ordsets:subtract(DelKeys, AddKeys),
+    Insert = ordsets:subtract(AddKeys, DelKeys),
+    case ets:insert_new(?SERVER, [{Key, Pid} || Key <- Insert]) of
+	true ->
+	    lists:foreach(fun(Key) -> delete_key(Key, Pid) end, Delete),
+	    NKeys = ordsets:union(ordsets:subtract(maps:get(Pid, State), Delete), Insert),
+	    {reply, ok, State#{Pid => NKeys}};
+	false ->
+	    {reply, {error, duplicate}, State}
+    end;
 
-handle_death(_Pid, _Reason, State) ->
-    State.
+handle_call({unregister, #context{} = Context}, {Pid, _Ref}, State0) ->
+    Keys = context2keys(Context),
+    State = delete_keys(Keys, Pid, State0),
+    {reply, ok, State};
+
+handle_call({unregister, Key}, {Pid, _Ref}, State0) ->
+    State = delete_keys([Key], Pid, State0),
+    {reply, ok, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info({'EXIT', Pid, _Reason}, State0) ->
+    Keys = maps:get(Pid, State0, []),
+    State = delete_keys(Keys, Pid, State0),
+    {noreply, State}.
 
 terminate(_Reason, _State) ->
 	ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
 
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================
 
-do_unregister(Key, State) ->
-    Pids = [Pid || {_, Pid} <- ets:take(?SERVER, Key)],
-    {Pids, State}.
+handle_add_keys(Keys, Pid, State) ->
+    ets:insert(?SERVER, [{Key, Pid} || Key <- Keys]),
+    link(Pid),
+    NKeys = ordsets:union(Keys, maps:get(Pid, State, [])),
+    {reply, ok, State#{Pid => NKeys}}.
+
+delete_keys(Keys, Pid, State) ->
+    lists:foreach(fun(Key) -> delete_key(Key, Pid) end, Keys),
+    case ordsets:subtract(maps:get(Pid, State, []), Keys) of
+	[] ->
+	    unlink(Pid),
+	    maps:remove(Pid, State);
+	Rest ->
+	    State#{Pid => Rest}
+    end.
+
+%% this is not the same a ets:take, the object will only
+%% be delete if Key and Pid match.....
+delete_key(Key, Pid) ->
+    case ets:lookup(?SERVER, Key) of
+	[{Key, Pid}] ->
+	    ets:take(?SERVER, Key);
+	Other ->
+	    Other
+    end.
+
+context2keys(#context{
+		control_port       = #gtp_port{name = CntlPortName},
+		local_control_tei  = LocalCntlTEI,
+		remote_control_ip  = RemoteCntlIP,
+		remote_control_tei = RemoteCntlTEI,
+		data_port          = #gtp_port{name = DataPortName},
+		local_data_tei     = LocalDataTEI,
+		remote_data_ip     = RemoteDataIP,
+		remote_data_tei    = RemoteDataTEI,
+		imsi               = IMSI,
+		imei               = IMEI}) ->
+    ordsets:from_list(
+      [{CntlPortName, {teid, 'gtp-c', LocalCntlTEI}},
+       {CntlPortName, {teid, 'gtp-u', LocalDataTEI}},
+       {CntlPortName, {teid, 'gtp-c', RemoteCntlIP, RemoteCntlTEI}},
+       {DataPortName, {teid, 'gtp-u', RemoteDataIP, RemoteDataTEI}}] ++
+	  [{CntlPortName, {imsi, IMSI}} || IMSI /= undefined] ++
+	  [{CntlPortName, {imei, IMEI}} || IMEI /= undefined]).

--- a/src/gtp_socket.erl
+++ b/src/gtp_socket.erl
@@ -15,8 +15,7 @@
 -export([validate_options/1,
 	 start_socket/2, start_link/1,
 	 send/4, send_response/3,
-	 send_request/4, send_request/6,
-	 send_request/5, resend_request/2,
+	 send_request/5, send_request/6, resend_request/2,
 	 get_restart_counter/1]).
 -export([get_request_q/1, get_response_q/1]).
 
@@ -95,9 +94,6 @@ send_response(#request{gtp_port = GtpPort, ip = RemoteIP} = ReqKey, Msg, DoCache
     message_counter(tx, GtpPort, RemoteIP, Msg),
     Data = gtp_packet:encode(Msg),
     cast(GtpPort, {send_response, ReqKey, Data, DoCache}).
-
-send_request(#gtp_port{type = 'gtp-c'} = GtpPort, RemoteIP, Msg = #gtp{}, CbInfo) ->
-    send_request(GtpPort, RemoteIP, ?T3, ?N3, Msg, CbInfo).
 
 send_request(#gtp_port{type = 'gtp-c'} = GtpPort, RemoteIP, T3, N3,
 	     Msg = #gtp{version = Version}, CbInfo) ->

--- a/src/gtp_socket.erl
+++ b/src/gtp_socket.erl
@@ -325,6 +325,9 @@ prepare_send_req(#send_req{msg = Msg0} = SendReq, State0) ->
     BinMsg = gtp_packet:encode(Msg),
     {SendReq#send_req{msg = Msg, data = BinMsg}, State}.
 
+new_sequence_number(#gtp{seq_no = SeqNo} = Msg, State)
+  when is_integer(SeqNo) ->
+    {Msg, State};
 new_sequence_number(#gtp{version = v1} = Msg, #state{v1_seq_no = SeqNo} = State) ->
     {Msg#gtp{seq_no = SeqNo}, State#state{v1_seq_no = (SeqNo + 1) rem 16#ffff}};
 new_sequence_number(#gtp{version = v2} = Msg, #state{v2_seq_no = SeqNo} = State) ->

--- a/src/pgw_s5s8_proxy.erl
+++ b/src/pgw_s5s8_proxy.erl
@@ -530,8 +530,8 @@ init_proxy_context(CntlPort, DataPort,
 			    control_interface = Interface, state = State},
 		   #proxy_info{ggsn = PGW, apn = APN, imsi = IMSI, msisdn = MSISDN}) ->
 
-    {ok, CntlTEI} = gtp_c_lib:alloc_tei(CntlPort),
-    {ok, DataTEI} = gtp_c_lib:alloc_tei(DataPort),
+    {ok, CntlTEI} = gtp_context_reg:alloc_tei(CntlPort),
+    {ok, DataTEI} = gtp_context_reg:alloc_tei(DataPort),
     #context{
        apn               = APN,
        imsi              = IMSI,

--- a/test/ergw_ggsn_test_lib.erl
+++ b/test/ergw_ggsn_test_lib.erl
@@ -133,17 +133,13 @@ make_request(create_pdp_context_request, SubType,
 	     #gtpc{restart_counter = RCnt, seq_no = SeqNo,
 		   local_control_tei = LocalCntlTEI,
 		   local_data_tei = LocalDataTEI}) ->
-    APN = case SubType of
-	      invalid_apn -> [<<"IN", "VA", "LID">>];
-	      _           -> ?'APN-EXAMPLE'
-	  end,
     IEs0 =
 	[#recovery{restart_counter = RCnt},
-	 #access_point_name{apn = APN},
+	 #access_point_name{apn = apn(SubType)},
 	 #gsn_address{instance = 0, address = gtp_c_lib:ip2bin(?CLIENT_IP)},
 	 #gsn_address{instance = 1, address = gtp_c_lib:ip2bin(?CLIENT_IP)},
-	 #imei{imei = <<"1234567890123456">>},
-	 #international_mobile_subscriber_identity{imsi = ?IMSI},
+	 #imei{imei = imei(SubType)},
+	 #international_mobile_subscriber_identity{imsi = imsi(SubType)},
 	 #ms_international_pstn_isdn_number{
 	    msisdn = {isdn_address,1,1,1, ?'MSISDN'}},
 	 #nsapi{nsapi = 5},
@@ -443,6 +439,15 @@ execute_request(MsgType, SubType, Socket, GtpC0) ->
     Response = send_recv_pdu(Socket, Msg),
 
     {validate_response(MsgType, SubType, Response, GtpC), Msg, Response}.
+
+apn(invalid_apn) -> [<<"IN", "VA", "LID">>];
+apn(_)           -> ?'APN-EXAMPLE'.
+
+imsi('2nd') -> <<"454545454545452">>;
+imsi(_)     -> ?IMSI.
+
+imei('2nd') -> <<"6543210987654321">>;
+imei(_)     -> <<"1234567890123456">>.
 
 %%%===================================================================
 %%% GGSN injected functions

--- a/test/ergw_ggsn_test_lib.erl
+++ b/test/ergw_ggsn_test_lib.erl
@@ -421,6 +421,13 @@ validate_response(ms_info_change_notification_request, simple, Response,
     ?equal(false, maps:is_key({imei,0}, IEs)),
     GtpC;
 
+validate_response(delete_pdp_context_request, not_found, Response, GtpC) ->
+    ?match(#gtp{type = delete_pdp_context_response,
+		tei = 0,
+		ie = #{{cause,0} := #cause{value = non_existent}}
+	       }, Response),
+    GtpC;
+
 validate_response(delete_pdp_context_request, _SubType, Response,
 		  #gtpc{local_control_tei = LocalCntlTEI} = GtpC) ->
     ?match(#gtp{type = delete_pdp_context_response,

--- a/test/ergw_pgw_test_lib.erl
+++ b/test/ergw_pgw_test_lib.erl
@@ -551,6 +551,14 @@ validate_response(resume_notification, _SubType, Response,
 	   }, Response),
     GtpC;
 
+validate_response(delete_session_request, not_found, Response, GtpC) ->
+    ?match(
+       #gtp{type = delete_session_response,
+	    tei = 0,
+	    ie = #{{v2_cause,0} := #v2_cause{v2_cause = context_not_found}}
+	   }, Response),
+    GtpC;
+
 validate_response(delete_session_request, _SubType, Response,
 		  #gtpc{local_control_tei = LocalCntlTEI} = GtpC) ->
     ?match(#gtp{type = delete_session_response,

--- a/test/ergw_pgw_test_lib.erl
+++ b/test/ergw_pgw_test_lib.erl
@@ -127,13 +127,9 @@ make_request(create_session_request, SubType,
 	     #gtpc{restart_counter = RCnt, seq_no = SeqNo,
 		   local_control_tei = LocalCntlTEI,
 		   local_data_tei = LocalDataTEI}) ->
-    APN = case SubType of
-	      invalid_apn -> [<<"IN", "VA", "LID">>];
-	      _           -> ?'APN-EXAMPLE'
-	  end,
     IEs0 =
 	[#v2_recovery{restart_counter = RCnt},
-	 #v2_access_point_name{apn = APN},
+	 #v2_access_point_name{apn = apn(SubType)},
 	 #v2_aggregate_maximum_bit_rate{uplink = 48128, downlink = 1704125},
 	 #v2_apn_restriction{restriction_type_value = 0},
 	 #v2_bearer_context{
@@ -155,8 +151,8 @@ make_request(create_session_request, SubType,
 	    key = LocalCntlTEI,
 	    ipv4 = gtp_c_lib:ip2bin(?CLIENT_IP)},
 	 #v2_international_mobile_subscriber_identity{
-	    imsi = ?'IMSI'},
-	 #v2_mobile_equipment_identity{mei = <<"AAAAAAAA">>},
+	    imsi = imsi(SubType)},
+	 #v2_mobile_equipment_identity{mei = imei(SubType)},
 	 #v2_msisdn{msisdn = ?'MSISDN'},
 	 #v2_rat_type{rat_type = 6},
 	 #v2_selection_mode{mode = 0},
@@ -583,6 +579,15 @@ execute_request(MsgType, SubType, Socket, GtpC0) ->
     Response = send_recv_pdu(Socket, Msg),
 
     {validate_response(MsgType, SubType, Response, GtpC), Msg, Response}.
+
+apn(invalid_apn) -> [<<"IN", "VA", "LID">>];
+apn(_)           -> ?'APN-EXAMPLE'.
+
+imsi('2nd') -> <<"454545454545452">>;
+imsi(_)     -> ?IMSI.
+
+imei('2nd') -> <<"BBBBBBBB">>;
+imei(_)     -> <<"AAAAAAAA">>.
 
 %%%===================================================================
 %%% PGW injected functions

--- a/test/ergw_test_lib.erl
+++ b/test/ergw_test_lib.erl
@@ -27,7 +27,7 @@
 	 recv_pdu/2, recv_pdu/3, recv_pdu/4]).
 -export([pretty_print/1]).
 -export([set_cfg_value/3, add_cfg_value/3]).
--export([outstanding_requests/0, hexstr2bin/1]).
+-export([outstanding_requests/0, wait4tunnels/1, hexstr2bin/1]).
 
 -include("ergw_test_lib.hrl").
 -include_lib("common_test/include/ct.hrl").
@@ -276,6 +276,18 @@ add_cfg_value([H | T], Value, Config) ->
 
 outstanding_requests() ->
     ets:match_object(gtp_context_reg, {{'_', {'_', '_', '_', '_', '_'}}, '_'}).
+
+wait4tunnels(Cnt) ->
+    case [X || X = #{tunnels := T} <- ergw_api:peer(all), T /= 0] of
+	[] -> ok;
+	Other ->
+	    if Cnt > 100 ->
+		    ct:sleep(100),
+		    wait4tunnels(Cnt - 100);
+	       true ->
+		    ct:fail("timeout, waiting for tunnels to terminate, left over ~p", [Other])
+	    end
+    end.
 
 %%%===================================================================
 %% hexstr2bin from otp/lib/crypto/test/crypto_SUITE.erl

--- a/test/ergw_test_lib.erl
+++ b/test/ergw_test_lib.erl
@@ -19,7 +19,8 @@
 -export([gtp_context/0,
 	 gtp_context_inc_seq/1,
 	 gtp_context_inc_restart_counter/1,
-	 gtp_context_new_teids/1]).
+	 gtp_context_new_teids/1,
+	 make_error_indication/1]).
 -export([make_gtp_socket/1,
 	 send_pdu/2,
 	 send_recv_pdu/2, send_recv_pdu/3, send_recv_pdu/4,
@@ -164,6 +165,13 @@ gtp_context_new_teids(GtpC) ->
       local_data_tei =
 	  ets:update_counter(?MODULE, teid, 1) rem 16#100000000
      }.
+
+%% pretend the other side send us a GTP-U packet for an invalid TEID
+-define('Tunnel Endpoint Identifier Data I', {tunnel_endpoint_identifier_data_i, 0}).
+make_error_indication(#gtpc{local_data_tei = TEI}) ->
+    #gtp{type = error_indication, version = v1, tei = 0,
+	 ie = #{?'Tunnel Endpoint Identifier Data I' =>
+		    #tunnel_endpoint_identifier_data_i{tei = TEI}}}.
 
 %%%===================================================================
 %%% I/O and socket functions

--- a/test/ergw_test_lib.hrl
+++ b/test/ergw_test_lib.hrl
@@ -24,7 +24,7 @@
 			  send_recv_pdu/2, send_recv_pdu/3, send_recv_pdu/4,
 			  recv_pdu/2, recv_pdu/3, recv_pdu/4]).
 -import('ergw_test_lib', [set_cfg_value/3, add_cfg_value/3]).
--import('ergw_test_lib', [outstanding_requests/0, hexstr2bin/1]).
+-import('ergw_test_lib', [outstanding_requests/0, wait4tunnels/1, hexstr2bin/1]).
 
 -endif.
 

--- a/test/ergw_test_lib.hrl
+++ b/test/ergw_test_lib.hrl
@@ -17,7 +17,8 @@
 -import('ergw_test_lib', [gtp_context/0,
 			  gtp_context_inc_seq/1,
 			  gtp_context_inc_restart_counter/1,
-			  gtp_context_new_teids/1]).
+			  gtp_context_new_teids/1,
+			  make_error_indication/1]).
 -import('ergw_test_lib', [make_gtp_socket/1,
 			  send_pdu/2,
 			  send_recv_pdu/2, send_recv_pdu/3, send_recv_pdu/4,

--- a/test/ggsn_SUITE.erl
+++ b/test/ggsn_SUITE.erl
@@ -551,8 +551,8 @@ delete_pdp_context_requested(Config) ->
 
     {GtpC, _, _} = create_pdp_context(S),
 
-    Context = gtp_context_reg:lookup(#gtp_port{name = 'irx'},
-				     {imsi, ?'IMSI'}),
+    Context = gtp_context_reg:lookup_key(#gtp_port{name = 'irx'},
+					 {imsi, ?'IMSI'}),
     true = is_pid(Context),
 
     Self = self(),
@@ -585,8 +585,8 @@ delete_pdp_context_requested_resend(Config) ->
 
     {_, _, _} = create_pdp_context(S),
 
-    Context = gtp_context_reg:lookup(#gtp_port{name = 'irx'},
-				     {imsi, ?'IMSI'}),
+    Context = gtp_context_reg:lookup_key(#gtp_port{name = 'irx'},
+					 {imsi, ?'IMSI'}),
     true = is_pid(Context),
 
     Self = self(),

--- a/test/ggsn_SUITE.erl
+++ b/test/ggsn_SUITE.erl
@@ -293,8 +293,7 @@ path_restart(Config) ->
     send_recv_pdu(S, Echo),
 
     ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
-    ct:sleep(1000),
-    [?match(#{tunnels := 0}, X) || X <- ergw_api:peer(all)],
+    wait4tunnels(?TIMEOUT),
     meck_validate(Config),
     ok.
 

--- a/test/ggsn_proxy_SUITE.erl
+++ b/test/ggsn_proxy_SUITE.erl
@@ -419,7 +419,7 @@ path_restart_recovery(Config) ->
     {GtpC1, _, _} = create_pdp_context(S),
 
     %% create 2nd session with new restart_counter (simulate SGSN restart)
-    {GtpC2, _, _} = create_pdp_context(S, gtp_context_inc_restart_counter(GtpC1)),
+    {GtpC2, _, _} = create_pdp_context('2nd', S, gtp_context_inc_restart_counter(GtpC1)),
 
     [?match(#{tunnels := 1}, X) || X <- ergw_api:peer(all)],
 
@@ -714,8 +714,8 @@ delete_pdp_context_requested(Config) ->
 
     {GtpC, _, _} = create_pdp_context(S),
 
-    Context = gtp_context_reg:lookup(#gtp_port{name = 'remote-irx'},
-				     {imsi, ?'PROXY-IMSI'}),
+    Context = gtp_context_reg:lookup_key(#gtp_port{name = 'remote-irx'},
+					 {imsi, ?'PROXY-IMSI'}),
     true = is_pid(Context),
 
     Self = self(),
@@ -747,8 +747,8 @@ delete_pdp_context_requested_resend(Config) ->
 
     {_, _, _} = create_pdp_context(S),
 
-    Context = gtp_context_reg:lookup(#gtp_port{name = 'remote-irx'},
-				     {imsi, ?'PROXY-IMSI'}),
+    Context = gtp_context_reg:lookup_key(#gtp_port{name = 'remote-irx'},
+					 {imsi, ?'PROXY-IMSI'}),
     true = is_pid(Context),
 
     Self = self(),
@@ -777,8 +777,8 @@ delete_pdp_context_requested_invalid_teid(Config) ->
 
     {GtpC, _, _} = create_pdp_context(S),
 
-    Context = gtp_context_reg:lookup(#gtp_port{name = 'remote-irx'},
-				     {imsi, ?'PROXY-IMSI'}),
+    Context = gtp_context_reg:lookup_key(#gtp_port{name = 'remote-irx'},
+					 {imsi, ?'PROXY-IMSI'}),
     true = is_pid(Context),
 
     Self = self(),
@@ -811,8 +811,8 @@ delete_pdp_context_requested_late_response(Config) ->
 
     {GtpC, _, _} = create_pdp_context(S),
 
-    Context = gtp_context_reg:lookup(#gtp_port{name = 'remote-irx'},
-				     {imsi, ?'PROXY-IMSI'}),
+    Context = gtp_context_reg:lookup_key(#gtp_port{name = 'remote-irx'},
+					 {imsi, ?'PROXY-IMSI'}),
     true = is_pid(Context),
 
     Self = self(),
@@ -848,8 +848,8 @@ ggsn_update_pdp_context_request(Config) ->
 
     {GtpC, _, _} = create_pdp_context(S),
 
-    Context = gtp_context_reg:lookup(#gtp_port{name = 'remote-irx'},
-				     {imsi, ?'PROXY-IMSI'}),
+    Context = gtp_context_reg:lookup_key(#gtp_port{name = 'remote-irx'},
+					 {imsi, ?'PROXY-IMSI'}),
     true = is_pid(Context),
 
     Self = self(),

--- a/test/ggsn_proxy_SUITE.erl
+++ b/test/ggsn_proxy_SUITE.erl
@@ -459,6 +459,26 @@ simple_pdp_context_request(Config) ->
     ok.
 
 %%--------------------------------------------------------------------
+duplicate_pdp_context_request() ->
+    [{doc, "Check the a new incomming request for the same IMSI terminates the first"}].
+duplicate_pdp_context_request(Config) ->
+    S = make_gtp_socket(Config),
+
+    {GtpC1, _, _} = create_pdp_context(S),
+
+    %% create 2nd PDP context with the same IMSI
+    {GtpC2, _, _} = create_pdp_context(S),
+
+    delete_pdp_context(not_found, S, GtpC1),
+    delete_pdp_context(S, GtpC2),
+
+    [?match(#{tunnels := 0}, X) || X <- ergw_api:peer(all)],
+    ?equal([], outstanding_requests()),
+    ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
+    meck_validate(Config),
+    ok.
+
+%%--------------------------------------------------------------------
 create_pdp_context_request_resend() ->
     [{doc, "Check that a retransmission of a Create PDP Context Request works"}].
 create_pdp_context_request_resend(Config) ->

--- a/test/ggsn_proxy_SUITE.erl
+++ b/test/ggsn_proxy_SUITE.erl
@@ -404,8 +404,7 @@ path_restart(Config) ->
     send_recv_pdu(S, Echo),
 
     ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
-    ct:sleep(1000),
-    [?match(#{tunnels := 0}, X) || X <- ergw_api:peer(all)],
+    wait4tunnels(?TIMEOUT),
     meck_validate(Config),
     ok.
 
@@ -472,9 +471,9 @@ duplicate_pdp_context_request(Config) ->
     delete_pdp_context(not_found, S, GtpC1),
     delete_pdp_context(S, GtpC2),
 
-    [?match(#{tunnels := 0}, X) || X <- ergw_api:peer(all)],
     ?equal([], outstanding_requests()),
     ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
+    wait4tunnels(?TIMEOUT),
     meck_validate(Config),
     ok.
 

--- a/test/pgw_SUITE.erl
+++ b/test/pgw_SUITE.erl
@@ -314,8 +314,7 @@ path_restart(Config) ->
     send_recv_pdu(S, Echo),
 
     ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
-    ct:sleep(1000),
-    [?match(#{tunnels := 0}, X) || X <- ergw_api:peer(all)],
+    wait4tunnels(?TIMEOUT),
     meck_validate(Config),
     ok.
 
@@ -358,8 +357,7 @@ path_restart_multi(Config) ->
     send_recv_pdu(S, Echo),
 
     ok = meck:wait(5, ?HUT, terminate, '_', ?TIMEOUT),
-    ct:sleep(1000),
-    [?match(#{tunnels := 0}, X) || X <- ergw_api:peer(all)],
+    wait4tunnels(?TIMEOUT),
     meck_validate(Config),
     ok.
 
@@ -390,9 +388,8 @@ duplicate_session_request(Config) ->
     delete_session(not_found, S, GtpC1),
     delete_session(S, GtpC2),
 
-    [?match(#{tunnels := 0}, X) || X <- ergw_api:peer(all)],
-
     ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
+    wait4tunnels(?TIMEOUT),
     meck_validate(Config),
     ok.
 
@@ -411,9 +408,8 @@ error_indication(Config) ->
     ct:sleep(100),
     delete_session(not_found, S, GtpC),
 
-    [?match(#{tunnels := 0}, X) || X <- ergw_api:peer(all)],
-
     ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
+    wait4tunnels(?TIMEOUT),
     meck_validate(Config),
     ok.
 

--- a/test/pgw_SUITE.erl
+++ b/test/pgw_SUITE.erl
@@ -615,7 +615,7 @@ delete_bearer_request(Config) ->
 
     {GtpC, _, _} = create_session(S),
 
-    Context = gtp_context_reg:lookup(#gtp_port{name = irx}, {imsi, ?'IMSI'}),
+    Context = gtp_context_reg:lookup_key(#gtp_port{name = irx}, {imsi, ?'IMSI'}),
     true = is_pid(Context),
 
     Self = self(),
@@ -647,7 +647,7 @@ delete_bearer_request_resend(Config) ->
 
     {_, _, _} = create_session(S),
 
-    Context = gtp_context_reg:lookup(#gtp_port{name = irx}, {imsi, ?'IMSI'}),
+    Context = gtp_context_reg:lookup_key(#gtp_port{name = irx}, {imsi, ?'IMSI'}),
     true = is_pid(Context),
 
     Self = self(),

--- a/test/pgw_proxy_SUITE.erl
+++ b/test/pgw_proxy_SUITE.erl
@@ -637,8 +637,14 @@ modify_bearer_command(Config) ->
     S = make_gtp_socket(Config),
 
     {GtpC1, _, _} = create_session(S),
-    {GtpC2, Req} = modify_bearer_command(simple, S, GtpC1),
-    ?equal({ok, timeout}, recv_pdu(S, Req#gtp.seq_no, ?TIMEOUT, ok)),
+    {GtpC2, Req0} = modify_bearer_command(simple, S, GtpC1),
+
+    Req1 = recv_pdu(S, Req0#gtp.seq_no, ?TIMEOUT, ok),
+    validate_response(modify_bearer_command, simple, Req1, GtpC2),
+    Response = make_response(Req1, simple, GtpC2),
+    send_pdu(S, Response),
+
+    ?equal({ok, timeout}, recv_pdu(S, Req1#gtp.seq_no, ?TIMEOUT, ok)),
     ?equal([], outstanding_requests()),
     delete_session(S, GtpC2),
 

--- a/test/pgw_proxy_SUITE.erl
+++ b/test/pgw_proxy_SUITE.erl
@@ -473,7 +473,7 @@ path_restart_recovery(Config) ->
     {GtpC1, _, _} = create_session(S),
 
     %% create 2nd session with new restart_counter (simulate SGW restart)
-    {GtpC2, _, _} = create_session(S, gtp_context_inc_restart_counter(GtpC1)),
+    {GtpC2, _, _} = create_session('2nd', S, gtp_context_inc_restart_counter(GtpC1)),
 
     [?match(#{tunnels := 1}, X) || X <- ergw_api:peer(all)],
 
@@ -828,8 +828,8 @@ delete_bearer_request(Config) ->
 
     {GtpC, _, _} = create_session(S),
 
-    Context = gtp_context_reg:lookup(#gtp_port{name = 'remote-irx'},
-				     {imsi, ?'PROXY-IMSI'}),
+    Context = gtp_context_reg:lookup_key(#gtp_port{name = 'remote-irx'},
+					 {imsi, ?'PROXY-IMSI'}),
     true = is_pid(Context),
 
     Self = self(),
@@ -862,8 +862,8 @@ delete_bearer_request_resend(Config) ->
 
     {_, _, _} = create_session(S),
 
-    Context = gtp_context_reg:lookup(#gtp_port{name = 'remote-irx'},
-				     {imsi, ?'PROXY-IMSI'}),
+    Context = gtp_context_reg:lookup_key(#gtp_port{name = 'remote-irx'},
+					 {imsi, ?'PROXY-IMSI'}),
     true = is_pid(Context),
 
     Self = self(),
@@ -893,8 +893,8 @@ delete_bearer_request_invalid_teid(Config) ->
 
     {GtpC, _, _} = create_session(S),
 
-    Context = gtp_context_reg:lookup(#gtp_port{name = 'remote-irx'},
-				     {imsi, ?'PROXY-IMSI'}),
+    Context = gtp_context_reg:lookup_key(#gtp_port{name = 'remote-irx'},
+					 {imsi, ?'PROXY-IMSI'}),
     true = is_pid(Context),
 
     Self = self(),
@@ -928,8 +928,8 @@ delete_bearer_request_late_response(Config) ->
 
     {GtpC, _, _} = create_session(S),
 
-    Context = gtp_context_reg:lookup(#gtp_port{name = 'remote-irx'},
-				     {imsi, ?'PROXY-IMSI'}),
+    Context = gtp_context_reg:lookup_key(#gtp_port{name = 'remote-irx'},
+					 {imsi, ?'PROXY-IMSI'}),
     true = is_pid(Context),
 
     Self = self(),
@@ -1015,8 +1015,8 @@ update_bearer_request(Config) ->
 
     {GtpC, _, _} = create_session(S),
 
-    Context = gtp_context_reg:lookup(#gtp_port{name = 'remote-irx'},
-				     {imsi, ?'PROXY-IMSI'}),
+    Context = gtp_context_reg:lookup_key(#gtp_port{name = 'remote-irx'},
+					 {imsi, ?'PROXY-IMSI'}),
     true = is_pid(Context),
 
     Self = self(),

--- a/test/pgw_proxy_SUITE.erl
+++ b/test/pgw_proxy_SUITE.erl
@@ -458,8 +458,7 @@ path_restart(Config) ->
     send_recv_pdu(S, Echo),
 
     ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
-    ct:sleep(1000),
-    [?match(#{tunnels := 0}, X) || X <- ergw_api:peer(all)],
+    wait4tunnels(?TIMEOUT),
     meck_validate(Config),
     ok.
 
@@ -525,9 +524,8 @@ duplicate_session_request(Config) ->
     delete_session(not_found, S, GtpC1),
     delete_session(S, GtpC2),
 
-    [?match(#{tunnels := 0}, X) || X <- ergw_api:peer(all)],
-
     ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
+    wait4tunnels(?TIMEOUT),
     meck_validate(Config),
     ok.
 


### PR DESCRIPTION
this makes sure that:
* context are cleaned properly
* duplicate context registration are caught
* incoming new context terminated colliding, old contexts