### PR TITLE
drop the special atom '_' from the permited APN labels

### DIFF
--- a/src/gtp_c_lib.erl
+++ b/src/gtp_c_lib.erl
@@ -19,8 +19,6 @@
 %% not end with hyphens, but we don't check that)
 %% also do not consider "." (dot) as not permitted character
 %% but split labels by it
-normalize_labels('_') ->
-    '_';
 normalize_labels(Labels) when is_list(Labels) ->
     lists:flatmap(fun normalize_labels/1, Labels);
 normalize_labels(Label) when is_binary(Label) ->


### PR DESCRIPTION
Using a list of APN labels with one of them being the wildcard
label was never supported. The wildcard was always supposed to
be the bare '_' atom (without a list).

The return value from normalize_labels for '_' was broken anyway
because lists:flatmap/2 expects a list as return from the mapping
fun.