### PR TITLE
use `git describe` to get a more semver like, readable tag

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,10 +59,14 @@ docker:
   services:
     - docker:dind
   script:
+    - git tag -l
+    - git describe
+    - git describe --always --tags --dirty --first-parent --debug
+    - git reflog
+    - export CI_COMMIT_DESCRIBE=$(git describe)
     - docker login -u gitlab-ci-token -p $CI_BUILD_TOKEN $CI_REGISTRY
-    - docker build -t $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA -f docker/Dockerfile .
-    - docker tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG
+    - docker build -t $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA -t $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG\_$CI_COMMIT_DESCRIBE -f docker/Dockerfile .
     - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
-    - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG
+    - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG\_$CI_COMMIT_DESCRIBE
     - if [ $CI_COMMIT_REF_NAME == "master" ] ; then docker tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA $CI_REGISTRY_IMAGE:latest ; docker push $CI_REGISTRY_IMAGE:latest ; fi
   when: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: required
 dist: xenial
 services:
   - docker
+git:
+  depth: false
 
 language: erlang
 
@@ -48,7 +50,8 @@ jobs:
         - docker build -t $BUILD_IMAGE -f docker/Dockerfile .
       after_success:
         - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-        - export TAG=`if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]; then echo PR-$TRAVIS_PULL_REQUEST_BRANCH\_$TRAVIS_PULL_REQUEST_SHA ; else echo $TRAVIS_BRANCH\_$TRAVIS_COMMIT ; fi`
+        - export GIT_DESCRIBE=`git describe`
+        - export TAG=`if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]; then echo PR-$TRAVIS_PULL_REQUEST_BRANCH\_$TRAVIS_PULL_REQUEST_SHA ; else echo $TRAVIS_BRANCH\_$GIT_DESCRIBE ; fi`
         - export TAG=`echo "$TAG" | sed -e 's,/,-,g'`
         - echo "Docker image $BUILD_IMAGE:$TAG"
         - if [ "$TAG" == "master" ]; then export TAG="latest"; fi


### PR DESCRIPTION
This create more readable image tags for builds from travis-ci.

gitlab CI is using a wrong tag, but that seems to be a gitlab CI bug (https://gitlab.com/gitlab-org/gitlab-ce/issues/61007)