### PR TITLE
Test gy ccr retry and rate limit

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -16,7 +16,7 @@
 	{gtplib, {git, "https://github.com/travelping/gtplib.git", {ref, "f036d98"}}},
 	{pfcplib, {git, "https://github.com/travelping/pfcplib.git", {branch, "master"}}},
 	{gen_socket, {git, "git://github.com/travelping/gen_socket", {ref, "195a427"}}},
-	{ergw_aaa, {git, "git://github.com/travelping/ergw_aaa", {ref, "21457c7"}}}
+	{ergw_aaa, {git, "git://github.com/travelping/ergw_aaa", {tag, "3.1.0"}}}
 ]}.
 
 {minimum_otp_vsn, "21.1"}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -8,7 +8,7 @@
   1},
  {<<"ergw_aaa">>,
   {git,"git://github.com/travelping/ergw_aaa",
-       {ref,"21457c7ea2d89cce38e53970a58e5c0baa05e9a2"}},
+       {ref,"537db8d2b228c74f2dc5518546bc9c3c4ae1cff9"}},
   0},
  {<<"erlando">>,
   {git,"https://github.com/travelping/erlando.git",


### PR DESCRIPTION
Set the ergw_aaa dependency version to 3.1.0 for Gy CCR retry and rate limiting