### PR TITLE
Fix error log about invalid response in gtp_socket

### DIFF
--- a/src/gtp_socket.erl
+++ b/src/gtp_socket.erl
@@ -517,7 +517,7 @@ handle_response(ArrivalTS, IP, _Port, Msg, #state{gtp_port = GtpPort} = State0) 
     case Req of
 	none -> %% duplicate, drop silently
 	    message_counter(rx, GtpPort, IP, Msg, duplicate),
-	    lager:error("~p: invalid response: ~p, ~p", [self(), SeqId]),
+	    lager:debug("~p: invalid response: ~p, ~p", [self(), SeqId, gtp_c_lib:fmt_gtp(Msg)]),
 	    State;
 
 	#send_req{} = SendReq ->


### PR DESCRIPTION
The third element in the list of data was missed.
Now we change this to debug level and print message via
gtp_c_lib:fmt_gtp/1.