### PR TITLE
Fix validation of exometer counters in test suites

### DIFF
--- a/test/ergw_test_lib.erl
+++ b/test/ergw_test_lib.erl
@@ -33,7 +33,7 @@
 -export([pretty_print/1]).
 -export([set_cfg_value/3, add_cfg_value/3]).
 -export([outstanding_requests/0, wait4tunnels/1, hexstr2bin/1]).
--export([match_exo_value/2, get_exo_value/1]).
+-export([match_exo_value/5, get_exo_value/1]).
 -export([has_ipv6_test_config/0]).
 -export([query_usage_report/2]).
 -export([match_map/4]).
@@ -490,8 +490,19 @@ mkint(C) when $a =< C, C =< $f ->
 %%% Exometer helpers
 %%%===================================================================
 
-match_exo_value(Path, Expect) ->
-    ?equal(Expect, get_exo_value(Path)).
+
+match_exo_value(Path, Expected, File, Line, Cnt) ->
+    case get_exo_value(Path) of
+	Expected ->
+	    ok;
+	_ when Cnt > 0 ->
+	    ct:sleep(100),
+	    match_exo_value(Path, Expected, File, Line, Cnt - 1);
+	Actual ->
+	    ct:pal("EXOMETER VALUE MISMATCH(~s:~b)~nExpected: ~p~nActual:   ~p~n",
+		   [?FILE, ?LINE, Expected, Actual]),
+	    error(badmatch)
+    end.
 
 get_exo_value(Path) ->
     {ok, Value} = exometer:get_value(Path),

--- a/test/ergw_test_lib.hrl
+++ b/test/ergw_test_lib.hrl
@@ -124,3 +124,6 @@
 	  end)())).
 
 -define(match_map(Expected, Actual), ergw_test_lib:match_map(Expected, Actual, ?FILE, ?LINE)).
+
+-define(match_exo_value(Expected, Actual),
+	ergw_test_lib:match_exo_value(Expected, Actual, ?FILE, ?LINE, 10)).

--- a/test/ggsn_SUITE.erl
+++ b/test/ggsn_SUITE.erl
@@ -446,7 +446,7 @@ end_per_testcase(_Config) ->
     stop_gtpc_server(),
 
     FreeP = [pool, <<"upstream">>, ipv4, {10,180,0,1}, free],
-    match_exo_value(FreeP, 65534),
+    ?match_exo_value(FreeP, 65534),
 
     ok.
 
@@ -565,8 +565,8 @@ create_pdp_context_request_gy_fail(Config) ->
     FreeP = [pool, <<"upstream">>, ipv4, {10,180,0,1}, free],
     UsedP = [pool, <<"upstream">>, ipv4, {10,180,0,1}, used],
 
-    match_exo_value(FreeP, 65534),
-    match_exo_value(UsedP, 0),
+    ?match_exo_value(FreeP, 65534),
+    ?match_exo_value(UsedP, 0),
 
     MetricsBefore = socket_counter_metrics(),
 
@@ -575,8 +575,10 @@ create_pdp_context_request_gy_fail(Config) ->
     MetricsAfter = socket_counter_metrics(),
     ?equal([], outstanding_requests()),
 
-    match_exo_value(FreeP, 65534),
-    match_exo_value(UsedP, 0),
+    ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
+
+    ?match_exo_value(FreeP, 65534),
+    ?match_exo_value(UsedP, 0),
 
     socket_counter_metrics_ok( MetricsBefore, MetricsAfter, create_pdp_context_request ),
     socket_counter_metrics_ok( MetricsBefore, MetricsAfter, system_failure ), % In response
@@ -733,15 +735,15 @@ simple_pdp_context_request(Config) ->
     FreeP = [pool, <<"upstream">>, ipv4, {10,180,0,1}, free],
     UsedP = [pool, <<"upstream">>, ipv4, {10,180,0,1}, used],
 
-    match_exo_value(FreeP, 65534),
-    match_exo_value(UsedP, 0),
+    ?match_exo_value(FreeP, 65534),
+    ?match_exo_value(UsedP, 0),
 
     MetricsBefore = socket_counter_metrics(),
     {GtpC, _, _} = create_pdp_context(Config),
     MetricsAfter = socket_counter_metrics(),
 
-    match_exo_value(FreeP, 65533),
-    match_exo_value(UsedP, 1),
+    ?match_exo_value(FreeP, 65533),
+    ?match_exo_value(UsedP, 1),
 
     delete_pdp_context(GtpC),
 
@@ -751,8 +753,8 @@ simple_pdp_context_request(Config) ->
     socket_counter_metrics_ok( MetricsBefore, MetricsAfter, create_pdp_context_request ),
     socket_counter_metrics_ok( MetricsBefore, MetricsAfter, request_accepted ), % In response
 
-    match_exo_value(FreeP, 65534),
-    match_exo_value(UsedP, 0),
+    ?match_exo_value(FreeP, 65534),
+    ?match_exo_value(UsedP, 0),
 
     meck_validate(Config),
     ok.
@@ -862,15 +864,16 @@ create_pdp_context_request_resend(Config) ->
     Dup0 = get_exo_value(DupId),
 
     {GtpC, Msg, Response} = create_pdp_context(Config),
-    match_exo_value(CntId, Cnt0 + 1),
+    ?match_exo_value(CntId, Cnt0 + 1),
     ?equal(Response, send_recv_pdu(GtpC, Msg)),
     ?equal([], outstanding_requests()),
 
     delete_pdp_context(GtpC),
-    match_exo_value(DupId, Dup0 + 1),
 
     ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
     ?match(0, meck:num_calls(?HUT, handle_request, ['_', '_', true, '_'])),
+
+    ?match_exo_value(DupId, Dup0 + 1),
     meck_validate(Config),
     ok.
 

--- a/test/pgw_SUITE.erl
+++ b/test/pgw_SUITE.erl
@@ -539,7 +539,7 @@ end_per_testcase(Config) ->
     stop_all_sx_nodes(),
 
     FreeP = [pool, <<"upstream">>, ipv4, {10,180,0,1}, free],
-    match_exo_value(FreeP, 65534),
+    ?match_exo_value(FreeP, 65534),
 
     AppsCfg = proplists:get_value(aaa_cfg, Config),
     ok = application:set_env(ergw_aaa, apps, AppsCfg),
@@ -657,15 +657,15 @@ create_session_request_gy_fail(Config) ->
     FreeP = [pool, <<"upstream">>, ipv4, {10,180,0,1}, free],
     UsedP = [pool, <<"upstream">>, ipv4, {10,180,0,1}, used],
 
-    match_exo_value(FreeP, 65534),
-    match_exo_value(UsedP, 0),
+    ?match_exo_value(FreeP, 65534),
+    ?match_exo_value(UsedP, 0),
 
     create_session(gy_fail, Config),
 
     ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
 
-    match_exo_value(FreeP, 65534),
-    match_exo_value(UsedP, 0),
+    ?match_exo_value(FreeP, 65534),
+    ?match_exo_value(UsedP, 0),
 
     meck_validate(Config),
     ok.
@@ -808,21 +808,21 @@ simple_session_request(Config) ->
     FreeP = [pool, <<"upstream">>, ipv4, {10,180,0,1}, free],
     UsedP = [pool, <<"upstream">>, ipv4, {10,180,0,1}, used],
 
-    match_exo_value(FreeP, 65534),
-    match_exo_value(UsedP, 0),
+    ?match_exo_value(FreeP, 65534),
+    ?match_exo_value(UsedP, 0),
 
     {GtpC, _, _} = create_session(Config),
 
-    match_exo_value(FreeP, 65533),
-    match_exo_value(UsedP, 1),
+    ?match_exo_value(FreeP, 65533),
+    ?match_exo_value(UsedP, 1),
 
     delete_session(GtpC),
 
     ?equal([], outstanding_requests()),
     ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
 
-    match_exo_value(FreeP, 65534),
-    match_exo_value(UsedP, 0),
+    ?match_exo_value(FreeP, 65534),
+    ?match_exo_value(UsedP, 0),
 
     [_, SER|_] = lists:filter(
 		   fun(#pfcp{type = session_establishment_request}) -> true;
@@ -1598,10 +1598,10 @@ interop_sgsn_to_sgw(Config) ->
     ClientIP = proplists:get_value(client_ip, Config),
 
     {GtpC1, _, _} = ergw_ggsn_test_lib:create_pdp_context(Config),
-    match_exo_value([path, 'irx-socket', ClientIP, contexts, v1], 1),
+    ?match_exo_value([path, 'irx-socket', ClientIP, contexts, v1], 1),
     {GtpC2, _, _} = modify_bearer(tei_update, GtpC1),
-    match_exo_value([path, 'irx-socket', ClientIP, contexts, v1], 0),
-    match_exo_value([path, 'irx-socket', ClientIP, contexts, v2], 1),
+    ?match_exo_value([path, 'irx-socket', ClientIP, contexts, v1], 0),
+    ?match_exo_value([path, 'irx-socket', ClientIP, contexts, v2], 1),
     delete_session(GtpC2),
 
     [SMR0|_] = lists:filter(
@@ -1621,8 +1621,8 @@ interop_sgsn_to_sgw(Config) ->
     meck_validate(Config),
     true = meck:validate(ggsn_gn),
 
-    match_exo_value([path, 'irx-socket', ClientIP, contexts, v1], 0),
-    match_exo_value([path, 'irx-socket', ClientIP, contexts, v2], 0),
+    ?match_exo_value([path, 'irx-socket', ClientIP, contexts, v1], 0),
+    ?match_exo_value([path, 'irx-socket', ClientIP, contexts, v2], 0),
     ok.
 
 %%--------------------------------------------------------------------
@@ -1645,10 +1645,10 @@ interop_sgw_to_sgsn(Config) ->
     ClientIP = proplists:get_value(client_ip, Config),
 
     {GtpC1, _, _} = create_session(Config),
-    match_exo_value([path, 'irx-socket', ClientIP, contexts, v2], 1),
+    ?match_exo_value([path, 'irx-socket', ClientIP, contexts, v2], 1),
     {GtpC2, _, _} = ergw_ggsn_test_lib:update_pdp_context(tei_update, GtpC1),
-    match_exo_value([path, 'irx-socket', ClientIP, contexts, v1], 1),
-    match_exo_value([path, 'irx-socket', ClientIP, contexts, v2], 0),
+    ?match_exo_value([path, 'irx-socket', ClientIP, contexts, v1], 1),
+    ?match_exo_value([path, 'irx-socket', ClientIP, contexts, v2], 0),
     ergw_ggsn_test_lib:delete_pdp_context(GtpC2),
 
     [SMR0|_] = lists:filter(
@@ -1668,8 +1668,8 @@ interop_sgw_to_sgsn(Config) ->
     meck_validate(Config),
     true = meck:validate(ggsn_gn),
 
-    match_exo_value([path, 'irx-socket', ClientIP, contexts, v1], 0),
-    match_exo_value([path, 'irx-socket', ClientIP, contexts, v2], 0),
+    ?match_exo_value([path, 'irx-socket', ClientIP, contexts, v1], 0),
+    ?match_exo_value([path, 'irx-socket', ClientIP, contexts, v2], 0),
     ok.
 
 %%--------------------------------------------------------------------

--- a/test/saegw_s11_SUITE.erl
+++ b/test/saegw_s11_SUITE.erl
@@ -411,7 +411,7 @@ end_per_testcase(_Config) ->
     stop_gtpc_server(),
 
     FreeP = [pool, <<"upstream">>, ipv4, {10,180,0,1}, free],
-    match_exo_value(FreeP, 65534),
+    ?match_exo_value(FreeP, 65534),
 
     ok.
 
@@ -490,15 +490,15 @@ create_session_request_gy_fail(Config) ->
     FreeP = [pool, <<"upstream">>, ipv4, {10,180,0,1}, free],
     UsedP = [pool, <<"upstream">>, ipv4, {10,180,0,1}, used],
 
-    match_exo_value(FreeP, 65534),
-    match_exo_value(UsedP, 0),
+    ?match_exo_value(FreeP, 65534),
+    ?match_exo_value(UsedP, 0),
 
     create_session(gy_fail, Config),
 
     ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
 
-    match_exo_value(FreeP, 65534),
-    match_exo_value(UsedP, 0),
+    ?match_exo_value(FreeP, 65534),
+    ?match_exo_value(UsedP, 0),
 
     meck_validate(Config),
     ok.
@@ -569,13 +569,13 @@ simple_session_request(Config) ->
     FreeP = [pool, <<"upstream">>, ipv4, {10,180,0,1}, free],
     UsedP = [pool, <<"upstream">>, ipv4, {10,180,0,1}, used],
 
-    match_exo_value(FreeP, 65534),
-    match_exo_value(UsedP, 0),
+    ?match_exo_value(FreeP, 65534),
+    ?match_exo_value(UsedP, 0),
 
     {GtpC1, _, _} = create_session(Config),
 
-    match_exo_value(FreeP, 65533),
-    match_exo_value(UsedP, 1),
+    ?match_exo_value(FreeP, 65533),
+    ?match_exo_value(UsedP, 1),
 
     {GtpC2, _, _} = modify_bearer(enb_u_tei, GtpC1),
     delete_session(GtpC2),
@@ -583,8 +583,8 @@ simple_session_request(Config) ->
     ?equal([], outstanding_requests()),
     ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
 
-    match_exo_value(FreeP, 65534),
-    match_exo_value(UsedP, 0),
+    ?match_exo_value(FreeP, 65534),
+    ?match_exo_value(UsedP, 0),
 
     meck_validate(Config),
     ok.


### PR DESCRIPTION
Some counters depend on shutdown methods that can a few clock
cycles longer. Retry a match on a exometer value at most
10 times.