### PR TITLE
make the fallback GGSN/PGW IP setting into a list of candidates

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -255,9 +255,9 @@ options.
 
     the default GTP-U data paths for forwarding requests
 
-  - `{ggsn, inet:ip_address()}`
+  - `{ggsn, inet:ip_address() | [inet:ip_address()]}`
 
-    the default GGSN IP address
+    the default GGSN(s) IP address
 
   - `{contexts, [context()]}`
 

--- a/src/ergw_proxy_lib.erl
+++ b/src/ergw_proxy_lib.erl
@@ -7,7 +7,7 @@
 
 -module(ergw_proxy_lib).
 
--export([validate_options/3, validate_option/2,
+-export([validate_options/3, validate_option/2, validate_next_gsn_option/2,
 	 forward_request/3, forward_request/6, forward_request/8,
 	 get_seq_no/3]).
 
@@ -70,6 +70,22 @@ validate_option(contexts, Values) when is_list(Values); is_map(Values) ->
     ergw_config:opts_fold(fun validate_context/3, #{}, Values);
 validate_option(Opt, Value) ->
     gtp_context:validate_option(Opt, Value).
+
+validate_ip_option({_,_,_,_} = Value) ->
+    Value;
+validate_ip_option({_,_,_,_,_,_,_,_} = Value) ->
+    Value;
+validate_ip_option(Value) ->
+    throw({error, {options, {ip, Value}}}).
+
+validate_next_gsn_option(_, Value)
+  when is_tuple(Value) ->
+    [validate_ip_option(Value)];
+validate_next_gsn_option(_, Values)
+  when is_list(Values), length(Values) /= 0 ->
+    [validate_ip_option(IP) || IP <- Values];
+validate_next_gsn_option(Opt, Value) ->
+    throw({error, {options, {Opt, Value}}}).
 
 validate_context_option(proxy_sockets, Value) when is_list(Value), Value /= [] ->
     Value;

--- a/src/ggsn_gn_proxy.erl
+++ b/src/ggsn_gn_proxy.erl
@@ -140,10 +140,8 @@ validate_options(Opts) ->
     lager:debug("GGSN Gn/Gp Options: ~p", [Opts]),
     ergw_proxy_lib:validate_options(fun validate_option/2, Opts, ?Defaults).
 
-validate_option(ggsn, {_,_,_,_} = Value) ->
-    Value;
-validate_option(ggsn, {_,_,_,_,_,_,_,_} = Value) ->
-    Value;
+validate_option(ggsn, Value) ->
+    ergw_proxy_lib:validate_next_gsn_option(ggsn, Value);
 validate_option(Opt, Value) ->
     ergw_proxy_lib:validate_option(Opt, Value).
 
@@ -573,14 +571,14 @@ set_req_from_context(_, _K, IE) ->
 update_gtp_req_from_context(Context, GtpReqIEs) ->
     maps:map(set_req_from_context(Context, _, _), GtpReqIEs).
 
-proxy_info(DefaultGGSN,
+proxy_info(DefaultGGSNs,
 	   #context{apn = APN, imsi = IMSI, msisdn = MSISDN,
 		    restrictions = Restrictions}) ->
-    GGSNs = [#proxy_ggsn{address = DefaultGGSN,
-                         dst_apn = APN,
-		                 restrictions = Restrictions}],
+    GSNs = [#proxy_ggsn{address = GGSN,
+			dst_apn = APN,
+			restrictions = Restrictions} || GGSN <- DefaultGGSNs],
     LookupAPN = (catch gtp_c_lib:normalize_labels(APN)),
-    #proxy_info{ggsns = GGSNs, imsi = IMSI, msisdn = MSISDN, src_apn = LookupAPN}.
+    #proxy_info{ggsns = GSNs, imsi = IMSI, msisdn = MSISDN, src_apn = LookupAPN}.
 
 build_context_request(#context{remote_control_tei = TEI} = Context,
 		      NewPeer, #gtp{ie = RequestIEs} = Request) ->

--- a/src/pgw_s5s8_proxy.erl
+++ b/src/pgw_s5s8_proxy.erl
@@ -118,10 +118,8 @@ validate_options(Opts) ->
     lager:debug("PGW S5/S8 Options: ~p", [Opts]),
     ergw_proxy_lib:validate_options(fun validate_option/2, Opts, ?Defaults).
 
-validate_option(pgw, {_,_,_,_} = Value) ->
-    Value;
-validate_option(pgw, {_,_,_,_,_,_,_,_} = Value) ->
-    Value;
+validate_option(pgw, Value) ->
+    ergw_proxy_lib:validate_next_gsn_option(pgw, Value);
 validate_option(Opt, Value) ->
     ergw_proxy_lib:validate_option(Opt, Value).
 
@@ -665,14 +663,14 @@ set_req_from_context(_, _K, IE) ->
 update_gtp_req_from_context(Context, GtpReqIEs) ->
     maps:map(set_req_from_context(Context, _, _), GtpReqIEs).
 
-proxy_info(DefaultGGSN,
+proxy_info(DefaultPGWs,
 	   #context{apn = APN, imsi = IMSI,
 		    msisdn = MSISDN, restrictions = Restrictions}) ->
-    GGSNs = [#proxy_ggsn{address = DefaultGGSN, 
-                         dst_apn = APN,
-		                 restrictions = Restrictions}],
+    GSNs = [#proxy_ggsn{address = PGW,
+			dst_apn = APN,
+			restrictions = Restrictions} || PGW <- DefaultPGWs],
     LookupAPN = (catch gtp_c_lib:normalize_labels(APN)),
-    #proxy_info{ggsns = GGSNs, imsi = IMSI, msisdn = MSISDN, src_apn = LookupAPN}.
+    #proxy_info{ggsns = GSNs, imsi = IMSI, msisdn = MSISDN, src_apn = LookupAPN}.
 
 build_context_request(#context{remote_control_tei = TEI} = Context,
 		      NewPeer, SeqNo, #gtp{ie = RequestIEs} = Request) ->

--- a/test/config_SUITE.erl
+++ b/test/config_SUITE.erl
@@ -354,7 +354,12 @@ config(_Config)  ->
     ?error_option(set_cfg_value([handlers, gn, contexts, invalid], [], ?GGSN_PROXY_CONFIG)),
     ?error_option(set_cfg_value([handlers, gn, contexts, <<"ams">>], invalid, ?GGSN_PROXY_CONFIG)),
     ?error_option(set_cfg_value([handlers, gn, contexts, <<"ams">>, proxy_sockets], invalid, ?GGSN_PROXY_CONFIG)),
+    ?ok_option(set_cfg_value([handlers, gn, ggsn], {1,2,3,4}, ?GGSN_PROXY_CONFIG)),
     ?ok_option(set_cfg_value([handlers, gn, ggsn], {1,2,3,4,5,6,7,8}, ?GGSN_PROXY_CONFIG)),
+    ?ok_option(set_cfg_value([handlers, gn, ggsn], [{1,1,1,1}, {1,1,1,2}], ?GGSN_PROXY_CONFIG)),
+    ?error_option(set_cfg_value([handlers, gn, ggsn], [], ?GGSN_PROXY_CONFIG)),
+    ?error_option(set_cfg_value([handlers, gn, ggsn], {1,2,3,4,5,6,7}, ?GGSN_PROXY_CONFIG)),
+    ?error_option(set_cfg_value([handlers, gn, ggsn], invalid, ?GGSN_PROXY_CONFIG)),
 
     ?ok_option(?PGW_CONFIG),
     ?error_option(set_cfg_value([handlers, 'h1'], [{handler, pgw_s5s8},
@@ -362,6 +367,11 @@ config(_Config)  ->
 						   {data_paths, [grx]}], ?PGW_CONFIG)),
 
     ?ok_option(?PGW_PROXY_CONFIG),
+    ?ok_option(set_cfg_value([handlers, gn, pgw], {1,2,3,4}, ?PGW_PROXY_CONFIG)),
     ?ok_option(set_cfg_value([handlers, gn, pgw], {1,2,3,4,5,6,7,8}, ?PGW_PROXY_CONFIG)),
+    ?ok_option(set_cfg_value([handlers, gn, pgw], [{1,1,1,1}, {1,1,1,2}], ?PGW_PROXY_CONFIG)),
+    ?error_option(set_cfg_value([handlers, gn, pgw], [], ?PGW_PROXY_CONFIG)),
+    ?error_option(set_cfg_value([handlers, gn, pgw], {1,2,3,4,5,6,7}, ?PGW_PROXY_CONFIG)),
+    ?error_option(set_cfg_value([handlers, gn, pgw], invalid, ?PGW_PROXY_CONFIG)),
 
     ok.


### PR DESCRIPTION
Loadbalancing between multiple destionation GSN's is already
supported. Make it so that the default GSN can also be a list of
condidates.