### PR TITLE
ensure context IP's are always released when the context terminates

### DIFF
--- a/src/gtp_context.erl
+++ b/src/gtp_context.erl
@@ -444,11 +444,15 @@ code_change(_OldVsn, State, _Extra) ->
 log_ctx_error(#ctx_err{level = Level, where = {File, Line}, reply = Reply}) ->
     lager:debug("CtxErr: ~w, at ~s:~w, ~p", [Level, File, Line, Reply]).
 
-handle_ctx_error(#ctx_err{level = Level} = CtxErr, State) ->
+handle_ctx_error(#ctx_err{level = Level, context = Context} = CtxErr, State) ->
     log_ctx_error(CtxErr),
     case Level of
+	?FATAL when is_record(Context, context) ->
+	    {stop, normal, State#{context => Context}};
 	?FATAL ->
 	    {stop, normal, State};
+	_ when is_record(Context, context) ->
+	    {noreply, State#{context => Context}};
 	_ ->
 	    {noreply, State}
     end.

--- a/src/pgw_s5s8.erl
+++ b/src/pgw_s5s8.erl
@@ -542,7 +542,8 @@ handle_response({From, TermCause},
     end,
     {stop, State#{context := Context}}.
 
-terminate(_Reason, _State) ->
+terminate(_Reason, #{context := Context}) ->
+    pdn_release_ip(Context),
     ok.
 
 %%%===================================================================
@@ -631,8 +632,12 @@ encode_paa({IPv4,_}, IPv6) ->
 encode_paa(Type, IPv4, IPv6) ->
     #v2_pdn_address_allocation{type = Type, address = <<IPv6/binary, IPv4/binary>>}.
 
-pdn_release_ip(#context{vrf = VRF, ms_v4 = MSv4, ms_v6 = MSv6}) ->
-    vrf:release_pdp_ip(VRF, MSv4, MSv6).
+pdn_release_ip(#context{vrf = VRF, ms_v4 = MSv4, ms_v6 = MSv6} = Context)
+  when MSv4 /= undefined; MSv6 /= undefined ->
+    vrf:release_pdp_ip(VRF, MSv4, MSv6),
+    Context#context{ms_v4 = undefined, ms_v6 = undefined};
+pdn_release_ip(Context) ->
+    Context.
 
 close_pdn_context(Reason, #{context := Context, pfcp := PCtx, 'Session' := Session}) ->
     URRs = ergw_gsn_lib:delete_sgi_session(Reason, Context, PCtx),
@@ -669,8 +674,7 @@ close_pdn_context(Reason, #{context := Context, pfcp := PCtx, 'Session' := Sessi
     ergw_gsn_lib:process_offline_charging_events(ChargeEv, Offline, Now, Session),
 
     %% ===========================================================================
-
-    pdn_release_ip(Context).
+    ok.
 
 query_usage_report(#{'Rating-Group' := [RatingGroup]}, Context, PCtx) ->
     ChargingKeys = [{online, RatingGroup}],
@@ -1085,9 +1089,10 @@ maybe_ip(Key, {{_,_,_,_,_,_,_,_},_} = IPv6, SessionIP) ->
 maybe_ip(_, _, SessionIP) ->
     SessionIP.
 
-assign_ips(SessionOps, PAA, #context{vrf = VRF, local_control_tei = LocalTEI} = Context) ->
+assign_ips(SessionOps, PAA, #context{vrf = VRF, local_control_tei = LocalTEI} = Context0) ->
     {PDNType, ReqMSv4, ReqMSv6} = session_ip_alloc(SessionOps, pdn_alloc(PAA)),
     {ok, MSv4, MSv6} = vrf:allocate_pdp_ip(VRF, LocalTEI, ReqMSv4, ReqMSv6),
+    Context = Context0#context{ms_v4 = MSv4, ms_v6 = MSv6},
     case PDNType of
 	ipv4v6 when MSv4 /= undefined, MSv6 /= undefined ->
 	    ok;
@@ -1100,7 +1105,7 @@ assign_ips(SessionOps, PAA, #context{vrf = VRF, local_control_tei = LocalTEI} = 
     end,
     SessionIP4 = maybe_ip('Framed-IP-Address', MSv4, #{}),
     SessionIP = maybe_ip('Framed-IPv6-Prefix', MSv6, SessionIP4),
-    {SessionIP, Context#context{ms_v4 = MSv4, ms_v6 = MSv6}}.
+    {SessionIP, Context}.
 
 session_to_context(SessionOpts, Context) ->
     %% RFC 6911

--- a/test/pgw_SUITE.erl
+++ b/test/pgw_SUITE.erl
@@ -538,6 +538,9 @@ end_per_testcase(Config) ->
     stop_gtpc_server(),
     stop_all_sx_nodes(),
 
+    FreeP = [pool, <<"upstream">>, ipv4, {10,180,0,1}, free],
+    match_exo_value(FreeP, 65534),
+
     AppsCfg = proplists:get_value(aaa_cfg, Config),
     ok = application:set_env(ergw_aaa, apps, AppsCfg),
     ok.
@@ -651,7 +654,18 @@ create_session_request_gx_fail(Config) ->
 create_session_request_gy_fail() ->
     [{doc, "Check Gy failure on Create Session Request"}].
 create_session_request_gy_fail(Config) ->
+    FreeP = [pool, <<"upstream">>, ipv4, {10,180,0,1}, free],
+    UsedP = [pool, <<"upstream">>, ipv4, {10,180,0,1}, used],
+
+    match_exo_value(FreeP, 65534),
+    match_exo_value(UsedP, 0),
+
     create_session(gy_fail, Config),
+
+    ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
+
+    match_exo_value(FreeP, 65534),
+    match_exo_value(UsedP, 0),
 
     meck_validate(Config),
     ok.
@@ -682,25 +696,19 @@ create_session_request_pool_exhausted() ->
     [{doc, "Dynamic IP pool exhausted"}].
 create_session_request_pool_exhausted(Config) ->
     ok = meck:expect(vrf, allocate_pdp_ip,
-		     fun(VRF, TEI, ReqIPv4, ReqIPv6) ->
-			     {ok, _IPv4, IPv6} =
-				 meck:passthrough([VRF, TEI, ReqIPv4, ReqIPv6]),
-			     {ok, undefined, IPv6}
+		     fun(VRF, TEI, ReqIPv4, _ReqIPv6) ->
+			     meck:passthrough([VRF, TEI, ReqIPv4, undefined])
 		     end),
     create_session(pool_exhausted, Config),
 
     ok = meck:expect(vrf, allocate_pdp_ip,
-		     fun(VRF, TEI, ReqIPv4, ReqIPv6) ->
-			     {ok, IPv4, _IPv6} =
-				 meck:passthrough([VRF, TEI, ReqIPv4, ReqIPv6]),
-			     {ok, IPv4, undefined}
+		     fun(VRF, TEI, _ReqIPv4, ReqIPv6) ->
+			     meck:passthrough([VRF, TEI, undefined, ReqIPv6])
 		     end),
     create_session(pool_exhausted, Config),
 
     ok = meck:expect(vrf, allocate_pdp_ip,
-		     fun(VRF, TEI, ReqIPv4, ReqIPv6) ->
-			     {ok, _IPv4, _IPv6} =
-				 meck:passthrough([VRF, TEI, ReqIPv4, ReqIPv6]),
+		     fun(_VRF, _TEI, _ReqIPv4, _ReqIPv6) ->
 			     {ok, undefined, undefined}
 		     end),
     create_session(pool_exhausted, Config),
@@ -797,11 +805,24 @@ path_restart_multi(Config) ->
 simple_session_request() ->
     [{doc, "Check simple Create Session, Delete Session sequence"}].
 simple_session_request(Config) ->
+    FreeP = [pool, <<"upstream">>, ipv4, {10,180,0,1}, free],
+    UsedP = [pool, <<"upstream">>, ipv4, {10,180,0,1}, used],
+
+    match_exo_value(FreeP, 65534),
+    match_exo_value(UsedP, 0),
+
     {GtpC, _, _} = create_session(Config),
+
+    match_exo_value(FreeP, 65533),
+    match_exo_value(UsedP, 1),
+
     delete_session(GtpC),
 
     ?equal([], outstanding_requests()),
     ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
+
+    match_exo_value(FreeP, 65534),
+    match_exo_value(UsedP, 0),
 
     [_, SER|_] = lists:filter(
 		   fun(#pfcp{type = session_establishment_request}) -> true;


### PR DESCRIPTION
* release the IP in the terminate handler and make sure the context
  always record allocated UE IPs.
* add exometer metrics
* add test cases