### PR TITLE
API for deleting multiple GTP contexts

### DIFF
--- a/src/ergw_api.erl
+++ b/src/ergw_api.erl
@@ -8,7 +8,7 @@
 -module(ergw_api).
 
 %% API
--export([peer/1, tunnel/1]).
+-export([peer/1, tunnel/1, contexts/1, delete_contexts/1]).
 
 %%%===================================================================
 %%% API
@@ -25,15 +25,22 @@ peer(Port) when is_atom(Port) ->
     collect_peer_info(gtp_path_reg:all(Port)).
 
 tunnel(all) ->
-    Contexts = lists:usort([Pid || {{_Socket, {teid, 'gtp-c', _TEID}}, {_, Pid}}
-				       <- gtp_context_reg:all(), is_pid(Pid)]),
-    lists:foldl(fun collect_contexts/2, [], Contexts);
+    lists:foldl(fun collect_contexts/2, [], contexts(all));
 tunnel({_,_,_,_} = IP) ->
     lists:foldl(fun collext_path_contexts/2, [], gtp_path_reg:all(IP));
 tunnel({_,_,_,_,_,_,_,_} = IP) ->
     lists:foldl(fun collext_path_contexts/2, [], gtp_path_reg:all(IP));
 tunnel(Port) when is_atom(Port) ->
     lists:foldl(fun collext_path_contexts/2, [], gtp_path_reg:all(Port)).
+
+contexts(all) ->
+    lists:usort([Pid || {{_Socket, {teid, 'gtp-c', _TEID}}, {_, Pid}}
+				       <- gtp_context_reg:all(), is_pid(Pid)]).
+
+delete_contexts(Count) ->
+    Contexts = lists:sublist(contexts(all), Count),
+    lists:foreach(fun(Pid) -> gtp_context:delete_context(Pid) end, Contexts).
+
 
 %%%===================================================================
 %%% Internal functions

--- a/src/ergw_http_api.erl
+++ b/src/ergw_http_api.erl
@@ -29,6 +29,7 @@ start_http_listener(#{ip := IP, port := Port, acceptors_num := AcceptorsNum}) ->
 		    {"/api/v1/status", http_api_handler, []},
 		    {"/api/v1/status/accept-new", http_api_handler, []},
 		    {"/api/v1/status/accept-new/:value", http_api_handler, []},
+		    {"/api/v1/contexts/:count", http_api_handler, []},
 		    {"/metrics", http_api_handler, []},
 		    {"/metrics/[...]", http_api_handler, []},
 		    %% serves static files for swagger UI


### PR DESCRIPTION
In order to drain a PGW from GTP contexts in batches of N, `gtp_context:delete_context/1` needs to be called N times.

This PR implements APIs for this behaviour:

* a public one via the REST-API:  DELETE /api/v1/contexts/<count>
* an ergw-internal one in `ergw_api:delete_contexts/1`

Technical note:  `delete_context` will send a `delete_bearer_request` to the SGW with `reactivation requested`.