### PR TITLE
implement Validity-Timer and the matching Reporting-Reason for Gy

### DIFF
--- a/include/ergw.hrl
+++ b/include/ergw.hrl
@@ -61,7 +61,9 @@
 	  idmap = #{}		:: map(),
 	  urr_by_id = #{}	:: map(),
 	  urr_by_grp = #{}	:: map(),
-	  sx_rules = #{}	:: map()
+	  sx_rules = #{}	:: map(),
+	  timers = #{}		:: map(),
+	  timer_by_tref = #{}	:: map()
 	 }).
 
 -record(gtp_endp, {

--- a/rebar.config
+++ b/rebar.config
@@ -16,7 +16,7 @@
 	{gtplib, {git, "https://github.com/travelping/gtplib.git", {ref, "f036d98"}}},
 	{pfcplib, {git, "https://github.com/travelping/pfcplib.git", {branch, "master"}}},
 	{gen_socket, {git, "git://github.com/travelping/gen_socket", {ref, "195a427"}}},
-	{ergw_aaa, {git, "git://github.com/travelping/ergw_aaa", {ref, "459e3f9"}}}
+	{ergw_aaa, {git, "git://github.com/travelping/ergw_aaa", {ref, "965037d"}}}
 ]}.
 
 {minimum_otp_vsn, "20.3"}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -8,7 +8,7 @@
   1},
  {<<"ergw_aaa">>,
   {git,"git://github.com/travelping/ergw_aaa",
-       {ref,"459e3f972ee5b8cd6527f5b374b610c6aed719d2"}},
+       {ref,"965037d33172e5a77a0ec7c8ff3d5ca6c8626868"}},
   0},
  {<<"erlando">>,
   {git,"https://github.com/travelping/erlando.git",

--- a/src/ggsn_gn.erl
+++ b/src/ggsn_gn.erl
@@ -121,8 +121,6 @@ handle_info({'DOWN', _MonitorRef, Type, Pid, _Info} = _I,
     close_pdp_context(upf_failure, State),
     {noreply, State};
 
-%% ===========================================================================
-
 handle_info(stop_from_session, #{context := Context} = State) ->
     delete_context(undefined, Context),
     {noreply, State};
@@ -134,29 +132,19 @@ handle_info(#aaa_request{procedure = {_, 'ASR'}},
     {noreply, State};
 
 handle_info(#aaa_request{procedure = {gy, 'RAR'}, request = Request},
-	    #{context := Context, 'Session' := Session} = State) ->
+	    #{'Session' := Session} = State) ->
     ergw_aaa_session:response(Session, ok, #{}),
     Now = erlang:monotonic_time(),
 
     %% Triggered CCR.....
-
-    case query_usage_report(Request, Context) of
-	#pfcp{type = session_modification_response,
-	      ie = #{pfcp_cause := #pfcp_cause{cause = 'Request accepted'}} = IEs} ->
-
-	    ChargeEv = interim,
-	    UsageReport = maps:get(usage_report_smr, IEs, undefined),
-	    {Online, Offline, _} =
-		ergw_gsn_lib:usage_report_to_charging_events(UsageReport, ChargeEv, Context),
-	    ergw_gsn_lib:process_online_charging_events(ChargeEv, Online, Now, Session),
-	    ergw_gsn_lib:process_offline_charging_events(ChargeEv, Offline, Now, Session),
-	    ok;
-	_ ->
-	    ok
-    end,
+    triggered_charging_event(interim, Now, Request, State),
     {noreply, State};
 
-%% ===========================================================================
+handle_info({pfcp_timer, #{validity_time := ChargingKeys}}, State) ->
+    Now = erlang:monotonic_time(),
+    triggered_charging_event(validity_time, Now, ChargingKeys, State),
+
+    {noreply, State};
 
 handle_info(_Info, State) ->
     lager:warning("~p, handle_info(~p, ~p)", [?MODULE, _Info, State]),
@@ -476,10 +464,28 @@ close_pdp_context(Reason, #{context := Context, 'Session' := Session}) ->
     pdp_release_ip(Context).
 
 query_usage_report(#{'Rating-Group' := [RatingGroup]}, Context) ->
-    ergw_gsn_lib:query_usage_report(RatingGroup, Context);
+    ChargingKeys = [{online, RatingGroup}],
+    ergw_gsn_lib:query_usage_report(ChargingKeys, Context);
+query_usage_report(ChargingKeys, Context) when is_list(ChargingKeys) ->
+    ergw_gsn_lib:query_usage_report(ChargingKeys, Context);
 query_usage_report(_, Context) ->
     ergw_gsn_lib:query_usage_report(Context).
 
+triggered_charging_event(ChargeEv, Now, Request,
+			 #{context := Context, 'Session' := Session}) ->
+    case query_usage_report(Request, Context) of
+	#pfcp{type = session_modification_response,
+	      ie = #{pfcp_cause := #pfcp_cause{cause = 'Request accepted'}} = IEs} ->
+
+	    UsageReport = maps:get(usage_report_smr, IEs, undefined),
+	    {Online, Offline, _} =
+		ergw_gsn_lib:usage_report_to_charging_events(UsageReport, ChargeEv, Context),
+	    ergw_gsn_lib:process_online_charging_events(ChargeEv, Online, Now, Session),
+	    ergw_gsn_lib:process_offline_charging_events(ChargeEv, Offline, Now, Session),
+	    ok;
+	_ ->
+	    ok
+    end.
 
 apply_context_change(NewContext0, OldContext, URRActions, #{'Session' := Session} = State) ->
     SessionOpts = ergw_aaa_session:get(Session),

--- a/src/gtp_context.erl
+++ b/src/gtp_context.erl
@@ -420,6 +420,13 @@ handle_info({update_session, Session, Events} = Us, #{interface := Interface} = 
 
 %%====================================================================
 
+handle_info({timeout, TRef, pfcp_timer} = Info,
+	    #{interface := Interface, context := #context{pfcp_ctx = PCtx0} = Ctx} = State) ->
+    lager:debug("handle_info ~p:~p", [Interface, lager:pr(Info, ?MODULE)]),
+    {Evs, PCtx} = ergw_pfcp:timer_expired(TRef, PCtx0),
+    CtxEvs = ergw_gsn_lib:pfcp_to_context_event(Evs),
+    Interface:handle_info({pfcp_timer, CtxEvs}, State#{context => Ctx#context{pfcp_ctx = PCtx}});
+
 handle_info(Info, #{interface := Interface} = State) ->
     lager:debug("handle_info ~p:~p", [Interface, lager:pr(Info, ?MODULE)]),
     Interface:handle_info(Info, State).

--- a/src/saegw_s11.erl
+++ b/src/saegw_s11.erl
@@ -128,8 +128,6 @@ handle_info({'DOWN', _MonitorRef, Type, Pid, _Info},
     close_pdn_context(upf_failure, State),
     {noreply, State};
 
-%% ===========================================================================
-
 handle_info(stop_from_session, #{context := Context} = State) ->
     delete_context(undefined, Context),
     {noreply, State};
@@ -141,29 +139,19 @@ handle_info(#aaa_request{procedure = {_, 'ASR'}},
     {noreply, State};
 
 handle_info(#aaa_request{procedure = {gy, 'RAR'}, request = Request},
-	    #{context := Context, 'Session' := Session} = State) ->
+	    #{'Session' := Session} = State) ->
     ergw_aaa_session:response(Session, ok, #{}),
     Now = erlang:monotonic_time(),
 
     %% Triggered CCR.....
-
-    case query_usage_report(Request, Context) of
-	#pfcp{type = session_modification_response,
-	      ie = #{pfcp_cause := #pfcp_cause{cause = 'Request accepted'}} = IEs} ->
-
-	    ChargeEv = interim,
-	    UsageReport = maps:get(usage_report_smr, IEs, undefined),
-	    {Online, Offline, _} =
-		ergw_gsn_lib:usage_report_to_charging_events(UsageReport, ChargeEv, Context),
-	    ergw_gsn_lib:process_online_charging_events(ChargeEv, Online, Now, Session),
-	    ergw_gsn_lib:process_offline_charging_events(ChargeEv, Offline, Now, Session),
-	    ok;
-	_ ->
-	    ok
-    end,
+    triggered_charging_event(interim, Now, Request, State),
     {noreply, State};
 
-%% ===========================================================================
+handle_info({pfcp_timer, #{validity_time := ChargingKeys}}, State) ->
+    Now = erlang:monotonic_time(),
+    triggered_charging_event(validity_time, Now, ChargingKeys, State),
+
+    {noreply, State};
 
 handle_info(_Info, State) ->
     {noreply, State}.
@@ -606,9 +594,28 @@ close_pdn_context(Reason, #{context := Context, 'Session' := Session}) ->
     pdn_release_ip(Context).
 
 query_usage_report(#{'Rating-Group' := [RatingGroup]}, Context) ->
-    ergw_gsn_lib:query_usage_report(RatingGroup, Context);
+    ChargingKeys = [{online, RatingGroup}],
+    ergw_gsn_lib:query_usage_report(ChargingKeys, Context);
+query_usage_report(ChargingKeys, Context) when is_list(ChargingKeys) ->
+    ergw_gsn_lib:query_usage_report(ChargingKeys, Context);
 query_usage_report(_, Context) ->
     ergw_gsn_lib:query_usage_report(Context).
+
+triggered_charging_event(ChargeEv, Now, Request,
+			 #{context := Context, 'Session' := Session}) ->
+    case query_usage_report(Request, Context) of
+	#pfcp{type = session_modification_response,
+	      ie = #{pfcp_cause := #pfcp_cause{cause = 'Request accepted'}} = IEs} ->
+
+	    UsageReport = maps:get(usage_report_smr, IEs, undefined),
+	    {Online, Offline, _} =
+		ergw_gsn_lib:usage_report_to_charging_events(UsageReport, ChargeEv, Context),
+	    ergw_gsn_lib:process_online_charging_events(ChargeEv, Online, Now, Session),
+	    ergw_gsn_lib:process_offline_charging_events(ChargeEv, Offline, Now, Session),
+	    ok;
+	_ ->
+	    ok
+    end.
 
 apply_context_change(NewContext0, OldContext, URRActions, #{'Session' := Session} = State) ->
     ModifyOpts = #{send_end_marker => true},

--- a/test/ggsn_SUITE.erl
+++ b/test/ggsn_SUITE.erl
@@ -121,7 +121,8 @@
 		]},
 
 	 {ergw_aaa,
-	  [{handlers,
+	  [
+	   {handlers,
 	    [{ergw_aaa_static,
 	      [{'NAS-Identifier',          <<"NAS-Identifier">>},
 	       {'Node-Id',                 <<"PGW-001">>},
@@ -144,11 +145,57 @@
 	       }
 	      ]}
 	    ]},
-	   {services, [{'Default', [{handler, 'ergw_aaa_static'}]}]},
-	   {apps, [{default, [{session, ['Default']}]}]}
+	   {services,
+	    [{'Default', [{handler, 'ergw_aaa_static'},
+			  {answers, #{'Initial-OCS' =>
+					  #{'Result-Code' => [2001],
+					    'Multiple-Services-Credit-Control' =>
+						[#{'Envelope-Reporting' => [0],
+						   'Granted-Service-Unit' =>
+						       [#{'CC-Time' => [3600],
+							  'CC-Total-Octets' => [102400]}],
+						   'Rating-Group' => [3000],
+						   'Validity-Time' => [2],
+						   'Result-Code' => [2001],
+						   'Time-Quota-Threshold' => [60],
+						   'Volume-Quota-Threshold' => [10240]}
+						]
+					   },
+				      'Update-OCS' =>
+					  #{'Result-Code' => [2001],
+					    'Multiple-Services-Credit-Control' =>
+						[#{'Envelope-Reporting' => [0],
+						   'Granted-Service-Unit' =>
+						       [#{'CC-Time' => [3600],
+							  'CC-Total-Octets' => [102400]}],
+						   'Rating-Group' => [3000],
+						   'Validity-Time' => [2],
+						   'Result-Code' => [2001],
+						   'Time-Quota-Threshold' => [60],
+						   'Volume-Quota-Threshold' => [10240]}
+						]
+					   }
+				     }
+			  }
+			 ]}
+	    ]},
+	   {apps,
+	    [{default,
+	      [{session, ['Default']},
+	       {procedures, [{authenticate, []},
+			     {authorize, []},
+			     {start, []},
+			     {interim, []},
+			     {stop, []},
+			     {{gy, 'CCR-Initial'},   []},
+			     {{gy, 'CCR-Update'},    []},
+			     %%{{gy, 'CCR-Update'},    [{'Default', [{answer, 'Update-If-Down'}]}]},
+			     {{gy, 'CCR-Terminate'}, []}
+			    ]}
+	      ]}
+	    ]}
 	  ]}
 	]).
-
 
 -define(CONFIG_UPDATE,
 	[{[sockets, cp, ip], localhost},
@@ -228,7 +275,8 @@ common() ->
      unsupported_request,
      cache_timeout,
      session_options,
-     session_accounting].
+     session_accounting,
+     gy_validity_timer].
 
 groups() ->
     [{ipv4, [], common()},
@@ -1084,6 +1132,65 @@ session_accounting(Config) ->
 
     ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
     meck_validate(Config),
+    ok.
+
+%%--------------------------------------------------------------------
+
+maps_recusive_merge(Key, Value, Map) ->
+    maps:update_with(Key, fun(V) -> maps_recusive_merge(V, Value) end, Value, Map).
+
+maps_recusive_merge(M1, M2)
+  when is_map(M1) andalso is_map(M1) ->
+    maps:fold(fun maps_recusive_merge/3, M1, M2);
+maps_recusive_merge(_, New) ->
+    New.
+
+cfg_get_value([], Cfg) ->
+    Cfg;
+cfg_get_value([H|T], Cfg) when is_map(Cfg) ->
+    cfg_get_value(T, maps:get(H, Cfg));
+cfg_get_value([H|T], Cfg) when is_list(Cfg) ->
+    cfg_get_value(T, proplists:get_value(H, Cfg)).
+
+gy_validity_timer() ->
+    [{doc, "Check Validity-Timer attached to MSCC"}].
+gy_validity_timer(Config) ->
+    {ok, Cfg0} = application:get_env(ergw_aaa, apps),
+    Session = cfg_get_value([default, session, 'Default'], Cfg0),
+    UpdCfg =
+	#{default =>
+	      #{procedures =>
+		    #{
+		      {gy, 'CCR-Initial'} =>
+			  [{'Default', Session#{answer => 'Initial-OCS'}}],
+		      {gy, 'CCR-Update'} =>
+			  [{'Default', Session#{answer => 'Update-OCS'}}]
+		     }
+	       }
+	 },
+    Cfg = maps_recusive_merge(Cfg0, UpdCfg),
+    ok = application:set_env(ergw_aaa, apps, Cfg),
+    ct:pal("Cfg: ~p", [Cfg]),
+
+    {GtpC, _, _} = create_pdp_context(Config),
+    ct:sleep({seconds, 10}),
+    delete_pdp_context(GtpC),
+
+    ?match(X when X >= 3, meck:num_calls(?HUT, handle_info, [{pfcp_timer, '_'}, '_'])),
+
+    CCRU = lists:foldl(
+	     fun({_, {ergw_aaa_session, invoke, [_, S, {gy,'CCR-Update'}, _]}, _}, Acc) ->
+		     ?match(#{used_credits := [{3000, #{'Reporting-Reason' := [4]}}]}, S),
+		     [S|Acc];
+		(_, Acc) -> Acc
+	     end, [], meck:history(ergw_aaa_session)),
+    ?match(X when X >= 3, length(CCRU)),
+
+    ?equal([], outstanding_requests()),
+    ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
+    meck_validate(Config),
+
+    ok = application:set_env(ergw_aaa, apps, Cfg0),
     ok.
 
 %%%===================================================================

--- a/test/saegw_s11_SUITE.erl
+++ b/test/saegw_s11_SUITE.erl
@@ -115,7 +115,8 @@
 		]},
 
 	 {ergw_aaa,
-	  [{handlers,
+	  [
+	   {handlers,
 	    [{ergw_aaa_static,
 	      [{'NAS-Identifier',          <<"NAS-Identifier">>},
 	       {'Node-Id',                 <<"PGW-001">>},
@@ -137,8 +138,55 @@
 	       }
 	      ]}
 	    ]},
-	   {services, [{'Default', [{handler, 'ergw_aaa_static'}]}]},
-	   {apps, [{default, [{session, ['Default']}]}]}
+	   {services,
+	    [{'Default', [{handler, 'ergw_aaa_static'},
+			  {answers, #{'Initial-OCS' =>
+					  #{'Result-Code' => [2001],
+					    'Multiple-Services-Credit-Control' =>
+						[#{'Envelope-Reporting' => [0],
+						   'Granted-Service-Unit' =>
+						       [#{'CC-Time' => [3600],
+							  'CC-Total-Octets' => [102400]}],
+						   'Rating-Group' => [3000],
+						   'Validity-Time' => [2],
+						   'Result-Code' => [2001],
+						   'Time-Quota-Threshold' => [60],
+						   'Volume-Quota-Threshold' => [10240]}
+						]
+					   },
+				      'Update-OCS' =>
+					  #{'Result-Code' => [2001],
+					    'Multiple-Services-Credit-Control' =>
+						[#{'Envelope-Reporting' => [0],
+						   'Granted-Service-Unit' =>
+						       [#{'CC-Time' => [3600],
+							  'CC-Total-Octets' => [102400]}],
+						   'Rating-Group' => [3000],
+						   'Validity-Time' => [2],
+						   'Result-Code' => [2001],
+						   'Time-Quota-Threshold' => [60],
+						   'Volume-Quota-Threshold' => [10240]}
+						]
+					   }
+				     }
+			  }
+			 ]}
+	    ]},
+	   {apps,
+	    [{default,
+	      [{session, ['Default']},
+	       {procedures, [{authenticate, []},
+			     {authorize, []},
+			     {start, []},
+			     {interim, []},
+			     {stop, []},
+			     {{gy, 'CCR-Initial'},   []},
+			     {{gy, 'CCR-Update'},    []},
+			     %%{{gy, 'CCR-Update'},    [{'Default', [{answer, 'Update-If-Down'}]}]},
+			     {{gy, 'CCR-Terminate'}, []}
+			    ]}
+	      ]}
+	    ]}
 	  ]}
 	]).
 
@@ -212,7 +260,8 @@ common() ->
      unsupported_request,
      create_session_overload,
      session_options,
-     enb_connection_suspend
+     enb_connection_suspend,
+     gy_validity_timer
     ].
 
 groups() ->
@@ -797,6 +846,65 @@ enb_connection_suspend(Config) ->
 
     ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
     meck_validate(Config),
+    ok.
+
+%%--------------------------------------------------------------------
+
+maps_recusive_merge(Key, Value, Map) ->
+    maps:update_with(Key, fun(V) -> maps_recusive_merge(V, Value) end, Value, Map).
+
+maps_recusive_merge(M1, M2)
+  when is_map(M1) andalso is_map(M1) ->
+    maps:fold(fun maps_recusive_merge/3, M1, M2);
+maps_recusive_merge(_, New) ->
+    New.
+
+cfg_get_value([], Cfg) ->
+    Cfg;
+cfg_get_value([H|T], Cfg) when is_map(Cfg) ->
+    cfg_get_value(T, maps:get(H, Cfg));
+cfg_get_value([H|T], Cfg) when is_list(Cfg) ->
+    cfg_get_value(T, proplists:get_value(H, Cfg)).
+
+gy_validity_timer() ->
+    [{doc, "Check Validity-Timer attached to MSCC"}].
+gy_validity_timer(Config) ->
+    {ok, Cfg0} = application:get_env(ergw_aaa, apps),
+    Session = cfg_get_value([default, session, 'Default'], Cfg0),
+    UpdCfg =
+	#{default =>
+	      #{procedures =>
+		    #{
+		      {gy, 'CCR-Initial'} =>
+			  [{'Default', Session#{answer => 'Initial-OCS'}}],
+		      {gy, 'CCR-Update'} =>
+			  [{'Default', Session#{answer => 'Update-OCS'}}]
+		     }
+	       }
+	 },
+    Cfg = maps_recusive_merge(Cfg0, UpdCfg),
+    ok = application:set_env(ergw_aaa, apps, Cfg),
+    ct:pal("Cfg: ~p", [Cfg]),
+
+    {GtpC, _, _} = create_session(Config),
+    ct:sleep({seconds, 10}),
+    delete_session(GtpC),
+
+    ?match(X when X >= 3, meck:num_calls(?HUT, handle_info, [{pfcp_timer, '_'}, '_'])),
+
+    CCRU = lists:foldl(
+	     fun({_, {ergw_aaa_session, invoke, [_, S, {gy,'CCR-Update'}, _]}, _}, Acc) ->
+		     ?match(#{used_credits := [{3000, #{'Reporting-Reason' := [4]}}]}, S),
+		     [S|Acc];
+		(_, Acc) -> Acc
+	     end, [], meck:history(ergw_aaa_session)),
+    ?match(X when X >= 3, length(CCRU)),
+
+    ?equal([], outstanding_requests()),
+    ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
+    meck_validate(Config),
+
+    ok = application:set_env(ergw_aaa, apps, Cfg0),
     ok.
 
 %%%===================================================================


### PR DESCRIPTION
Handle Validity-Timer in C-node. The timer is started after the CCA
is received (as defined in RFC 4006).