### PR TITLE
Fix fmt_ies/1 during pretty print of gtp message

### DIFF
--- a/src/gtp_c_lib.erl
+++ b/src/gtp_c_lib.erl
@@ -67,7 +67,8 @@ fmt_ie(V) ->
 fmt_ies(IEs) when is_map(IEs) ->
     maps:map(fun(_K, V) -> fmt_ie(V) end, IEs);
 fmt_ies(IEs) when is_list(IEs) ->
-    lists:map(fun fmt_ie/1, IEs).
+    lists:map(fun fmt_ie/1, IEs);
+fmt_ies(IEs) -> IEs.
 
 fmt_gtp(#gtp{ie = IEs} = Msg) ->
     lager:pr(Msg#gtp{ie = fmt_ies(IEs)}, ?MODULE).


### PR DESCRIPTION
IEs can be in binary format when we do the following:

     gtp_packet:decode(Data, #{ies => binary})

This change prevent crash for such case.