### PR TITLE
Fix memory regression

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -40,8 +40,7 @@
 		      ]},
 	       {deps, [
 		       {recon, "2.5.0"},
-		       {observer_cli, "1.5.0"},
-		       {entop, {git, "https://github.com/mazenharake/entop.git", {tag, "0.4.2"}}}
+		       {observer_cli, "1.5.0"}
 		      ]}
 	       ]},
 	     {native,
@@ -83,7 +82,6 @@
 	  runtime_tools,
 	  hipe,
 	  recon,
-	  entop,
 	  observer_cli]},
 	{exclude_apps, [wx]},
 


### PR DESCRIPTION
In 4f84f63, *entop* was bumped to 0.4.2. At the same time, it was also
added to a *relx*-release. After seeing massive leaks of memory in
instances deployed in a testlab, recon:bin_leak/1 points to *cecho* for
leaking binaries. The memory usage reported by the Erlang VM itself kept
stable, but the OS level memory usage grew and grew. This memory leaking
stopped completely as soon as `application:stop(cecho)` was called.

As a result, *entop* and its dependency *cecho* are removed from *ergw*
for the time being.