### PR TITLE
Add redirector mode for GTP socket

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-sudo: false
-dist: xenial
+sudo: required
+dist: trusty
 
 language: erlang
 
@@ -14,7 +14,9 @@ install: "true"
 script:
   - source test/env.sh
   - rebar3 compile
-  - rebar3 do xref, ct, coveralls send
+  # sudo -E ... doesn't work see https://github.com/travis-ci/travis-ci/issues/5224
+  # we do it some unflexable way
+  - sudo env PATH=$PATH CI_RUN_SLOW_TESTS=$CI_RUN_SLOW_TESTS rebar3 do xref, ct, coveralls send
 
 notifications:
   slack:

--- a/METRICS.md
+++ b/METRICS.md
@@ -36,8 +36,8 @@ The path `rtt` is the round trip time histogram for each request/response
 message pair.
 
 The `tx` and `rx` metrics count the number of message of a given type
-transmitted and received. The `timeout` counter exists only for requests
-that require a response.
+transmitted and received. The `timeout` counter exists only for requests that 
+require a response.
 
 The `pt` metrics are a histogram of the total processing time for the last
 incoming message of that type.

--- a/src/gtp_redirector.erl
+++ b/src/gtp_redirector.erl
@@ -1,0 +1,346 @@
+%% Copyright 2017, Travelping GmbH <info@travelping.com>
+
+%% This program is free software; you can redistribute it and/or
+%% modify it under the terms of the GNU General Public License
+%% as published by the Free Software Foundation; either version
+%% 2 of the License, or (at your option) any later version.
+
+-module(gtp_redirector).
+
+-export([init/2, 
+         validate_options/1, 
+         keep_alive/2, 
+         timeout_requests/1, 
+         handle_message/6, 
+         echo_response/6]).
+
+-type nodes_map() :: #{binary() => {v1 | v2, inet:ip_address()}}.
+-type condition() :: {sgsn_ip, inet:ip_address()} |
+                     {version, list(v1 | v2)} |
+                     {imsi, binary()}.
+-type rule():: #{conditions => list(condition()),
+                 nodes => list(binary())}.
+
+-record(redirector, {
+          socket     = undefined    :: undefined | gen_socket:socket(),
+
+          % lists of all nodes, including bad
+          nodes      = #{}    :: nodes_map(),
+
+          % here we have nodes which are not answered for Keep-Alive echo request
+          % no requests should be transfered to such nodes
+          bad_nodes  = #{}       :: nodes_map(),
+          lb_type    = random    :: random | round_robin, % for now only random is supported
+          ka_timeout = 60000     :: non_neg_integer(), % Keep-Alive timeout
+          ka_timer   = undefined :: reference(),
+
+          rules      = []  :: list(rule()),
+
+          % cached nodes for requests, because retransmission should happen for the same node
+          requests,         % :: ergw_cache(),
+          rt_timeout = 10000  :: non_neg_integer(), % retransmission timeout
+
+          % timestamps for responses which used by Keep-Alive mechanism
+          responses  = maps:new() :: map()
+         }).
+
+-type redirector() :: #redirector{}.
+
+-export_type([redirector/0]).
+
+-include_lib("gtplib/include/gtp_packet.hrl").
+
+-include("include/ergw.hrl").
+
+-define(T3, 10 * 1000).
+
+init(IP, #{redirector := #{keep_alive_timeout := KATimeout,
+                           retransmit_timeout := RTTimeout,
+                           lb_type := LBType,
+                           rules := Rules,
+                           nodes := Nodes} = _Opts}) -> 
+    {ok, Socket} = make_gtp_redirector_socket(IP, 0, #{hdrincl => true}),
+    TRef = erlang:start_timer(KATimeout, self(), redirector_keep_alive),
+    % let's assume that on start all backends are available 
+    % then set echo_response to the time now for all of them
+    Responses = maps:fold(fun(_, Node, Acc) -> Acc#{Node => erlang:monotonic_time()} end, #{}, Nodes),
+    #redirector{socket = Socket, 
+                nodes = Nodes,
+                rules = Rules,
+                lb_type = LBType,
+                ka_timeout = KATimeout,
+                ka_timer = TRef,
+                requests = ergw_cache:new(?T3 * 4, redirector_requests), 
+                rt_timeout = RTTimeout,
+                responses = Responses};
+init(_IP, _Opts) -> undefined.
+
+make_gtp_redirector_socket(IP, Port, Opts) ->
+    {ok, Socket} = gen_socket:socket(gtp_socket:family(IP), raw, udp),
+    bind_gtp_socket(Socket, IP, Port, Opts).
+
+bind_gtp_socket(Socket, {_,_,_,_} = IP, Port, Opts) ->
+    ok = gen_socket:bind(Socket, {inet4, IP, Port}),
+    maps:fold(fun(K, V, ok) -> ok = socket_setopts(Socket, K, V) end, ok, Opts),
+    {ok, Socket};
+bind_gtp_socket(_Socket, {_,_,_,_,_,_,_,_} = _IP, _Port, _Opts) ->
+    throw("inet6 is not supported now").
+
+socket_setopts(Socket, hdrincl, true) ->
+    gen_socket:setsockopt(Socket, sol_ip, hdrincl, true);
+socket_setopts(_Socket, _, _) -> ok.
+
+-define(DefaultOptions, [{lb_type, random},
+                         {keep_alive_timeout, 60000},
+                         {retransmit_timeout, 10000},
+                         {nodes, []},
+                         {rules, []}]).
+-define(DefaultNode, [{name, undefined}, 
+                      {address, undefined},
+                      {keep_alive_version, v1}]).
+-define(DefaultRule, [{conditions, []}, {nodes, []}]).
+
+validate_options(Values) ->
+    ergw_config:validate_options(fun validate_option/2, Values, ?DefaultOptions, map).
+
+validate_option(rules, Rules) when is_list(Rules) ->
+    [Rule || {rule, Rule} 
+             <- ergw_config:validate_options(fun validate_rule/2, Rules, [], list)];
+validate_option(nodes, Nodes0) when is_list(Nodes0) ->
+    Nodes = ergw_config:validate_options(fun validate_node/2, Nodes0, [], list),
+    maps:from_list(lists:map(fun({node, Node}) -> Node end, Nodes));
+validate_option(lb_type, Type) 
+  when Type == round_robin; Type == random ->
+    Type;
+validate_option(keep_alive_timeout, Timeout)
+  when is_integer(Timeout), Timeout > 0 ->
+    Timeout;
+validate_option(retransmit_timeout, Timeout)
+  when is_integer(Timeout), Timeout > 0 ->
+    Timeout;
+validate_option(Opt, Value) ->
+    throw({error, {redirector_options, {Opt, Value}}}).
+
+validate_rule(rule, Rule) ->
+    ergw_config:validate_options(fun validate_rule_option/2, Rule, ?DefaultRule, map);
+validate_rule(Opt, Value) ->
+    throw({error, {redirector_rule, {Opt, Value}}}).
+
+validate_rule_option(conditions, Conditions) when is_list(Conditions) ->
+    lists:map(fun validate_condition/1, Conditions);
+validate_rule_option(nodes, Nodes) when is_list(Nodes) ->
+    lists:map(fun validate_rule_node/1, Nodes);
+validate_rule_option(Opt, Value) ->
+    throw({error, {redirector_rule_option, {Opt, Value}}}).
+
+validate_rule_node(Node) when is_binary(Node) -> Node;
+validate_rule_node(Value) ->
+    throw({error, {redirector_rule, Value}}).
+
+validate_condition({sgsn_ip, {_, _, _, _}} = Value) ->
+    Value;
+validate_condition({version, Versions}) ->
+    {version, validate_versions(Versions)};
+validate_condition({imsi, IMSI} = Value) when is_list(IMSI); is_binary(IMSI) ->
+    Value;
+validate_condition(Value) ->
+    throw({error, {redirector_rule_condition, Value}}).
+
+validate_node(node, Node0) ->
+    Node = ergw_config:validate_options(fun validate_node_option/2, Node0, ?DefaultNode, map),
+    #{name := Name, address := Address, keep_alive_version := Version} = Node,
+    {Name, {Version, Address}};
+validate_node(Opt, Value) ->
+    throw({error, {redirector_node, {Opt, Value}}}).
+
+validate_node_option(name, Name) when is_binary(Name) ->
+    Name;
+validate_node_option(keep_alive_version, Version) 
+  when Version == v1; Version == v2 ->
+    Version;
+validate_node_option(address, {_, _, _, _} = IPv4) ->
+    IPv4;
+validate_node_option(Opt, Value) ->
+    throw({error, {redirector_node_option, {Opt, Value}}}).
+
+validate_versions(Versions) when is_list(Versions) ->
+    lists:map(fun validate_versions/1, Versions);
+validate_versions(v1) -> v1;
+validate_versions(v2) -> v2;
+validate_versions(Value) ->
+    throw({error, {redirector_rule_version, Value}}).
+
+keep_alive(#redirector{ka_timeout = KATimeout,
+                       nodes = Nodes,
+                       responses = Responses} = Redirector, GtpPort) ->
+    NotAnswered = maps:map(fun(_K, TS) when is_integer(TS) ->  
+                                   Now = erlang:monotonic_time(),
+                                   Duration = erlang:convert_time_unit(Now - TS, native, millisecond),
+                                   Duration > (KATimeout * 2);
+                              (_K, _V) -> true
+                           end, Responses),
+    BadNodes = maps:filter(fun(_, Node) -> maps:get(Node, NotAnswered, false) end, Nodes),
+    maps:map(fun(_, {Version, IP}) ->
+                      Msg = case Version of
+                                v1 -> gtp_v1_c:build_echo_request(GtpPort);
+                                v2 -> gtp_v2_c:build_echo_request(GtpPort)
+                            end,
+                      gtp_socket:send_request(GtpPort, IP, ?GTP1c_PORT, ?T3 * 2, 0, Msg, [])
+                  end, Nodes),
+    TRef = erlang:start_timer(KATimeout, self(), redirector_keep_alive),
+    Redirector#redirector{ka_timer = TRef, 
+                          bad_nodes = BadNodes};
+keep_alive(Redirector, _) -> Redirector.
+
+timeout_requests(#redirector{requests = Requests} = Redirector) ->
+    Redirector#redirector{requests = ergw_cache:expire(Requests)};
+timeout_requests(Redirector) -> Redirector.
+
+handle_message(#redirector{socket = Socket,
+                           rt_timeout = RTTimeout,
+                           requests = Requests
+                          } = Redirector,
+               GtpPort, IP, Port, 
+               #gtp{type = Type, seq_no = SeqId} = Msg, Packet0)
+  when Socket /= undefined, Type /= echo_response, Type /= echo_request ->
+    ReqKey = {GtpPort, IP, Port, Type, SeqId},
+    Result = case ergw_cache:get(ReqKey, Requests) of
+                 {value, CachedNode} -> 
+                     lager:debug("~p: ~p was cached for using backend: ~p", 
+                                 [GtpPort#gtp_port.name, ReqKey, CachedNode]),
+                     {true, {CachedNode, Redirector}};
+                 _Other -> {false, route(Redirector, Msg)}
+             end,
+    case Result of
+        {_, {error, no_nodes}} -> 
+            lager:warning("~p: no nodes to redirect request ~p", 
+                          [GtpPort#gtp_port.name, ReqKey]),
+            Redirector;
+        {Cached, {{_, DstIP} = Node, NewRedirector}} ->
+            % if a backend was taken from cache we should not update it in cache this time
+            NewRequests = if Cached == true -> Requests;
+                             true -> ergw_cache:enter(ReqKey, Node, RTTimeout, Requests)
+                          end,
+            Family = gtp_socket:family(DstIP),
+            DstPort = ?GTP1c_PORT,
+            Packet = case Family of
+                         inet -> create_ipv4_udp_packet(IP, Port, DstIP, DstPort, Packet0);
+                         inet6 -> throw("inet6 is not supported now")
+                     end,
+            gen_socket:sendto(Socket, {inet4, DstIP, DstPort}, Packet), % only IPv4 for now 
+            lager:debug("~p: redirect to ~p", [GtpPort#gtp_port.name, DstIP]),
+            NewRedirector#redirector{requests = NewRequests}
+    end;
+handle_message(Redirector, _GtpPort, _IP, _Port, _Msg, _Packet) -> Redirector.
+
+echo_response(#redirector{socket = Socket,
+                          %nodes = [_|_] = Nodes,
+                          nodes = Nodes,
+                          responses = Responses} = Redirector,
+              #gtp_port{name = Name},
+              IP, Port, #gtp{version = Version, type = echo_request}, 
+              ArrivalTS)
+  when Socket /= undefined ->
+    Match = lists:any(fun({_, {V0, IP0}}) -> IP0 == IP andalso V0 == Version;
+                         (_) -> false
+                      end, maps:to_list(Nodes)),
+    if Match == true ->
+        lager:info("~p: ~p got echo_response from ~p:~p", [ArrivalTS, Name, IP, Port]),
+        NewResponses = Responses#{{Version, IP} => ArrivalTS},
+        Redirector#redirector{responses = NewResponses};
+       true -> Redirector
+    end;
+echo_response(Redirector, _, _, _, _, _) -> Redirector.
+
+optlen(HL) -> (HL - 5) * 4.
+create_ipv4_udp_packet({SA1, SA2, SA3, SA4}, SPort, {DA1, DA2, DA3, DA4}, DPort, Payload) ->
+    % UDP
+    ULen = 8 + byte_size(Payload),
+    USum = 0,
+    UDP = <<SPort:16, DPort:16, ULen:16, USum:16, Payload/binary>>,
+    % IPv4
+    HL = 5, DSCP = 0, ECN = 0, Len = 160 + optlen(HL) + byte_size(UDP),
+    Id = 0, DF = 0, MF = 0, Off = 0,
+    TTL = 64, Protocol = 17, Sum = 0,
+    Opt = <<>>,
+    % Packet
+    <<4:4, HL:4, DSCP:6, ECN:2, Len:16, 
+      Id:16, 0:1, DF:1, MF:1, Off:13, 
+      TTL:8, Protocol:8, Sum:16,
+      SA1:8, SA2:8, SA3:8, SA4:8, 
+      DA1:8, DA2:8, DA3:8, DA4:8, 
+      Opt:(optlen(HL))/binary, UDP/binary>>.
+
+route(#redirector{nodes = Nodes, 
+                  bad_nodes = BadNodes} = Redirector, Msg) ->
+    case maps:filter(fun(Node, _) -> not maps:is_key(Node, BadNodes) end, Nodes) of
+        [] -> {error, no_nodes};
+        _ -> route_1(Redirector, Msg)
+    end.
+
+route_1(#redirector{bad_nodes = BadNodes, rules = Rules} = Redirector, Msg) ->
+    #{nodes := Nodes} = match(Rules, BadNodes, Msg),
+    case lists:filter(fun(Node) -> not maps:is_key(Node, BadNodes) end, Nodes) of
+        [] -> {error, no_nodes};
+        Nodes0 -> 
+            % random
+            Index = rand:uniform(length(Nodes0)),
+            Name = lists:nth(Index, Nodes0),
+            {maps:get(Name, Redirector#redirector.nodes), Redirector}
+    end.
+
+match(Rules, BadNodes, Msg) ->
+    IEs = (gtp_packet:decode_ies(Msg))#gtp.ie,
+    Matched = lists:filter(
+                fun(#{conditions := Conditions, nodes := Nodes}) ->
+                        length(lists:filter(fun(Node) -> not maps:is_key(Node, BadNodes) end, Nodes)) > 0
+                        andalso
+                        lists:all(fun({sgsn_ip, IP}) -> match_sender_ip(Msg#gtp.version, IP, IEs);
+                                     ({version, Versions}) when is_list(Versions) -> 
+                                          lists:member(Msg#gtp.version, Versions);
+                                     ({version, Version}) -> Version == Msg#gtp.version;
+                                     ({imsi, IMSI}) -> match_imsi(Msg#gtp.version, IMSI, IEs);
+                                     (_) -> false
+                                  end, Conditions);
+                   (_) -> false
+                end, Rules),
+    case Matched of
+        [Rule | _] -> Rule;
+        _ -> #{nodes => []}
+    end.
+
+match_sender_ip(v1, IP, IEs) ->
+    #gsn_address{address = IP0} 
+        = maps:get({gsn_address, 0}, IEs,
+                   #gsn_address{}),
+    if is_tuple(IP) -> gtp_c_lib:ip2bin(IP) == IP0;
+       true -> IP == IP0
+    end;
+
+match_sender_ip(v2, IP, IEs) ->
+    #v2_fully_qualified_tunnel_endpoint_identifier{ipv4 = IP0} 
+        = maps:get({v2_fully_qualified_tunnel_endpoint_identifier, 0}, IEs, 
+                   #v2_fully_qualified_tunnel_endpoint_identifier{}),
+    if is_tuple(IP) -> gtp_c_lib:ip2bin(IP) == IP0;
+       true -> IP == IP0
+    end;
+
+match_sender_ip(_, _, _) -> false.
+
+match_imsi(v1, IMSI, IEs) ->
+    #international_mobile_subscriber_identity{imsi = IMSI0} 
+        = maps:get({international_mobile_subscriber_identity, 0}, IEs, 
+                   #international_mobile_subscriber_identity{}),
+    if is_list(IMSI) -> list_to_binary(IMSI) == IMSI0;
+       true -> IMSI == IMSI0
+    end;
+
+match_imsi(v2, IMSI, IEs) ->
+    #v2_international_mobile_subscriber_identity{imsi = IMSI0} 
+        = maps:get({v2_international_mobile_subscriber_identity, 0}, IEs, 
+                   #v2_international_mobile_subscriber_identity{}),
+    if is_list(IMSI) -> list_to_binary(IMSI) == IMSI0;
+       true -> IMSI == IMSI0
+    end;
+
+match_imsi(_, _, _) -> false.

--- a/test/ergw_http_api_SUITE.erl
+++ b/test/ergw_http_api_SUITE.erl
@@ -95,7 +95,7 @@ all() ->
 init_per_suite(Config0) ->
     inets:start(),
     Config1 = [{app_cfg, ?TEST_CONFIG},
-              {handler_under_test, ggsn_gn_proxy}
+              {handlers_under_test, [ggsn_gn_proxy]}
 	      | Config0],
     Config = lib_init_per_suite(Config1),
 

--- a/test/ergw_test_lib.erl
+++ b/test/ergw_test_lib.erl
@@ -113,9 +113,10 @@ meck_init(Config) ->
 
     ok = meck:new(gtp_socket, [passthrough, no_link]),
 
-    {_, Hut} = lists:keyfind(handler_under_test, 1, Config),   %% let it crash if HUT is undefined
-    ok = meck:new(Hut, [passthrough, no_link]),
-    ok = meck:expect(Hut, handle_request,
+    {_, Hs} = lists:keyfind(handlers_under_test, 1, Config),   %% let it crash if HUT is undefined
+    [begin
+        ok = meck:new(Hut, [passthrough, no_link]),
+        ok = meck:expect(Hut, handle_request,
 		     fun(ReqKey, Request, Resent, State) ->
 			     try
 				 meck:passthrough([ReqKey, Request, Resent, State])
@@ -123,22 +124,24 @@ meck_init(Config) ->
 				 throw:#ctx_err{} = CtxErr ->
 				     meck:exception(throw, CtxErr)
 			     end
-		     end).
+		     end)
+     end || Hut <- Hs].
 
 meck_reset(Config) ->
     meck:reset(gtp_dp),
     meck:reset(gtp_socket),
-    meck:reset(proplists:get_value(handler_under_test, Config)).
+    [meck:reset(Hut) || Hut <- proplists:get_value(handlers_under_test, Config)].
 
 meck_unload(Config) ->
     meck:unload(gtp_dp),
     meck:unload(gtp_socket),
-    meck:unload(proplists:get_value(handler_under_test, Config)).
+    [meck:unload(Hut) || Hut <- proplists:get_value(handlers_under_test, Config)].
 
 meck_validate(Config) ->
     ?equal(true, meck:validate(gtp_dp)),
     ?equal(true, meck:validate(gtp_socket)),
-    ?equal(true, meck:validate(proplists:get_value(handler_under_test, Config))).
+    [?equal(true, meck:validate(Hut)) 
+     || Hut <- proplists:get_value(handlers_under_test, Config)].
 
 %%%===================================================================
 %%% GTP entity and context function
@@ -232,6 +235,10 @@ send_pdu(S, Msg) ->
     Data = gtp_packet:encode(Msg),
     ok = gen_udp:send(S, ?TEST_GSN, ?GTP2c_PORT, Data).
 
+send_pdu(S, IP, Msg) ->
+    Data = gtp_packet:encode(Msg),
+    ok = gen_udp:send(S, IP, ?GTP2c_PORT, Data).
+
 send_recv_pdu(S, Msg) ->
     send_recv_pdu(S, Msg, ?TIMEOUT).
 
@@ -255,8 +262,8 @@ recv_pdu(S, SeqNo, Timeout, Fail) ->
     Now = erlang:monotonic_time(millisecond),
     recv_active(S),
     receive
-	{udp, S, ?TEST_GSN, _InPortNo, Response} ->
-	    recv_pdu_msg(Response, Now, S, SeqNo, Timeout, Fail);
+	{udp, S, IP, _InPortNo, Response} when IP == ?TEST_GSN; IP == ?TEST_GSN_R ->
+	    recv_pdu_msg(Response, Now, S, IP, SeqNo, Timeout, Fail);
 	{udp, _Socket, _IP, _InPortNo, _Packet} = Unexpected ->
 	    recv_pdu_fail(Fail, Unexpected);
 	{S, #gtp{seq_no = SeqNo} = Msg}
@@ -284,12 +291,12 @@ update_timeout(infinity, _At) ->
 update_timeout(Timeout, At) ->
     Timeout - (erlang:monotonic_time(millisecond) - At).
 
-recv_pdu_msg(Response, At, S, SeqNo, Timeout, Fail) ->
+recv_pdu_msg(Response, At, S, IP, SeqNo, Timeout, Fail) ->
     ct:pal("Msg: ~s", [pretty_print((catch gtp_packet:decode(Response)))]),
     case gtp_packet:decode(Response) of
 	#gtp{type = echo_request} = Msg ->
 	    Resp = Msg#gtp{type = echo_response, ie = []},
-	    send_pdu(S, Resp),
+	    send_pdu(S, IP, Resp),
 	    recv_pdu(S, SeqNo, update_timeout(Timeout, At), Fail);
 	#gtp{seq_no = SeqNo} = Msg
 	  when is_integer(SeqNo) ->

--- a/test/ergw_test_lib.hrl
+++ b/test/ergw_test_lib.hrl
@@ -34,6 +34,7 @@
 -define(LOCALHOST, {127,0,0,1}).
 -define(CLIENT_IP, {127,127,127,127}).
 -define(TEST_GSN, ?LOCALHOST).
+-define(TEST_GSN_R, {127,0,1,1}). % used in gtp_redirector_SUITE
 -define(PROXY_GSN, {127,0,100,1}).
 -define(FINAL_GSN, {127,0,200,1}).
 

--- a/test/ggsn_SUITE.erl
+++ b/test/ggsn_SUITE.erl
@@ -78,12 +78,13 @@
 	 {ergw_aaa, [{ergw_aaa_provider, {ergw_aaa_mock, [{shared_secret, <<"MySecret">>}]}}]}
 	]).
 
+get_test_config() -> ?TEST_CONFIG.
 
 suite() ->
     [{timetrap,{seconds,30}}].
 
 init_per_suite(Config0) ->
-    Config = [{handler_under_test, ?HUT},
+    Config = [{handlers_under_test, [?HUT]},
 	      {app_cfg, ?TEST_CONFIG}
 	      | Config0],
 

--- a/test/ggsn_proxy_SUITE.erl
+++ b/test/ggsn_proxy_SUITE.erl
@@ -187,7 +187,7 @@ suite() ->
     [{timetrap,{seconds,30}}].
 
 init_per_suite(Config0) ->
-    [{handler_under_test, ?HUT} | Config0].
+    [{handlers_under_test, [?HUT]} | Config0].
 
 end_per_suite(_Config) ->
     ok.

--- a/test/gtp_redirector_SUITE.erl
+++ b/test/gtp_redirector_SUITE.erl
@@ -1,0 +1,278 @@
+%% Copyright 2017, Travelping GmbH <info@travelping.com>
+
+%% This program is free software; you can redistribute it and/or
+%% modify it under the terms of the GNU General Public License
+%% as published by the Free Software Foundation; either version
+%% 2 of the License, or (at your option) any later version.
+
+-module(gtp_redirector_SUITE).
+
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("common_test/include/ct.hrl").
+
+-include("../include/ergw.hrl").
+-include("ergw_test_lib.hrl").
+-include("ergw_ggsn_test_lib.hrl").
+
+-define(TIMEOUT, 2000).
+-define(REDIRECTOR_OPTS, 
+        [{keep_alive_timeout, 500},
+         {retransmit_timeout, 10000},
+         {lb_type, random},
+         {nodes, [
+                  {node, [{name, <<"gsn">>},
+                          {keep_alive_version, v1},
+                          {address, ?TEST_GSN_R}
+                         ]},
+                  {node, [{name, <<"broken">>},
+                          {keep_alive_version, v1},
+                          {address, {10,0,0,1}}
+                         ]}
+                 ]},
+         {rules, [
+                  % this rule should never happen by sgsn_ip
+                  {rule, [
+                          {conditions, [{sgsn_ip, {192, 255, 127, 127}},
+                                        {version, [v1, v2]}
+                                       ]},
+                          {nodes, [<<"gsn">>]}
+                         ]},
+                  % to ggsn
+                  {rule, [% when ip and imsi are matched
+                          {conditions, [{sgsn_ip, {127, 127, 127, 127}},
+                                        {imsi, <<"111111111111111">>},
+                                        {version, [v1]}
+                                       ]},
+                          {nodes, [<<"gsn">>, <<"broken">>]}
+                         ]},
+                  % to pgw
+                  {rule, [% when ip and imsi are matched
+                          {conditions, [{sgsn_ip, {127, 127, 127, 127}},
+                                        {imsi, <<"111111111111111">>},
+                                        {version, [v2]}
+                                       ]},
+                          {nodes, [<<"gsn">>, <<"broken">>]}
+                         ]},
+                  {rule, [% TODO: some request like delete_pdp_context_request
+                          %       go to this rule. we do it because now test helpers are
+                          %       not able to change destination api to send requests.
+                          {conditions, []},
+                          {nodes, [<<"gsn">>]}
+                         ]}
+                 ]} 
+        ]).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+suite() ->
+    [{timetrap,{seconds,30}}].
+
+init_per_suite(Config0) ->
+    AppCfg = inject_redirector(ggsn_SUITE:get_test_config()),
+    Config = [{handlers_under_test, [ggsn_gn, pgw_s5s8]},
+              {app_cfg, AppCfg}
+              | Config0],
+    Config1 = lib_init_per_suite(Config),
+    % we need this timeout (2 times of Keep-Alive timeout) to be sure 
+    % that nodes which are not available will be removed
+    timer:sleep(1100),
+    Config1.
+
+inject_redirector(Config) ->
+    ModifyIRX = 
+        fun({irx, _}) -> 
+                IRX = [{type, 'gtp-c'},
+                       {ip,  ?TEST_GSN_R}, % 127.0.0.1 -> 127.0.1.1
+                       {reuseaddr, true}],
+                {irx, IRX};
+           (Other) -> Other
+        end,
+    RRX = {rrx, [{type, 'gtp-c'},
+                 {ip,  ?TEST_GSN},
+                 {reuseaddr, true},
+                 {redirector,  ?REDIRECTOR_OPTS}
+                ]},
+    S5S8 = {s5s8, [{handler, pgw_s5s8},
+                   {sockets, [irx]},
+                   {data_paths, [grx]},
+                   {aaa, [{'Username',
+                           [{default, ['IMSI',   <<"/">>,
+                                       'IMEI',   <<"/">>,
+                                       'MSISDN', <<"/">>,
+                                       'ATOM',   <<"/">>,
+                                       "TEXT",   <<"/">>,
+                                       12345,
+                                       <<"@">>, 'APN']}]}]}
+                  ]},
+    ModifySocketsAndHandlers = 
+        fun({sockets, Sockets}) -> {sockets, lists:map(ModifyIRX, [RRX | Sockets])};
+           ({handlers, Handlers}) -> {handlers, [S5S8 | Handlers]};
+           (Other) -> Other
+        end,
+    lists:map(fun({ergw, Ergw}) -> 
+                      {ergw, lists:map(ModifySocketsAndHandlers, Ergw)};
+                 (Other) -> Other
+             end, Config).
+
+end_per_suite(Config) ->
+    ok = lib_end_per_suite(Config),
+    ok.
+
+all() ->
+    [
+     validate_options,
+     invalid_gtp_pdu,
+     invalid_gtp_msg,
+     simple_pdp_context_request,
+     create_pdp_context_request_resend,
+     create_session_request_resend,
+     keep_alive
+    ].
+
+%%%===================================================================
+%%% Tests
+%%%===================================================================
+init_per_testcase(create_pdp_context_request_resend, Config) ->
+    ct:pal("Sockets: ~p", [gtp_socket_reg:all()]),
+    ok = meck:new(ergw_cache, [passthrough, no_link]),
+    meck_reset(Config),
+    Config;
+
+init_per_testcase(_, Config) ->
+    ct:pal("Sockets: ~p", [gtp_socket_reg:all()]),
+    meck_reset(Config),
+    Config.
+
+end_per_testcase(create_pdp_context_request_resend, Config) ->
+    meck:unload(ergw_cache),
+    Config;
+
+end_per_testcase(_, Config) ->
+    Config.
+
+%%--------------------------------------------------------------------
+validate_options() ->
+    [{doc, "Check all possible configuration options"}].
+validate_options(_Config) ->
+    % all options are default
+    ?equal(#{keep_alive_timeout => 60000,
+             lb_type => random,
+             retransmit_timeout => 10000,
+             rules => [],
+             nodes => #{}},
+           gtp_redirector:validate_options([])),
+    % some options are default
+    ?equal(#{keep_alive_timeout => 60000,
+             lb_type => round_robin,
+             retransmit_timeout => 10000,
+             rules => [],
+             nodes => #{}},
+           validate([{lb_type, round_robin}])),
+    ?equal(#{keep_alive_timeout => 10000,
+             lb_type => random,
+             retransmit_timeout => 10000,
+             rules => [],
+             nodes => #{}},
+           validate([{keep_alive_timeout, 10000}])),
+    ?equal(#{keep_alive_timeout => 60000,
+             lb_type => random,
+             retransmit_timeout => 1000,
+             rules => [],
+             nodes => #{}},
+           validate([{retransmit_timeout, 1000}])),
+    % negative cases
+    ?equal({error, {redirector_options, {rules, 1000}}},
+           validate([{rules, 1000}])),
+    ?equal({error, {redirector_options, {nodes, 1000}}},
+           validate([{nodes, 1000}])),
+    % nodes and rules
+    ?equal(#{keep_alive_timeout => 500,
+             retransmit_timeout => 10000,
+             lb_type => random,
+             nodes =>
+                 #{<<"broken">> => {v1,{10,0,0,1}},
+                  <<"gsn">> => {v1,{127,0,1,1}}},
+             rules =>
+                 [#{conditions =>
+                    [{sgsn_ip,{192,255,127,127}},
+                     {version,[v1,v2]}],
+                    nodes => [<<"gsn">>]},
+                  #{conditions =>
+                    [{sgsn_ip,{127,127,127,127}},
+                     {imsi,<<"111111111111111">>},
+                     {version,[v1]}],
+                    nodes => [<<"gsn">>,<<"broken">>]},
+                  #{conditions =>
+                    [{sgsn_ip,{127,127,127,127}},
+                     {imsi,<<"111111111111111">>},
+                     {version,[v2]}],
+                    nodes => [<<"gsn">>,<<"broken">>]},
+                  #{conditions => [],nodes => [<<"gsn">>]}]},
+           gtp_redirector:validate_options(?REDIRECTOR_OPTS)),
+    ok.
+
+validate(Opts) ->
+    catch (gtp_redirector:validate_options(Opts)).
+
+%%--------------------------------------------------------------------
+invalid_gtp_pdu() ->
+    [{doc, "Test that an invalid PDU is silently ignored "
+           "and that the GTP Redirector socket is not crashing"}].
+invalid_gtp_pdu(Config) ->
+    ggsn_SUITE:invalid_gtp_pdu(Config).
+
+%%--------------------------------------------------------------------
+invalid_gtp_msg() ->
+    [{doc, "Test that an invalid message is silently ignored"
+      " and that the GTP socket is not crashing"}].
+invalid_gtp_msg(Config) ->
+    ggsn_SUITE:invalid_gtp_msg(Config).
+
+%%--------------------------------------------------------------------
+simple_pdp_context_request() ->
+    [{doc, "Check simple Create PDP Context and Delete PDP Context sequence "
+           "through GTP Redirector"}].
+simple_pdp_context_request(Config) ->
+    ggsn_SUITE:simple_pdp_context_request(Config).
+
+%%--------------------------------------------------------------------
+create_pdp_context_request_resend() ->
+    [{doc, "Check that a retransmission cache of some request works"}].
+create_pdp_context_request_resend(Config) ->
+    % We are going to check how much times ergw_cache:enter will be called to storing 
+    % a node for the particular create_pdp_context_request in redirector mode.
+    % `ggsn_SUITE:create_pdp_context_request_resend` sends `create_pdp_context_request` twice
+    % but because rederector socket has some retransmission cache we expect that `enter`
+    % will be called just once, and the seconds request will be processed to node 
+    % which was cached before
+    Count = get_count(),
+    ggsn_SUITE:create_pdp_context_request_resend(Config),
+    ?equal(1, get_count() - Count).
+
+get_count() ->
+    Id = {'_', '_', '_', create_pdp_context_request, '_'},
+    Node = {'_', '_'},
+    meck:num_calls(ergw_cache, enter, [Id, Node, '_', '_']).
+
+%%--------------------------------------------------------------------
+keep_alive() ->
+    [{doc, "All backend GTP-C should answer on echo_request which sent by timeout"}].
+keep_alive(_Config) ->
+    Id = [path, irx, {127,0,0,1}, tx, v1, echo_response, count],
+    Cnt0 = get_value(exometer:get_value(Id)),
+    timer:sleep(1000),
+    Cnt = get_value(exometer:get_value(Id)),
+    ?match(true, Cnt > Cnt0),
+    ok.
+
+get_value({ok, DPs}) -> proplists:get_value(value, DPs, -1);
+get_value(_) -> -1.
+
+%%--------------------------------------------------------------------
+create_session_request_resend() ->
+    [{doc, "Check that a retransmission of a Create Session Request works through Redirector socket"}].
+create_session_request_resend(Config) ->
+    pgw_SUITE:create_session_request_resend(Config).

--- a/test/pgw_SUITE.erl
+++ b/test/pgw_SUITE.erl
@@ -94,7 +94,7 @@ suite() ->
     [{timetrap,{seconds,30}}].
 
 init_per_suite(Config0) ->
-    Config = [{handler_under_test, ?HUT},
+    Config = [{handlers_under_test, [?HUT]},
 	      {app_cfg, ?TEST_CONFIG}
 	      | Config0],
 

--- a/test/pgw_proxy_SUITE.erl
+++ b/test/pgw_proxy_SUITE.erl
@@ -212,7 +212,7 @@ suite() ->
     [{timetrap,{seconds,30}}].
 
 init_per_suite(Config0) ->
-    [{handler_under_test, ?HUT} | Config0].
+    [{handlers_under_test, [?HUT]} | Config0].
 
 end_per_suite(_Config) ->
     ok.


### PR DESCRIPTION
The redirection mode means that a GTP request will be transferred to a GTP backed with saving source IP and port. For the GTP backend, such request looks like it came from particular GTP client directly. 

There are some matching rules to making a decision, see the example of configuration:

```erlang
{rrx, [
    {type,      'gtp-c'},
    {ip,        {192, 168, 1, 100}},
    {reuseaddr, true},
    {redirector, [
        {keep_alive_timeout, 60000},  % (ms) how often redirector socket will send echo_request to nodes to keep connection up
        {retransmit_timeout, 10000},  % (ms) how long request will be memorized to use previously selected node
        {lb_type,            random}, % how to select node from list of nodes. now only `random` is supported
        {nodes, [
            {node, [
                {name, <<"gsn">>},           % name will be used to describe nodes to make routing in `rules` section
                {keep_alive_version, v1},    % v1 | v2. version to build echo_request
                {address, {192, 168, 1, 16}} % only ipv4 for now
            ]},
            {node, [
                {name, <<"gsn2">>},
                {keep_alive_version, v1},
                {address, {192, 168, 1, 17}}
            ]}
        ]},
        {rules, [
            % both v1 and v2 requests from 192.255.127.127 go to `gsn` described above 
            {rule, [
                {conditions, [
                    {sgsn_ip, {192, 255, 127, 127}},
                    {version, [v1, v2]}
                ]},
                {nodes, [<<"gsn">>]}
            ]},
            % v1 requests from 127.127.127.127 with imsi 111111111111111 go randomly to `gsn` or `gsn2`
            {rule, [
                {conditions, [
                    {sgsn_ip, {127, 127, 127, 127}},
                    {imsi,    <<"111111111111111">>},
                    {version, [v1]}
                ]},
                {nodes, [<<"gsn">>, <<"gsn2">>]}
            ]},
            % v2 requests from 127.127.127.127 with imsi 111111111111111 go `gsn2`
            {rule, [
                {conditions, [
                    {sgsn_ip, {127, 127, 127, 127}},
                    {imsi,    <<"111111111111111">>},
                    {version, [v2]}
                ]},
                {nodes, [<<"gsn2">>]}
            ]}
        ]} 
    ]}
]}

```