### PR TITLE
fix cache expire logic

### DIFF
--- a/src/gtp_redirector.erl
+++ b/src/gtp_redirector.erl
@@ -10,7 +10,7 @@
 -export([init/2, 
          validate_options/1, 
          keep_alive/2, 
-         timeout_requests/1, 
+         timeout_requests/2, 
          handle_message/6, 
          echo_response/6]).
 
@@ -192,9 +192,9 @@ keep_alive(#redirector{ka_timeout = KATimeout,
                           bad_nodes = BadNodes};
 keep_alive(Redirector, _) -> Redirector.
 
-timeout_requests(#redirector{requests = Requests} = Redirector) ->
-    Redirector#redirector{requests = ergw_cache:expire(Requests)};
-timeout_requests(Redirector) -> Redirector.
+timeout_requests(TRef, #redirector{requests = Requests} = Redirector) ->
+    Redirector#redirector{requests = ergw_cache:expire(TRef, Requests)};
+timeout_requests(_TRef, Redirector) -> Redirector.
 
 handle_message(#redirector{socket = Socket,
                            rt_timeout = RTTimeout,


### PR DESCRIPTION
Calling ergw_cache:expire/1 outside of an timeout event will
start a new timer regardless of wether there is already one
running.
Also, there is really no need to invoke expire outside of an
timer event. The normal internal cleanup in enter/4 should be
sufficient and the timer events will handle the rest.

Change the expire API so that it can deals with the timers
properly.