### PR TITLE
Rework DNS resolver to traverse records manually

### DIFF
--- a/src/ergw_dns.erl
+++ b/src/ergw_dns.erl
@@ -13,7 +13,9 @@
 
 -module(ergw_dns).
 
--export([naptr/1, lookup/1, lookup/2]).
+-export([naptr/1, srv/1, a/1]).
+
+-export([lookup/1, lookup/2]).
 
 %%====================================================================
 %% API
@@ -21,23 +23,22 @@
 
 %% @private
 naptr(Name) ->
-    NsOpts =
-	case setup:get_env(ergw, nameservers) of
-	    undefined ->
-		[];
-	    {ok, Nameservers} ->
-		[{nameservers, Nameservers}]
-	end,
-    %% 3GPP DNS answers are almost always large, use TCP by default....
-    inet_res:resolve(Name, in, naptr, [{usevc, true} | NsOpts]).
+    inet_res:lookup(Name, in, naptr, get_ns_opts()).
+
+%% @private
+srv(Name) ->
+    inet_res:lookup(Name, in, srv, get_ns_opts()).
+
+%% @private
+a(Name) ->
+    inet_res:lookup(Name, in, a, get_ns_opts()).
 
 -spec lookup(Name :: string() | inet:ip_address()) -> 
     list(inet:ip_address()).
-lookup(Name) -> 
-    Response = ?MODULE:naptr(Name),
-    lists:usort(match(Response, v1) ++ match(Response, v2)).
+lookup(Name) ->
+    match(?MODULE:naptr(Name)).
 
--spec lookup(Name :: string() | inet:ip_address(), Version :: v1 | v2) -> 
+-spec lookup(Name :: string() | inet:ip_address(), Version :: v1 | v2) ->
     list(inet:ip_address()).
 lookup(Name, Version) ->
     Response = ?MODULE:naptr(Name),
@@ -46,53 +47,52 @@ lookup(Name, Version) ->
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================
+match(Results) ->
+    FilteredResources = [Result
+                         || Result <- Results,
+                            version(Result, v1)]
+                     ++ [Result
+                         || Result <- Results,
+                            version(Result, v2)],
+    Resources = [follow(Resource)
+                 || Resource <- lists:usort(FilteredResources)],
+    lists:usort(lists:flatten(Resources)).
 
-match({ok, Msg}, Version) ->
-    FilteredAnswers = [data(Answer)
-		       || Answer <- inet_dns:msg(Msg, anlist),
-				    inet_dns:rr(Answer, type) =:= naptr,
-				    version(Answer, Version)],
-    FilteredResources = [follow(Answer, inet_dns:msg(Msg, arlist))
-			 || Answer <- FilteredAnswers],
-    lists:flatten(FilteredResources);
-match(_, _) -> [].
+match(Results, Version) ->
+    FilteredResources = [follow(Result)
+                         || Result <- Results,
+                            version(Result, Version)],
+    lists:usort(lists:flatten(FilteredResources)).
 
-%% RFC2915: "A" means that the next lookup should be for either an A, AAAA, or A6 record. 
+%% RFC2915: "A" means that the next lookup should be for either an A, AAAA, or A6 record.
 %% We only support A for now.
-follow({_Order, _Pref, "a", _Server, _Regexp, Replacement}, Resources) -> 
-    [data(Resource)
-     || Resource <- Resources,
-		    type(Resource) =:= a,
-		    string_equal(domain(Resource), Replacement)];
+follow({_Order, _Pref, "a", _Server, _Regexp, Replacement}) ->
+    ?MODULE:a(Replacement);
 
 %% RFC2915: the "S" flag means that the next lookup should be for SRV records.
-follow({_Order, _Pref, "s", _Server, _Regexp, Replacement}, Resources) -> 
-    [follow(data(Resource), Resources)
-     || Resource <- Resources,
-		    type(Resource) =:= srv,
-		    string_equal(domain(Resource), Replacement)];
+follow({_Order, _Pref, "s", _Server, _Regexp, Replacement}) ->
+    [follow(Answer) || Answer <- ?MODULE:srv(Replacement)];
 
 %% This happens for SRV resource
-follow({_Prio, _Weight, _Port, Target}, Resources) ->
-    [data(Resource)
-     || Resource <- Resources,
-		    type(Resource) =:= a,
-		    string_equal(domain(Resource), Target)];
+follow({_Prio, _Weight, _Port, Target}) ->
+    ?MODULE:a(Target);
 
-follow(_, _) -> [].
+follow(_) -> [].
 
-domain(Resource) -> inet_dns:rr(Resource, domain).
-data(Resource) -> inet_dns:rr(Resource, data).
-type(Resource) -> inet_dns:rr(Resource, type).
-
-string_equal(Str1, Str2) -> string:to_lower(Str1) == string:to_lower(Str2).
+get_ns_opts() ->
+    %% 3GPP DNS answers are almost always large, use TCP by default....
+	case setup:get_env(ergw, nameservers) of
+	    undefined ->
+    		[{usevc, true}];
+	    {ok, Nameservers} ->
+    		[{usevc, true}, {nameservers, Nameservers}]
+	end.
 
 % x-gn and x-gp for GTPv1,
 % x-s5-gtp and x-s8-gtp for GTPv2
 version(RR, v1) -> version(RR, ["x-gn", "x-gp"]);
 version(RR, v2) -> version(RR, ["x-s5-gtp", "x-s8-gtp"]);
-version(RR, Offer) when is_list(Offer) ->
-    {_, _, _, Services0, _, _} = data(RR),
+version({_, _, _, Services0, _, _}, Offer) when is_list(Offer) ->
     %% XXX: Services (3GPP TS 23.003 Section 19.4.3) are ignored
     [_Service | Protocols] = string:tokens(Services0, ":"),
     lists:any(fun(Protocol) -> lists:member(Protocol, Protocols) end, Offer);

--- a/test/dns_SUITE.erl
+++ b/test/dns_SUITE.erl
@@ -6,59 +6,10 @@
 
 -include("ergw_test_lib.hrl").
 
-% copy from kernel/src/inet_dns.hrl
--record(dns_rec, {header, qdlist = [], anlist = [], nslist = [], arlist = []}).
--record(dns_rr, {domain = "", type = any, class = in, cnt = 0, ttl = 0, data = [],
-		 tm, bm = [], func = false}).
-
 -define(ERGW1, {100, 255, 4, 133}).
 -define(ERGW2, {100, 255, 4, 125}).
 -define(HUB1,  {100, 255, 5, 46}).
 -define(HUB2,  {100, 255, 5, 45}).
-
--define(SRV_q,
-	#dns_rec{
-	   anlist = [#dns_rr{domain = "example.apn.epc.mnc123.mcc310.3gppnetwork.org",
-			     type = naptr,
-			     data = % order pref flags service		      regexp
-				    { 100,  100, "s",  "x-3gpp-pgw:x-s8-gtp", [],
-				    % replacement
-				      "pgw-list-2.node.epc.mnc123.mcc310.3gppnetwork.org"}}], 
-	   arlist = [#dns_rr{domain = "ergw.ovh.node.epc.mnc123.mcc310.3gppnetwork.org", 
-			     type = a,
-			     data = ?ERGW1},
-		     #dns_rr{domain = "ergw.ovh.node.epc.mnc123.mcc310.3gppnetwork.org", 
-			     type = a,
-			     data = ?ERGW2},
-		     #dns_rr{domain = "ns0.mnc123.mcc310.3gppnetwork.org", 
-			     type = a,
-			     data = {10, 10, 4, 2}},
-		     #dns_rr{domain = "ns1.mnc123.mcc310.3gppnetwork.org", 
-			     type = a,
-			     data = {10, 10, 4, 3}},
-		     #dns_rr{domain = "pgw-list-2.node.epc.mnc123.mcc310.3gppnetwork.org",
-			     type = srv,
-			     data = % priority weight port
-				    { 100,     100,   2123, 
-				    % target
-				     "ergw.ovh.node.epc.mnc123.mcc310.3gppnetwork.org"}}]
-	  }).
-
--define(A_q,
-	#dns_rec{
-	   anlist = [#dns_rr{domain = "example.apn.epc.mnc001.mcc456.3gppnetwork.org",
-			     type = naptr,
-			     data = % order pref flags service
-				    { 20,   20, "a",   "x-3gpp-pgw:x-s5-gtp:x-s8-gtp:x-gn",
-				    % regexp replacement       
-				      [],     "hub.node.epc.mnc001.mcc456.3gppnetwork.org"}}],
-	   arlist = [#dns_rr{domain = "hub.node.epc.mnc001.mcc456.3gppnetwork.org",
-			     type = a,
-			     data = ?HUB1},
-		     #dns_rr{domain = "hub.node.epc.mnc001.mcc456.3gppnetwork.org",
-			     type = a,
-			     data = ?HUB2}]
-	  }).
 
 %%%===================================================================
 %%% Common Test callbacks
@@ -76,11 +27,33 @@ groups() ->
 init_per_suite(Config) ->
     ok = meck:new(ergw_dns, [passthrough, no_link]),
     ok = meck:expect(ergw_dns, naptr, 
-		     fun("example.apn.epc.mnc123.mcc310.3gppnetwork.org.") -> 
-			     {ok, ?SRV_q};
-			("example.apn.epc.mnc001.mcc456.3gppnetwork.org.") -> 
-			     {ok, ?A_q}
-		     end),
+                     fun("example.apn.epc.mnc001.mcc456.3gppnetwork.org.") -> 
+                             % order pref flags service                              regexp
+                             [{20,   20,  "a",  "x-3gpp-pgw:x-s5-gtp:x-s8-gtp:x-gn", [], 
+                             % replacement
+                              "hub.node.epc.mnc001.mcc456.3gppnetwork.org"}];
+                        ("example.apn.epc.mnc123.mcc310.3gppnetwork.org.") -> 
+                             % order pref flags service                regexp
+                             [{100,  100, "s",  "x-3gpp-pgw:x-s8-gtp", [], 
+                             % replacement
+                              "pgw-list-2.node.epc.mnc123.mcc310.3gppnetwork.org"}];
+                        (_) -> []
+                     end),
+    ok = meck:expect(ergw_dns, srv, 
+                     fun("pgw-list-2.node.epc.mnc123.mcc310.3gppnetwork.org") -> 
+                             % priority weight port 
+                             [{100,     100,   2123, 
+                             % target
+                              "ergw.ovh.node.epc.mnc123.mcc310.3gppnetwork.org"}];
+                        (_) -> []
+                     end),
+    ok = meck:expect(ergw_dns, a, 
+                     fun("hub.node.epc.mnc001.mcc456.3gppnetwork.org" ) -> 
+                             [?HUB1, ?HUB2];
+                        ("ergw.ovh.node.epc.mnc123.mcc310.3gppnetwork.org") ->
+                             [?ERGW1, ?ERGW2];
+                        (_) -> []
+                     end),
     Config.
 
 end_per_suite(_Config) ->


### PR DESCRIPTION
Before we used `resolve` and expected that server returns answer with
all entries resolved recursively. This cant be try in all cases.
This commit reworks lookup mechanism to traverse entries manually.