### PR TITLE
Upgrade `gen_socket` to work on Erlang-R20+

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
 	{erlando, {git, "https://github.com/travelping/erlando.git", {tag, "1.0.0"}}},
 	{netdata, {git, "https://github.com/RoadRunnr/erl_netdata.git", {ref, "cbd6eaf"}}},
 	{gtplib, {git, "https://github.com/travelping/gtplib.git", {ref, "91e8ff8"}}},
-	{gen_socket, {git, "git://github.com/travelping/gen_socket", {tag, "0.6.2"}}},
+	{gen_socket, {git, "git://github.com/travelping/gen_socket", {ref, "195a42700ba15b7ddc26a49865abcdaa627eba33"}}},
 	{ergw_aaa, {git, "git://github.com/travelping/ergw_aaa", {ref, "3caddf6"}}},
 	{cowboy, "2.0.0"},
 	{jobs, "0.6.0"},

--- a/rebar.lock
+++ b/rebar.lock
@@ -22,7 +22,7 @@
  {<<"folsom">>,{pkg,<<"folsom">>,<<"0.8.5">>},1},
  {<<"gen_socket">>,
   {git,"git://github.com/travelping/gen_socket",
-       {ref,"c155d2007f1fbd350e663780849e4feba26b8083"}},
+       {ref,"195a42700ba15b7ddc26a49865abcdaa627eba33"}},
   0},
  {<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
  {<<"gtplib">>,


### PR DESCRIPTION
With `gen_socket-0.6.3` came support for Erlang-R20+. A few commits (but
"untagged" yet) support for compiling on Alpine-Linux was added - hence
commit 195a42700ba15b7ddc26a49865abcdaa627eba33 of `gen_socket`.