### PR TITLE
Split APN label if there is a dot

### DIFF
--- a/src/gtp_c_lib.erl
+++ b/src/gtp_c_lib.erl
@@ -18,13 +18,18 @@
 %% make sure DNS and APN labels are lower case and contain only
 %% permited characters (labels have to start with letters and
 %% not end with hyphens, but we don't check that)
+%% also do not consider "." (dot) as not permitted character
+%% but split labels by it
 normalize_labels('_') ->
     '_';
 normalize_labels(Labels) when is_list(Labels) ->
-    lists:map(fun normalize_labels/1, Labels);
+    lists:flatmap(fun normalize_labels/1, Labels);
 normalize_labels(Label) when is_binary(Label) ->
-    << << (dns_char(C)):8 >> || <<C:8>> <= Label >>.
+    binary:split(<< << (dns_char(C)):8 >> || <<C:8>> <= Label >>,
+                 <<$.>>, [global, trim_all]).
 
+dns_char($.) ->
+    $.;
 dns_char($-) ->
     $-;
 dns_char(C) when C >= $0 andalso C =< $9 ->

--- a/test/ergw_ggsn_test_lib.erl
+++ b/test/ergw_ggsn_test_lib.erl
@@ -448,6 +448,7 @@ execute_request(MsgType, SubType, Socket, GtpC0) ->
     {validate_response(MsgType, SubType, Response, GtpC), Msg, Response}.
 
 apn(invalid_apn) -> [<<"IN", "VA", "LID">>];
+apn(dotted_apn)  -> ?'APN-EXA.MPLE';
 apn(_)           -> ?'APN-EXAMPLE'.
 
 imsi('2nd', _) ->

--- a/test/ergw_pgw_test_lib.erl
+++ b/test/ergw_pgw_test_lib.erl
@@ -620,6 +620,7 @@ execute_request(MsgType, SubType, Socket, GtpC0) ->
     {validate_response(MsgType, SubType, Response, GtpC), Msg, Response}.
 
 apn(invalid_apn) -> [<<"IN", "VA", "LID">>];
+apn(dotted_apn)  -> ?'APN-EXA.MPLE';
 apn(_)           -> ?'APN-ExAmPlE'.
 
 imsi('2nd', _) ->

--- a/test/ergw_test_lib.hrl
+++ b/test/ergw_test_lib.hrl
@@ -40,6 +40,7 @@
 
 -define('APN-EXAMPLE', [<<"example">>, <<"net">>]).
 -define('APN-ExAmPlE', [<<"eXaMpLe">>, <<"net">>]).
+-define('APN-EXA.MPLE', [<<"exa.mple">>, <<"net">>]).
 -define('IMSI', <<"111111111111111">>).
 -define('MSISDN', <<"440000000000">>).
 

--- a/test/ggsn_SUITE.erl
+++ b/test/ggsn_SUITE.erl
@@ -72,6 +72,7 @@
 
 		 {apns,
 		  [{?'APN-EXAMPLE', [{vrf, upstream}]},
+		   {[<<"exa">>, <<"mple">>, <<"net">>], [{vrf, upstream}]},
 		   {[<<"APN1">>], [{vrf, upstream}]}
 		  ]}
 		]},
@@ -100,6 +101,7 @@ all() ->
      create_pdp_context_request_missing_ie,
      create_pdp_context_request_aaa_reject,
      create_pdp_context_request_invalid_apn,
+     create_pdp_context_request_dotted_apn,
      create_pdp_context_request_accept_new,
      path_restart, path_restart_recovery, path_restart_multi,
      simple_pdp_context_request,
@@ -259,6 +261,18 @@ create_pdp_context_request_invalid_apn(Config) ->
     S = make_gtp_socket(Config),
 
     create_pdp_context(invalid_apn, S),
+
+    ?equal([], outstanding_requests()),
+    meck_validate(Config),
+    ok.
+
+%%--------------------------------------------------------------------
+create_pdp_context_request_dotted_apn() ->
+    [{doc, "Check dotted APN return on Create PDP Context Request"}].
+create_pdp_context_request_dotted_apn(Config) ->
+    S = make_gtp_socket(Config),
+
+    create_pdp_context(dotted_apn, S),
 
     ?equal([], outstanding_requests()),
     meck_validate(Config),

--- a/test/pgw_SUITE.erl
+++ b/test/pgw_SUITE.erl
@@ -83,6 +83,7 @@
 
 		 {apns,
 		  [{?'APN-EXAMPLE', [{vrf, upstream}]},
+		   {[<<"exa">>, <<"mple">>, <<"net">>], [{vrf, upstream}]},
 		   {[<<"APN1">>], [{vrf, upstream}]}
 		  ]}
 		]},
@@ -110,6 +111,7 @@ all() ->
      create_session_request_missing_ie,
      create_session_request_aaa_reject,
      create_session_request_invalid_apn,
+     create_session_request_dotted_apn,
      create_session_request_accept_new,
      path_restart, path_restart_recovery, path_restart_multi,
      simple_session_request,
@@ -301,6 +303,17 @@ create_session_request_invalid_apn(Config) ->
     S = make_gtp_socket(Config),
 
     create_session(invalid_apn, S),
+
+    meck_validate(Config),
+    ok.
+
+%%--------------------------------------------------------------------
+create_session_request_dotted_apn() ->
+    [{doc, "Check dotted APN return on Create Session Request"}].
+create_session_request_dotted_apn(Config) ->
+    S = make_gtp_socket(Config),
+
+    create_session(dotted_apn, S),
 
     meck_validate(Config),
     ok.


### PR DESCRIPTION
Prevents nonstandard-labels like "a.b" from being a problem later on.
In general labels should not contain dots:
https://www.etsi.org/deliver/etsi_ts/123000_123099/123003/14.07.00_60/ts_123003v140700p.pdf#page=67
but sometimes they do.