### PR TITLE
fix context tear down

### DIFF
--- a/include/ergw.hrl
+++ b/include/ergw.hrl
@@ -34,6 +34,8 @@
 	  imsi                   :: 'undefined' | binary(),
 	  imei                   :: 'undefined' | binary(),
 	  msisdn                 :: 'undefined' | binary(),
+	  context_id             :: term(),
+
 	  version                :: 'v1' | 'v2',
 	  control_interface      :: atom(),
 	  control_port           :: #gtp_port{},

--- a/src/ergw_proxy_lib.erl
+++ b/src/ergw_proxy_lib.erl
@@ -23,7 +23,7 @@ forward_request(Direction,
 		Request, ReqKey, SeqNo, NewPeer) ->
     {ReqId, ReqInfo} = make_proxy_request(Direction, ReqKey, SeqNo, NewPeer),
     lager:debug("Invoking Context Send Request: ~p", [Request]),
-    gtp_context:send_request(GtpPort, RemoteCntlIP, ReqId, Request, ReqInfo).
+    gtp_context:send_request(GtpPort, RemoteCntlIP, ?GTP1c_PORT, ReqId, Request, ReqInfo).
 
 forward_request(#context{control_port = GtpPort}, ReqKey, Request) ->
     ReqId = make_request_id(ReqKey, Request),

--- a/src/ggsn_gn.erl
+++ b/src/ggsn_gn.erl
@@ -550,7 +550,7 @@ send_request(#context{control_port = GtpPort,
 		      remote_control_ip = RemoteCntlIP},
 	     T3, N3, Type, RequestIEs, ReqInfo) ->
     Msg = #gtp{version = v1, type = Type, tei = RemoteCntlTEI, ie = RequestIEs},
-    gtp_context:send_request(GtpPort, RemoteCntlIP, T3, N3, Msg, ReqInfo).
+    gtp_context:send_request(GtpPort, RemoteCntlIP, ?GTP1c_PORT, T3, N3, Msg, ReqInfo).
 
 %% delete_context(From, #context_state{nsapi = NSAPI} = Context) ->
 delete_context(From, Context) ->

--- a/src/ggsn_gn_proxy.erl
+++ b/src/ggsn_gn_proxy.erl
@@ -594,7 +594,7 @@ send_request(#context{control_port = GtpPort,
 		      remote_control_ip = RemoteCntlIP},
 	     T3, N3, Type, RequestIEs) ->
     Msg = #gtp{version = v1, type = Type, tei = RemoteCntlTEI, ie = RequestIEs},
-    gtp_context:send_request(GtpPort, RemoteCntlIP, T3, N3, Msg, undefined).
+    gtp_context:send_request(GtpPort, RemoteCntlIP, ?GTP1c_PORT, T3, N3, Msg, undefined).
 
 initiate_delete_pdp_context_request(#context{state = #context_state{nsapi = NSAPI}} = Context) ->
     RequestIEs0 = [#cause{value = request_accepted},

--- a/src/ggsn_gn_proxy.erl
+++ b/src/ggsn_gn_proxy.erl
@@ -493,7 +493,7 @@ copy_to_session(_K, _V, Session) ->
     Session.
 
 init_proxy_context(CntlPort, DataPort,
-		   #context{imei = IMEI, version = Version,
+		   #context{imei = IMEI, context_id = ContextId, version = Version,
 			    control_interface = Interface, state = State},
 		   #proxy_info{imsi = IMSI, msisdn = MSISDN},
            #proxy_ggsn{address = GGSN, dst_apn = APN}) ->
@@ -505,6 +505,7 @@ init_proxy_context(CntlPort, DataPort,
        imsi              = IMSI,
        imei              = IMEI,
        msisdn            = MSISDN,
+       context_id        = ContextId,
 
        version           = Version,
        control_interface = Interface,
@@ -538,8 +539,9 @@ get_context_from_req(_K, #nsapi{instance = 0, nsapi = NSAPI}, #context{state = S
 get_context_from_req(_K, _, Context) ->
     Context.
 
-update_context_from_gtp_req(#gtp{ie = IEs}, Context) ->
-    maps:fold(fun get_context_from_req/3, Context, IEs).
+update_context_from_gtp_req(#gtp{ie = IEs} = Req, Context0) ->
+    Context1 = gtp_v1_c:update_context_id(Req, Context0),
+    maps:fold(fun get_context_from_req/3, Context1, IEs).
 
 set_req_from_context(#context{apn = APN},
 		  _K, #access_point_name{instance = 0} = IE)

--- a/src/gtp_context.erl
+++ b/src/gtp_context.erl
@@ -12,8 +12,8 @@
 
 -export([handle_message/2, handle_packet_in/4, handle_response/4,
 	 start_link/5,
-	 send_request/6, send_response/2,
-	 send_request/5, resend_request/2,
+	 send_request/7, send_response/2,
+	 send_request/6, resend_request/2,
 	 request_finished/1,
 	 path_restart/2,
 	 terminate_colliding_context/1, terminate_context/1, delete_context/1,
@@ -116,13 +116,13 @@ handle_packet_in(GtpPort, IP, Port,
 handle_response(Context, ReqInfo, Request, Response) ->
     gen_server:cast(Context, {handle_response, ReqInfo, Request, Response}).
 
-send_request(GtpPort, RemoteIP, T3, N3, Msg, ReqInfo) ->
+send_request(GtpPort, DstIP, DstPort, T3, N3, Msg, ReqInfo) ->
     CbInfo = {?MODULE, handle_response, [self(), ReqInfo, Msg]},
-    gtp_socket:send_request(GtpPort, RemoteIP, T3, N3, Msg, CbInfo).
+    gtp_socket:send_request(GtpPort, DstIP, DstPort, T3, N3, Msg, CbInfo).
 
-send_request(GtpPort, RemoteIP, ReqId, Msg, ReqInfo) ->
+send_request(GtpPort, DstIP, DstPort, ReqId, Msg, ReqInfo) ->
     CbInfo = {?MODULE, handle_response, [self(), ReqInfo, Msg]},
-    gtp_socket:send_request(GtpPort, RemoteIP, ReqId, Msg, CbInfo).
+    gtp_socket:send_request(GtpPort, DstIP, DstPort, ReqId, Msg, CbInfo).
 
 resend_request(GtpPort, ReqId) ->
     gtp_socket:resend_request(GtpPort, ReqId).

--- a/src/gtp_path.erl
+++ b/src/gtp_path.erl
@@ -372,11 +372,11 @@ stop_echo_request(#state{echo_timer = EchoTRef} = State) ->
     end,
     State#state{echo_timer = stopped}.
 
-send_echo_request(#state{gtp_port = GtpPort, handler = Handler, ip = RemoteIP,
+send_echo_request(#state{gtp_port = GtpPort, handler = Handler, ip = DstIP,
 			 t3 = T3, n3 = N3} = State) ->
     Msg = Handler:build_echo_request(GtpPort),
     CbInfo = {?MODULE, handle_response, [self()]},
-    gtp_socket:send_request(GtpPort, RemoteIP, T3, N3, Msg, CbInfo),
+    gtp_socket:send_request(GtpPort, DstIP, ?GTP1c_PORT, T3, N3, Msg, CbInfo),
     State#state{echo_timer = awaiting_response} .
 
 echo_response(Msg, #state{echo = EchoInterval,

--- a/src/pgw_s5s8.erl
+++ b/src/pgw_s5s8.erl
@@ -683,7 +683,7 @@ msg(#context{remote_control_tei = RemoteCntlTEI}, Type, RequestIEs) ->
 send_request_msg(#context{control_port = GtpPort,
 			  remote_control_ip = RemoteCntlIP},
 		 T3, N3, Msg, ReqInfo) ->
-    gtp_context:send_request(GtpPort, RemoteCntlIP, T3, N3, Msg, ReqInfo).
+    gtp_context:send_request(GtpPort, RemoteCntlIP, ?GTP2c_PORT, T3, N3, Msg, ReqInfo).
 
 send_request(Context, T3, N3, Type, RequestIEs, ReqInfo) ->
     send_request_msg(Context, T3, N3, msg(Context, Type, RequestIEs), ReqInfo).

--- a/src/pgw_s5s8_proxy.erl
+++ b/src/pgw_s5s8_proxy.erl
@@ -710,7 +710,7 @@ send_request(#context{control_port = GtpPort,
 		      remote_control_ip = RemoteCntlIP},
 	     T3, N3, Type, RequestIEs) ->
     Msg = #gtp{version = v2, type = Type, tei = RemoteCntlTEI, ie = RequestIEs},
-    gtp_context:send_request(GtpPort, RemoteCntlIP, T3, N3, Msg, undefined).
+    gtp_context:send_request(GtpPort, RemoteCntlIP, ?GTP2c_PORT, T3, N3, Msg, undefined).
 
 initiate_delete_session_request(#context{state = #context_state{ebi = EBI}} = Context) ->
     RequestIEs0 = [#v2_cause{v2_cause = network_failure},

--- a/src/pgw_s5s8_proxy.erl
+++ b/src/pgw_s5s8_proxy.erl
@@ -565,7 +565,7 @@ update_path_bind(NewContext, _OldContext) ->
     NewContext.
 
 init_proxy_context(CntlPort, DataPort,
-		   #context{imei = IMEI, version = Version,
+		   #context{imei = IMEI, context_id = ContextId, version = Version,
 			    control_interface = Interface, state = State},
 		   #proxy_info{imsi = IMSI, msisdn = MSISDN},
 		   #proxy_ggsn{address = PGW, dst_apn = APN}) ->
@@ -577,6 +577,7 @@ init_proxy_context(CntlPort, DataPort,
        imsi              = IMSI,
        imei              = IMEI,
        msisdn            = MSISDN,
+       context_id        = ContextId,
 
        version           = Version,
        control_interface = Interface,
@@ -641,8 +642,9 @@ get_context_from_req(?'MSISDN', #v2_msisdn{msisdn = MSISDN}, Context) ->
 get_context_from_req(_K, _, Context) ->
     Context.
 
-update_context_from_gtp_req(#gtp{ie = IEs}, Context) ->
-    maps:fold(fun get_context_from_req/3, Context, IEs).
+update_context_from_gtp_req(#gtp{ie = IEs} = Req, Context0) ->
+    Context1 = gtp_v2_c:update_context_id(Req, Context0),
+    maps:fold(fun get_context_from_req/3, Context1, IEs).
 
 set_bearer_from_context(#context{data_port = #gtp_port{ip = DataIP}, local_data_tei = DataTEI},
 			_, #v2_fully_qualified_tunnel_endpoint_identifier{interface_type = ?'S5/S8-U SGW'} = IE) ->

--- a/src/pgw_s5s8_proxy.erl
+++ b/src/pgw_s5s8_proxy.erl
@@ -24,6 +24,7 @@
 -define(GTP_v1_Interface, ggsn_gn_proxy).
 -define(T3, 10 * 1000).
 -define(N3, 5).
+-define(RESPONSE_TIMEOUT, (?T3 + (?T3 div 2))).
 
 -define(IS_REQUEST_CONTEXT(Key, Msg, Context),
 	(is_record(Key, request) andalso
@@ -171,6 +172,20 @@ handle_cast({packet_in, _GtpPort, _IP, _Port, #gtp{type = error_indication}},
 handle_cast({packet_in, _GtpPort, _IP, _Port, _Msg}, State) ->
     lager:warning("packet_in not handled (yet): ~p", [_Msg]),
     {noreply, State}.
+
+handle_info({timeout, _, {delete_session_request, Direction, _ReqKey, _Request}},
+	    #{context := Context, proxy_context := ProxyContext} = State) ->
+    lager:warning("Proxy Delete Session Timeout ~p", [Direction]),
+
+    dp_delete_pdp_context(Context, ProxyContext),
+    {stop, normal, State};
+
+handle_info({timeout, _, {delete_bearer_request, Direction, _ReqKey, _Request}},
+	    #{context := Context, proxy_context := ProxyContext} = State) ->
+    lager:warning("Proxy Delete Bearer Timeout ~p", [Direction]),
+
+    dp_delete_pdp_context(Context, ProxyContext),
+    {stop, normal, State};
 
 handle_info(_Info, State) ->
     {noreply, State}.
@@ -360,10 +375,14 @@ handle_request(ReqKey,
 %%
 handle_request(ReqKey,
 	       #gtp{type = delete_session_request} = Request, _Resent,
-	       #{context := Context} = State)
+	       #{context := Context} = State0)
   when ?IS_REQUEST_CONTEXT(ReqKey, Request, Context) ->
 
-    forward_request(sgw2pgw, ReqKey, Request, State),
+    forward_request(sgw2pgw, ReqKey, Request, State0),
+
+    Msg = {delete_session_request, sgw2pgw, ReqKey, Request},
+    State = restart_timeout(?RESPONSE_TIMEOUT, Msg, State0),
+
     {noreply, State};
 
 %%
@@ -371,10 +390,14 @@ handle_request(ReqKey,
 %%
 handle_request(ReqKey,
 	       #gtp{type = delete_bearer_request} = Request, _Resent,
-	       #{proxy_context := ProxyContext} = State)
+	       #{proxy_context := ProxyContext} = State0)
   when ?IS_REQUEST_CONTEXT(ReqKey, Request, ProxyContext) ->
 
-    forward_request(pgw2sgw, ReqKey, Request, State),
+    forward_request(pgw2sgw, ReqKey, Request, State0),
+
+    Msg = {delete_bearer_request, pgw2sgw, ReqKey, Request},
+    State = restart_timeout(?RESPONSE_TIMEOUT, Msg, State0),
+
     {noreply, State};
 
 handle_request(ReqKey, _Request, _Resent, State) ->
@@ -754,3 +777,20 @@ get_proxy_sockets(#proxy_ggsn{context = Context},
 		{ProxyPorts, ProxyDPs}
 	end,
     {gtp_socket_reg:lookup(hd(Cntl)), gtp_socket_reg:lookup(hd(Data))}.
+
+cancel_timeout(#{timeout := TRef} = State) ->
+    case erlang:cancel_timer(TRef) of
+        false ->
+            receive {timeout, TRef, _} -> ok
+            after 0 -> ok
+            end;
+        _ ->
+            ok
+    end,
+    maps:remove(timeout, State);
+cancel_timeout(State) ->
+    State.
+
+restart_timeout(Timeout, Msg, State) ->
+    cancel_timeout(State),
+    State#{timeout => erlang:start_timer(Timeout, self(), Msg)}.

--- a/test/ergw_ggsn_test_lib.erl
+++ b/test/ergw_ggsn_test_lib.erl
@@ -138,8 +138,8 @@ make_request(create_pdp_context_request, SubType,
 	 #access_point_name{apn = apn(SubType)},
 	 #gsn_address{instance = 0, address = gtp_c_lib:ip2bin(?CLIENT_IP)},
 	 #gsn_address{instance = 1, address = gtp_c_lib:ip2bin(?CLIENT_IP)},
-	 #imei{imei = imei(SubType)},
-	 #international_mobile_subscriber_identity{imsi = imsi(SubType)},
+	 #imei{imei = imei(SubType, LocalCntlTEI)},
+	 #international_mobile_subscriber_identity{imsi = imsi(SubType, LocalCntlTEI)},
 	 #ms_international_pstn_isdn_number{
 	    msisdn = {isdn_address,1,1,1, ?'MSISDN'}},
 	 #nsapi{nsapi = 5},
@@ -450,11 +450,19 @@ execute_request(MsgType, SubType, Socket, GtpC0) ->
 apn(invalid_apn) -> [<<"IN", "VA", "LID">>];
 apn(_)           -> ?'APN-EXAMPLE'.
 
-imsi('2nd') -> <<"454545454545452">>;
-imsi(_)     -> ?IMSI.
+imsi('2nd', _) ->
+    <<"454545454545452">>;
+imsi(random, TEI) ->
+    integer_to_binary(700000000000000 + TEI);
+imsi(_, _) ->
+    ?IMSI.
 
-imei('2nd') -> <<"6543210987654321">>;
-imei(_)     -> <<"1234567890123456">>.
+imei('2nd', _) ->
+    <<"6543210987654321">>;
+imei(random, TEI) ->
+    integer_to_binary(7000000000000000 + TEI);
+imei(_, _) ->
+ <<"1234567890123456">>.
 
 %%%===================================================================
 %%% GGSN injected functions

--- a/test/ergw_ggsn_test_lib.erl
+++ b/test/ergw_ggsn_test_lib.erl
@@ -482,4 +482,4 @@ ggsn_send_request(#context{control_port = GtpPort,
 			  remote_control_ip = RemoteCntlIP},
 		 T3, N3, Type, RequestIEs, From) ->
     Msg = #gtp{version = v1, type = Type, tei = RemoteCntlTEI, ie = RequestIEs},
-    gtp_context:send_request(GtpPort, RemoteCntlIP, T3, N3, Msg, From).
+    gtp_context:send_request(GtpPort, RemoteCntlIP, ?GTP1c_PORT, T3, N3, Msg, From).

--- a/test/ergw_pgw_test_lib.erl
+++ b/test/ergw_pgw_test_lib.erl
@@ -154,8 +154,8 @@ make_request(create_session_request, SubType,
 	    key = LocalCntlTEI,
 	    ipv4 = gtp_c_lib:ip2bin(?CLIENT_IP)},
 	 #v2_international_mobile_subscriber_identity{
-	    imsi = imsi(SubType)},
-	 #v2_mobile_equipment_identity{mei = imei(SubType)},
+	    imsi = imsi(SubType, LocalCntlTEI)},
+	 #v2_mobile_equipment_identity{mei = imei(SubType, LocalCntlTEI)},
 	 #v2_msisdn{msisdn = ?'MSISDN'},
 	 #v2_rat_type{rat_type = 6},
 	 #v2_selection_mode{mode = 0},
@@ -622,11 +622,19 @@ execute_request(MsgType, SubType, Socket, GtpC0) ->
 apn(invalid_apn) -> [<<"IN", "VA", "LID">>];
 apn(_)           -> ?'APN-ExAmPlE'.
 
-imsi('2nd') -> <<"454545454545452">>;
-imsi(_)     -> ?IMSI.
+imsi('2nd', _) ->
+    <<"454545454545452">>;
+imsi(random, TEI) ->
+    integer_to_binary(700000000000000 + TEI);
+imsi(_, _) ->
+    ?IMSI.
 
-imei('2nd') -> <<"BBBBBBBB">>;
-imei(_)     -> <<"AAAAAAAA">>.
+imei('2nd', _) ->
+    <<"BBBBBBBB">>;
+imei(random, TEI) ->
+    integer_to_binary(70000000 + TEI);
+imei(_, _)     ->
+    <<"AAAAAAAA">>.
 
 %%%===================================================================
 %%% PGW injected functions

--- a/test/ergw_pgw_test_lib.erl
+++ b/test/ergw_pgw_test_lib.erl
@@ -659,4 +659,4 @@ pgw_send_request(#context{control_port = GtpPort,
 			  remote_control_ip = RemoteCntlIP},
 		 T3, N3, Type, RequestIEs, From) ->
     Msg = #gtp{version = v2, type = Type, tei = RemoteCntlTEI, ie = RequestIEs},
-    gtp_context:send_request(GtpPort, RemoteCntlIP, T3, N3, Msg, From).
+    gtp_context:send_request(GtpPort, RemoteCntlIP, ?GTP2c_PORT, T3, N3, Msg, From).

--- a/test/ergw_test_lib.hrl
+++ b/test/ergw_test_lib.hrl
@@ -20,7 +20,8 @@
 			  gtp_context_inc_restart_counter/1,
 			  gtp_context_new_teids/1,
 			  make_error_indication/1]).
--import('ergw_test_lib', [make_gtp_socket/1,
+-import('ergw_test_lib', [start_gtpc_server/1, stop_gtpc_server/1,
+			  make_gtp_socket/1, make_gtp_socket/2,
 			  send_pdu/2,
 			  send_recv_pdu/2, send_recv_pdu/3, send_recv_pdu/4,
 			  recv_pdu/2, recv_pdu/3, recv_pdu/4]).

--- a/test/ggsn_SUITE.erl
+++ b/test/ggsn_SUITE.erl
@@ -145,13 +145,13 @@ init_per_testcase(TestCase, Config)
   when TestCase == delete_pdp_context_requested_resend ->
     init_per_testcase(Config),
     ok = meck:expect(gtp_socket, send_request,
-		     fun(GtpPort, RemoteIP, _T3, _N3,
+		     fun(GtpPort, DstIP, DstPort, _T3, _N3,
 			 #gtp{type = delete_pdp_context_request} = Msg, CbInfo) ->
 			     %% reduce timeout to 1 second and 2 resends
 			     %% to speed up the test
-			     meck:passthrough([GtpPort, RemoteIP, 1000, 2, Msg, CbInfo]);
-			(GtpPort, RemoteIP, T3, N3, Msg, CbInfo) ->
-			     meck:passthrough([GtpPort, RemoteIP, T3, N3, Msg, CbInfo])
+			     meck:passthrough([GtpPort, DstIP, DstPort, 1000, 2, Msg, CbInfo]);
+			(GtpPort, DstIP, DstPort, T3, N3, Msg, CbInfo) ->
+			     meck:passthrough([GtpPort, DstIP, DstPort, T3, N3, Msg, CbInfo])
 		     end),
     Config;
 init_per_testcase(request_fast_resend, Config) ->

--- a/test/ggsn_SUITE.erl
+++ b/test/ggsn_SUITE.erl
@@ -646,6 +646,7 @@ delete_pdp_context_requested_resend(Config) ->
 	    ct:fail(timeout)
     end,
 
+    wait4tunnels(?TIMEOUT),
     ?equal([], outstanding_requests()),
     meck_validate(Config),
     ok.

--- a/test/ggsn_proxy_SUITE.erl
+++ b/test/ggsn_proxy_SUITE.erl
@@ -425,6 +425,7 @@ path_restart_recovery(Config) ->
     delete_pdp_context(S, GtpC2),
 
     ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
+    [?match(#{tunnels := 0}, X) || X <- ergw_api:peer(all)],
     meck_validate(Config),
     ok.
 
@@ -475,6 +476,8 @@ duplicate_pdp_context_request(Config) ->
 
     %% create 2nd PDP context with the same IMSI
     {GtpC2, _, _} = create_pdp_context(S),
+
+    [?match(#{tunnels := 1}, X) || X <- ergw_api:peer(all)],
 
     delete_pdp_context(not_found, S, GtpC1),
     delete_pdp_context(S, GtpC2),
@@ -742,7 +745,7 @@ delete_pdp_context_requested(Config) ->
     {GtpC, _, _} = create_pdp_context(S),
 
     Context = gtp_context_reg:lookup_key(#gtp_port{name = 'remote-irx'},
-					 {imsi, ?'PROXY-IMSI'}),
+					 {imsi, ?'PROXY-IMSI', 5}),
     true = is_pid(Context),
 
     Self = self(),
@@ -777,7 +780,7 @@ delete_pdp_context_requested_resend(Config) ->
     {_, _, _} = create_pdp_context(S),
 
     Context = gtp_context_reg:lookup_key(#gtp_port{name = 'remote-irx'},
-					 {imsi, ?'PROXY-IMSI'}),
+					 {imsi, ?'PROXY-IMSI', 5}),
     true = is_pid(Context),
 
     Self = self(),
@@ -810,7 +813,7 @@ delete_pdp_context_requested_invalid_teid(Config) ->
     {GtpC, _, _} = create_pdp_context(S),
 
     Context = gtp_context_reg:lookup_key(#gtp_port{name = 'remote-irx'},
-					 {imsi, ?'PROXY-IMSI'}),
+					 {imsi, ?'PROXY-IMSI', 5}),
     true = is_pid(Context),
 
     Self = self(),
@@ -846,7 +849,7 @@ delete_pdp_context_requested_late_response(Config) ->
     {GtpC, _, _} = create_pdp_context(S),
 
     Context = gtp_context_reg:lookup_key(#gtp_port{name = 'remote-irx'},
-					 {imsi, ?'PROXY-IMSI'}),
+					 {imsi, ?'PROXY-IMSI', 5}),
     true = is_pid(Context),
 
     Self = self(),
@@ -885,7 +888,7 @@ ggsn_update_pdp_context_request(Config) ->
     {GtpC, _, _} = create_pdp_context(S),
 
     Context = gtp_context_reg:lookup_key(#gtp_port{name = 'remote-irx'},
-					 {imsi, ?'PROXY-IMSI'}),
+					 {imsi, ?'PROXY-IMSI', 5}),
     true = is_pid(Context),
 
     Self = self(),

--- a/test/ggsn_proxy_SUITE.erl
+++ b/test/ggsn_proxy_SUITE.erl
@@ -265,13 +265,13 @@ init_per_testcase(TestCase, Config)
        TestCase == delete_pdp_context_requested_late_response ->
     init_per_testcase(Config),
     ok = meck:expect(gtp_socket, send_request,
-		     fun(GtpPort, RemoteIP, _T3, _N3,
+		     fun(GtpPort, DstIP, DstPort, _T3, _N3,
 			 #gtp{type = delete_pdp_context_request} = Msg, CbInfo) ->
 			     %% reduce timeout to 1 second and 2 resends
 			     %% to speed up the test
-			     meck:passthrough([GtpPort, RemoteIP, 1000, 2, Msg, CbInfo]);
-			(GtpPort, RemoteIP, T3, N3, Msg, CbInfo) ->
-			     meck:passthrough([GtpPort, RemoteIP, T3, N3, Msg, CbInfo])
+			     meck:passthrough([GtpPort, DstIP, DstPort, 1000, 2, Msg, CbInfo]);
+			(GtpPort, DstIP, DstPort, T3, N3, Msg, CbInfo) ->
+			     meck:passthrough([GtpPort, DstIP, DstPort, T3, N3, Msg, CbInfo])
 		     end),
     Config;
 init_per_testcase(request_fast_resend, Config) ->
@@ -332,7 +332,7 @@ end_per_testcase(TestCase, Config)
   when TestCase == delete_pdp_context_requested_resend;
        TestCase == delete_pdp_context_requested_invalid_teid;
        TestCase == delete_pdp_context_requested_late_response ->
-    ok = meck:delete(gtp_socket, send_request, 6),
+    ok = meck:delete(gtp_socket, send_request, 7),
     Config;
 end_per_testcase(request_fast_resend, Config) ->
     ok = meck:unload(ggsn_gn),

--- a/test/ggsn_proxy_SUITE.erl
+++ b/test/ggsn_proxy_SUITE.erl
@@ -761,6 +761,8 @@ delete_pdp_context_requested(Config) ->
     after ?TIMEOUT ->
 	    ct:fail(timeout)
     end,
+
+    [?match(#{tunnels := 0}, X) || X <- ergw_api:peer(all)],
     ?equal([], outstanding_requests()),
     ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
     meck_validate(Config),
@@ -792,7 +794,10 @@ delete_pdp_context_requested_resend(Config) ->
     after ?TIMEOUT ->
 	    ct:fail(timeout)
     end,
+
     ?match([_], outstanding_requests()),
+    wait4tunnels(20000),
+    ?equal([], outstanding_requests()),
     meck_validate(Config),
     ok.
 
@@ -825,6 +830,8 @@ delete_pdp_context_requested_invalid_teid(Config) ->
     after ?TIMEOUT ->
 	    ct:fail(timeout)
     end,
+
+    [?match(#{tunnels := 0}, X) || X <- ergw_api:peer(all)],
     ?equal([], outstanding_requests()),
     ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
     meck_validate(Config),
@@ -861,6 +868,8 @@ delete_pdp_context_requested_late_response(Config) ->
     after ?TIMEOUT ->
 	    ct:fail(timeout)
     end,
+
+    [?match(#{tunnels := 0}, X) || X <- ergw_api:peer(all)],
     ?equal([], outstanding_requests()),
     ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
     meck_validate(Config),

--- a/test/pgw_SUITE.erl
+++ b/test/pgw_SUITE.erl
@@ -777,6 +777,9 @@ delete_bearer_request(Config) ->
     after ?TIMEOUT ->
 	    ct:fail(timeout)
     end,
+
+    wait4tunnels(?TIMEOUT),
+    ?equal([], outstanding_requests()),
     ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
     meck_validate(Config),
     ok.
@@ -807,7 +810,9 @@ delete_bearer_request_resend(Config) ->
     after ?TIMEOUT ->
 	    ct:fail(timeout)
     end,
-    ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
+
+    wait4tunnels(?TIMEOUT),
+    ?equal([], outstanding_requests()),
     meck_validate(Config),
     ok.
 

--- a/test/pgw_SUITE.erl
+++ b/test/pgw_SUITE.erl
@@ -180,15 +180,15 @@ init_per_testcase(TestCase, Config)
        TestCase == modify_bearer_command_timeout ->
     init_per_testcase(Config),
     ok = meck:expect(gtp_socket, send_request,
-		     fun(GtpPort, RemoteIP, _T3, _N3,
+		     fun(GtpPort, DstIP, DstPort, _T3, _N3,
 			 #gtp{type = Type} = Msg, CbInfo)
 			   when Type == delete_bearer_request;
 				Type == update_bearer_request ->
 			     %% reduce timeout to 1 second and 2 resends
 			     %% to speed up the test
-			     meck:passthrough([GtpPort, RemoteIP, 1000, 2, Msg, CbInfo]);
-			(GtpPort, RemoteIP, T3, N3, Msg, CbInfo) ->
-			     meck:passthrough([GtpPort, RemoteIP, T3, N3, Msg, CbInfo])
+			     meck:passthrough([GtpPort, DstIP, DstPort, 1000, 2, Msg, CbInfo]);
+			(GtpPort, DstIP, DstPort, T3, N3, Msg, CbInfo) ->
+			     meck:passthrough([GtpPort, DstIP, DstPort, T3, N3, Msg, CbInfo])
 		     end),
     Config;
 init_per_testcase(request_fast_resend, Config) ->

--- a/test/pgw_proxy_SUITE.erl
+++ b/test/pgw_proxy_SUITE.erl
@@ -530,6 +530,8 @@ duplicate_session_request(Config) ->
     %% create 2nd session with the same IMSI
     {GtpC2, _, _} = create_session(S, GtpC1),
 
+    [?match(#{tunnels := 1}, X) || X <- ergw_api:peer(all)],
+
     delete_session(not_found, S, GtpC1),
     delete_session(S, GtpC2),
 
@@ -863,7 +865,7 @@ delete_bearer_request(Config) ->
     {GtpC, _, _} = create_session(S),
 
     Context = gtp_context_reg:lookup_key(#gtp_port{name = 'remote-irx'},
-					 {imsi, ?'PROXY-IMSI'}),
+					 {imsi, ?'PROXY-IMSI', 5}),
     true = is_pid(Context),
 
     Self = self(),
@@ -899,7 +901,7 @@ delete_bearer_request_resend(Config) ->
     {_, _, _} = create_session(S),
 
     Context = gtp_context_reg:lookup_key(#gtp_port{name = 'remote-irx'},
-					 {imsi, ?'PROXY-IMSI'}),
+					 {imsi, ?'PROXY-IMSI', 5}),
     true = is_pid(Context),
 
     Self = self(),
@@ -933,7 +935,7 @@ delete_bearer_request_invalid_teid(Config) ->
     {GtpC, _, _} = create_session(S),
 
     Context = gtp_context_reg:lookup_key(#gtp_port{name = 'remote-irx'},
-					 {imsi, ?'PROXY-IMSI'}),
+					 {imsi, ?'PROXY-IMSI', 5}),
     true = is_pid(Context),
 
     Self = self(),
@@ -970,7 +972,7 @@ delete_bearer_request_late_response(Config) ->
     {GtpC, _, _} = create_session(S),
 
     Context = gtp_context_reg:lookup_key(#gtp_port{name = 'remote-irx'},
-					 {imsi, ?'PROXY-IMSI'}),
+					 {imsi, ?'PROXY-IMSI', 5}),
     true = is_pid(Context),
 
     Self = self(),
@@ -1075,7 +1077,7 @@ update_bearer_request(Config) ->
     {GtpC, _, _} = create_session(S),
 
     Context = gtp_context_reg:lookup_key(#gtp_port{name = 'remote-irx'},
-					 {imsi, ?'PROXY-IMSI'}),
+					 {imsi, ?'PROXY-IMSI', 5}),
     true = is_pid(Context),
 
     Self = self(),

--- a/test/pgw_proxy_SUITE.erl
+++ b/test/pgw_proxy_SUITE.erl
@@ -290,13 +290,13 @@ init_per_testcase(TestCase, Config)
        TestCase == delete_bearer_request_late_response ->
     init_per_testcase(Config),
     ok = meck:expect(gtp_socket, send_request,
-		     fun(GtpPort, RemoteIP, _T3, _N3,
+		     fun(GtpPort, DstIP, DstPort, _T3, _N3,
 			 #gtp{type = delete_bearer_request} = Msg, CbInfo) ->
 			     %% reduce timeout to 1 second and 2 resends
 			     %% to speed up the test
-			     meck:passthrough([GtpPort, RemoteIP, 1000, 2, Msg, CbInfo]);
-			(GtpPort, RemoteIP, T3, N3, Msg, CbInfo) ->
-			     meck:passthrough([GtpPort, RemoteIP, T3, N3, Msg, CbInfo])
+			     meck:passthrough([GtpPort, DstIP, DstPort, 1000, 2, Msg, CbInfo]);
+			(GtpPort, DstIP, DstPort, T3, N3, Msg, CbInfo) ->
+			     meck:passthrough([GtpPort, DstIP, DstPort, T3, N3, Msg, CbInfo])
 		     end),
     Config;
 init_per_testcase(simple_session, Config) ->
@@ -366,7 +366,7 @@ end_per_testcase(TestCase, Config)
   when TestCase == delete_bearer_request_resend;
        TestCase == delete_bearer_request_invalid_teid;
        TestCase == delete_bearer_request_late_response ->
-    ok = meck:delete(gtp_socket, send_request, 6),
+    ok = meck:delete(gtp_socket, send_request, 7),
     Config;
 end_per_testcase(simple_session, Config) ->
     ok = meck:unload(pgw_s5s8),

--- a/test/pgw_proxy_SUITE.erl
+++ b/test/pgw_proxy_SUITE.erl
@@ -882,6 +882,8 @@ delete_bearer_request(Config) ->
     after ?TIMEOUT ->
 	    ct:fail(timeout)
     end,
+
+    [?match(#{tunnels := 0}, X) || X <- ergw_api:peer(all)],
     ?equal([], outstanding_requests()),
     ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
     meck_validate(Config),
@@ -914,7 +916,10 @@ delete_bearer_request_resend(Config) ->
     after ?TIMEOUT ->
 	    ct:fail(timeout)
     end,
+
     ?match([_], outstanding_requests()),
+    wait4tunnels(20000),
+    ?equal([], outstanding_requests()),
     meck_validate(Config),
     ok.
 
@@ -948,6 +953,8 @@ delete_bearer_request_invalid_teid(Config) ->
     after ?TIMEOUT ->
 	    ct:fail(timeout)
     end,
+
+    [?match(#{tunnels := 0}, X) || X <- ergw_api:peer(all)],
     ?equal([], outstanding_requests()),
     ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
     meck_validate(Config),
@@ -985,6 +992,8 @@ delete_bearer_request_late_response(Config) ->
     after ?TIMEOUT ->
 	    ct:fail(timeout)
     end,
+
+    [?match(#{tunnels := 0}, X) || X <- ergw_api:peer(all)],
     ?equal([], outstanding_requests()),
     ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
     meck_validate(Config),


### PR DESCRIPTION
The missing context tear down and the wrong context keys caused the system failure error returns.

This should fix them.