### PR TITLE
fix PFCP sequence number overflow handling

### DIFF
--- a/src/ergw_sx_socket.erl
+++ b/src/ergw_sx_socket.erl
@@ -465,7 +465,7 @@ make_send_req(Address, T1, N1, Msg, CbInfo) ->
       }.
 
 new_sequence_number(Msg, #state{seq_no = SeqNo} = State) ->
-    {Msg#pfcp{seq_no = SeqNo}, State#state{seq_no = SeqNo + 1}}.
+    {Msg#pfcp{seq_no = SeqNo}, State#state{seq_no = (SeqNo + 1) band 16#ffffff}}.
 
 start_request(#send_req{t1 = Timeout, msg = Msg} = SendReq, State) ->
     #pfcp{seq_no = SeqNo} = Msg,


### PR DESCRIPTION
The PFCP sequence number needs to wrap arround at 24bits. The encoding
will cut off any excessive bits, but the resulting shorter sequence
number in the request packet will no longer match the internal (expected)
sequence number.
This mean that the answer could net be matched with request, leading
to a break down of communication.