### PR TITLE
Fix metric name of IP pool in metrics

### DIFF
--- a/src/http_api_handler.erl
+++ b/src/http_api_handler.erl
@@ -189,13 +189,15 @@ ioize({_,_,_,_} = IP) ->
     list_to_binary(inet:ntoa(IP));
 ioize({_,_,_,_,_,_,_,_} = IP) ->
     list_to_binary(inet:ntoa(IP));
+ioize(Bin) when is_binary(Bin) ->
+    Bin;
 ioize(Something) ->
     iolist_to_binary(io_lib:format("~p", [Something])).
 
 make_metric_name(Path) ->
     NameList = lists:join($_, lists:map(fun ioize/1, Path)),
     NameBin = iolist_to_binary(NameList),
-    re:replace(NameBin, "-|\\.", "_", [global, {return,binary}]).
+    re:replace(NameBin, "-|\\.|:", "_", [global, {return,binary}]).
 
 map_type(undefined)     -> <<"untyped">>;
 map_type(counter)       -> <<"counter">>;


### PR DESCRIPTION
8cf5938 introduced IP pool metrics. Upon accessing these metrics via the
Prometheus format, the following invalid metric name is created:

    pool_<<"sgi">>_ipv4_10_0_0_1_free 262112

The invalid part `<<"sgi">>` is caused by http_api_handler:ioize/1. This
commit fixes the function to produce:

    pool_sgi_ipv4_10_0_0_1_free 262112

In addition, pools for IPv6 addresses would create an invalid metric
name for Prometheus (see [1]). By converting the ":" to "_", this is
fixed as well.

[1]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels