### PR TITLE
DNS resolver: fix issue when after NAPTR we get A record with IP

### DIFF
--- a/src/ergw_dns.erl
+++ b/src/ergw_dns.erl
@@ -60,10 +60,17 @@ match(_, _) -> [].
 %% RFC2915: "A" means that the next lookup should be for either an A, AAAA, or A6 record. 
 %% We only support A for now.
 follow({_Order, _Pref, "a", _Server, _Regexp, Replacement}, Resources) -> 
-    [data(Resource)
-     || Resource <- Resources,
-		    type(Resource) =:= a,
-		    string_equal(domain(Resource), Replacement)];
+    IPs = [data(Resource)
+           || Resource <- Resources,
+              type(Resource) =:= a,
+              string_equal(domain(Resource), Replacement)],
+    if IPs == [] -> 
+           case inet:parse_ipv4_address(Replacement) of
+               {ok, IP} -> [IP];
+               _ -> IPs
+           end;
+       true -> IPs
+    end;
 
 %% RFC2915: the "S" flag means that the next lookup should be for SRV records.
 follow({_Order, _Pref, "s", _Server, _Regexp, Replacement}, Resources) -> 

--- a/test/dns_SUITE.erl
+++ b/test/dns_SUITE.erl
@@ -15,6 +15,8 @@
 -define(ERGW2, {100, 255, 4, 125}).
 -define(HUB1,  {100, 255, 5, 46}).
 -define(HUB2,  {100, 255, 5, 45}).
+-define(HUB3,  {100, 255, 10, 1}).
+-define(HUB3str,  "100.255.10.1").
 
 -define(SRV_q,
 	#dns_rec{
@@ -60,12 +62,24 @@
 			     data = ?HUB2}]
 	  }).
 
+-define(A_IP_q,
+	#dns_rec{
+	   anlist = [#dns_rr{domain = "example.apn.epc.mnc002.mcc456.3gppnetwork.org",
+			     type = naptr,
+			     data = % order pref flags service
+				    { 20,   20, "a",   "x-3gpp-pgw:x-s5-gtp:x-s8-gtp:x-gn",
+				    % regexp replacement       
+				      [],    ?HUB3str}}],
+	   arlist = []
+	  }).
+
+
 %%%===================================================================
 %%% Common Test callbacks
 %%%===================================================================
 
 all() ->
-    [srv_lookup, a_lookup].
+    [srv_lookup, a_lookup, a_ip_lookup].
 
 suite() ->
     [{timetrap, {seconds, 30}}].
@@ -79,7 +93,9 @@ init_per_suite(Config) ->
 		     fun("example.apn.epc.mnc123.mcc310.3gppnetwork.org.") -> 
 			     {ok, ?SRV_q};
 			("example.apn.epc.mnc001.mcc456.3gppnetwork.org.") -> 
-			     {ok, ?A_q}
+			     {ok, ?A_q};
+			("example.apn.epc.mnc002.mcc456.3gppnetwork.org.") -> 
+			     {ok, ?A_IP_q}
 		     end),
     Config.
 
@@ -101,4 +117,10 @@ a_lookup() ->
     [{doc, "NPTR lookup with following A"}].
 a_lookup(_Config) ->
     ?equal([], [?HUB1, ?HUB2] -- ergw_dns:lookup("example.apn.epc.mnc001.mcc456.3gppnetwork.org.")),
+    ok.
+
+a_ip_lookup() ->
+    [{doc, "NPTR lookup with A when Replacement is an IP"}].
+a_ip_lookup(_Config) ->
+    ?equal([], [?HUB3] -- ergw_dns:lookup("example.apn.epc.mnc002.mcc456.3gppnetwork.org.")),
     ok.


### PR DESCRIPTION
Despite [RFC 3958](https://tools.ietf.org/html/rfc3958#section-6.4)
says:

```
"A" means that the output of the Rule is a domain name and should
be used to lookup address records for that domain.
```

Result of NAPTR may be A record with IP address as a replacement.
In that case we just need to use that IP as result of lookup procedure.
