### PR TITLE
extend http API with Session API

### DIFF
--- a/include/ergw.hrl
+++ b/include/ergw.hrl
@@ -54,7 +54,8 @@
 	  ms_v6                  :: inet:ip6_address(),
 	  state                  :: term(),
 	  restrictions = []      :: [{'v1', boolean()} |
-				     {'v2', boolean()}]
+				     {'v2', boolean()}],
+	  start_time             :: calendar:datetime()
 	 }).
 
 -record(request, {

--- a/priv/static/specs/http_api_spec.yaml
+++ b/priv/static/specs/http_api_spec.yaml
@@ -52,6 +52,61 @@ paths:
       responses:
         '200':
           description: returns the metrics
+  /sessions:
+    get:
+      summary: 'get list of sessions'
+      responses:
+        '200':
+          description: 'returns list of the sessions'
+          schema:
+            $ref: '#/definitions/SessionsList'
+  /sessions/{id}/{bearer_id}:
+    get:
+      summary: 'returns information about session with the given IMSI or IMEI'
+      parameters:
+        - name: id
+          in: path
+          required: true
+          type: string
+          description: 'session identity (IMSI or IMEI)'
+        - name: bearer_id
+          in: path
+          required: true
+          type: integer
+          default: 5
+          description: 'EPS Bearer Id'
+      responses:
+        '200':
+          description: 'session with the given session identity'
+          schema:
+            $ref: '#/definitions/SessionInfo'
+        '404':
+          description: 'a session with the given session identity is not found'
+          schema:
+            $ref: '#/definitions/SessionItemNotFound'
+    delete:
+      summary: 'stops a session with the given session IMSI or IMEI'
+      parameters:
+        - name: id
+          in: path
+          required: true
+          type: string
+          description: 'session identity'
+        - name: bearer_id
+          in: path
+          required: true
+          default: 5
+          type: integer
+          description: 'EPS Bearer Id'
+      responses:
+        '200':
+          description: 'a session with the given session identity is stopped'
+          schema:
+            $ref: '#/definitions/SessionDeleted'
+        '404':
+          description: 'a session with the given session identity is not found'
+          schema:
+            $ref: '#/definitions/SessionNotFound'
 definitions:
   Status:
     type: "object"
@@ -79,3 +134,91 @@ definitions:
     properties:
       version:
         type: "string"
+  SessionsList:
+    type: "object"
+    properties:
+      TotalCount:
+        type: integer
+      Sessions:
+        type: array
+        items:
+          $ref: '#/definitions/SessionInfo'
+  SessionInfo:
+    type: "object"
+    properties:
+      IMSI:
+        type: string
+      IMEI:
+        type: string
+      MSISDN:
+        type: string
+      StartTime:
+        type: string
+        format: date-time
+      LocalGTPEntity:
+        type: object
+        properties:
+          GTP-C:
+            type: object
+            properties:
+              Version:
+                type: string
+              TEID:
+                type: integer
+              IP:
+                type: string
+          GTP-U:
+            type: object
+            properties:
+              Version:
+                type: string
+              TEID:
+                type: integer
+              IP:
+                type: string
+      RemoteGTPEntity:
+        type: object
+        properties:
+          GTP-C:
+            type: object
+            properties:
+              Version:
+                type: string
+              TEID:
+                type: integer
+              IP:
+                type: string
+          GTP-U:
+            type: object
+            properties:
+              Version:
+                type: string
+              TEID:
+                type: integer
+              IP:
+                type: string
+      APN:
+        type: array
+        items:
+          type: string
+  SessionItemNotFound:
+    type: "object"
+    properties:
+      TotalCount:
+        type: integer
+      Session:
+        type: array
+        items:
+          type: string
+  SessionNotFound:
+    type: "object"
+    properties:
+      Result:
+        type: string
+        default: "Session not found"
+  SessionDeleted:
+    type: "object"
+    properties:
+      Result:
+        type: string
+        default: "ok"

--- a/src/ergw_http_api.erl
+++ b/src/ergw_http_api.erl
@@ -39,6 +39,7 @@ start_http_listener(HttpOpts) ->
                                         {"/api/v1/status", http_api_handler, []},
                                         {"/api/v1/status/accept-new", http_api_handler, []},
                                         {"/api/v1/status/accept-new/:value", http_api_handler, []},
+                                        {"/api/v1/sessions/[:id/[:bearer_id]]", http_api_handler, []},
                                         {"/metrics", http_api_handler, []},
                                         {"/metrics/[...]", http_api_handler, []},
                                         % serves static files for swagger UI

--- a/src/gtp_context.erl
+++ b/src/gtp_context.erl
@@ -267,7 +267,8 @@ init([CntlPort, Version, Interface,
 		 control_port      = CntlPort,
 		 local_control_tei = CntlTEI,
 		 data_port         = DataPort,
-		 local_data_tei    = DataTEI
+		 local_data_tei    = DataTEI,
+		 start_time        = calendar:universal_time()
 		},
 
     State = #{


### PR DESCRIPTION
This patch provides three new http API endpoints:

  * GET /sessions
  * GET /sessions/id/bearer_id
  * DELETE /sessions/id/bearer_id

The first two are to get list of sessions or information about a certain
session by id which can be IMSI or IMEI.

The last one is to terminate a session by the given IMSI or IMEI.

@RoadRunnr The list API just returns all sessions from the ets table, and there is no any manipulations with limit/offset for now