### PR TITLE
make delete_sgi_session always delete the PFCP session

### DIFF
--- a/src/ergw_gsn_lib.erl
+++ b/src/ergw_gsn_lib.erl
@@ -41,7 +41,8 @@
 %%% Sx DP API
 %%%===================================================================
 
-delete_sgi_session(normal, Ctx, PCtx) ->
+delete_sgi_session(Reason, Ctx, PCtx)
+  when Reason /= upf_failure ->
     Req = #pfcp{version = v1, type = session_deletion_request, ie = []},
     case ergw_sx_node:call(PCtx, Req, Ctx) of
 	#pfcp{type = session_deletion_response,


### PR DESCRIPTION
The only reason not to send the deletion request is when
the UPF just failed.