### PR TITLE
reselect UPF after result of authorization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ before_script:
       sudo ip addr add fd96:dcd2:efdb:41c3::20/64 dev lo;
       sudo ip addr add fd96:dcd2:efdb:41c3::30/64 dev lo;
       sudo ip addr add fd96:dcd2:efdb:41c3::40/64 dev lo;
+      sudo ip addr add fd96:dcd2:efdb:41c3::50/64 dev lo;
     fi
 
 script:

--- a/src/ggsn_gn.erl
+++ b/src/ggsn_gn.erl
@@ -336,15 +336,13 @@ handle_request(ReqKey,
     SessionOpts = init_session_qos(IEs, SessionOpts1),
 
     ergw_sx_node:wait_connect(SxConnectId),
-    {ok, PendingPCtx, NodeCaps} = ergw_sx_node:select_sx_node(Candidates, ContextPreAuth),
+    {UPinfo0, ContextUP} = ergw_gsn_lib:select_upf(Candidates, ContextPreAuth),
 
-    {ContextVRF, APNOpts} = ergw_gsn_lib:select_vrf_and_pool(NodeCaps, ContextPreAuth),
     {ok, ActiveSessionOpts0, AuthSEvs} =
-       authenticate(ContextVRF, Session, SessionOpts, Request),
+	authenticate(ContextUP, Session, SessionOpts, Request),
 
-    %% -----------------------------------------------------------
-    %% TBD: reselect VRF and Pool based on outcome of authenticate
-    %% -----------------------------------------------------------
+    {PendingPCtx, NodeCaps, APNOpts, ContextVRF} =
+	ergw_gsn_lib:reselect_upf(Candidates, ActiveSessionOpts0, ContextUP, UPinfo0),
 
     ActiveSessionOpts1 = apply_session_opts(APNOpts, ActiveSessionOpts0),
     {IPOpts, ContextPending} = assign_ips(ActiveSessionOpts1, EUA, ContextVRF),

--- a/src/gtp_proxy_ds.erl
+++ b/src/gtp_proxy_ds.erl
@@ -89,11 +89,11 @@ handle_call({map, #proxy_info{ggsns = GGSNs0, imsi = IMSI, src_apn = APN} = Prox
 	end,
     ProxyInfo =
 	case ergw_gsn_lib:apn(APN, APNMap) of
-	    {ok, DstAPN} ->
+	    false ->
+		ProxyInfo1;
+	    DstAPN ->
 		ProxyInfo1#proxy_info{
-		  ggsns = [GGSN#proxy_ggsn{dst_apn = DstAPN} || GGSN <- GGSNs0]};
-	    _ ->
-		ProxyInfo1
+		  ggsns = [GGSN#proxy_ggsn{dst_apn = DstAPN} || GGSN <- GGSNs0]}
 	end,
     {reply, {ok, ProxyInfo}, State}.
 

--- a/src/pgw_s5s8.erl
+++ b/src/pgw_s5s8.erl
@@ -368,15 +368,13 @@ handle_request(ReqKey,
     %% SessionOpts = init_session_qos(ReqQoSProfile, SessionOpts1),
 
     ergw_sx_node:wait_connect(SxConnectId),
-    {ok, PendingPCtx, NodeCaps} = ergw_sx_node:select_sx_node(Candidates, ContextPreAuth),
+    {UPinfo0, ContextUP} = ergw_gsn_lib:select_upf(Candidates, ContextPreAuth),
 
-    {ContextVRF, APNOpts} = ergw_gsn_lib:select_vrf_and_pool(NodeCaps, ContextPreAuth),
     {ok, ActiveSessionOpts0, AuthSEvs} =
-	authenticate(ContextVRF, Session, SessionOpts, Request),
+	authenticate(ContextUP, Session, SessionOpts, Request),
 
-    %% -----------------------------------------------------------
-    %% TBD: reselect VRF and Pool based on outcome of authenticate
-    %% -----------------------------------------------------------
+    {PendingPCtx, NodeCaps, APNOpts, ContextVRF} =
+	ergw_gsn_lib:reselect_upf(Candidates, ActiveSessionOpts0, ContextUP, UPinfo0),
 
     ActiveSessionOpts1 = apply_session_opts(APNOpts, ActiveSessionOpts0),
     {IPOpts, ContextPending} = assign_ips(ActiveSessionOpts1, PAA, ContextVRF),

--- a/src/saegw_s11.erl
+++ b/src/saegw_s11.erl
@@ -359,15 +359,13 @@ handle_request(ReqKey,
     %% SessionOpts = init_session_qos(ReqQoSProfile, SessionOpts1),
 
     ergw_sx_node:wait_connect(SxConnectId),
-    {ok, PendingPCtx, NodeCaps} = ergw_sx_node:select_sx_node(Candidates, ContextPreAuth),
+    {UPinfo0, ContextUP} = ergw_gsn_lib:select_upf(Candidates, ContextPreAuth),
 
-    {ContextVRF, APNOpts} = ergw_gsn_lib:select_vrf_and_pool(NodeCaps, ContextPreAuth),
     {ok, ActiveSessionOpts0, AuthSEvs} =
-	authenticate(ContextVRF, Session, SessionOpts, Request),
+	authenticate(ContextUP, Session, SessionOpts, Request),
 
-    %% -----------------------------------------------------------
-    %% TBD: reselect VRF and Pool based on outcome of authenticate
-    %% -----------------------------------------------------------
+    {PendingPCtx, NodeCaps, APNOpts, ContextVRF} =
+	ergw_gsn_lib:reselect_upf(Candidates, ActiveSessionOpts0, ContextUP, UPinfo0),
 
     ActiveSessionOpts1 = apply_session_opts(APNOpts, ActiveSessionOpts0),
     {IPOpts, ContextPending} = assign_ips(ActiveSessionOpts1, PAA, ContextVRF),

--- a/src/tdf.erl
+++ b/src/tdf.erl
@@ -348,8 +348,7 @@ start_session(#data{apn = APN, context = Context0, dp_node = Node,
 		    session = Session, pcc = PCC0} = Data) ->
 
     {ok, PendingPCtx, NodeCaps} = ergw_sx_node:attach(Node, Context0),
-    {ok, OutVrf, _APNOpts} = ergw_gsn_lib:select_vrf(NodeCaps, APN),
-    PendingContext = Context0#tdf_ctx{out_vrf = OutVrf},
+    PendingContext = Context0#tdf_ctx{out_vrf = ergw_gsn_lib:select_vrf(NodeCaps, APN)},
 
     Now = erlang:monotonic_time(),
     SOpts = #{now => Now},

--- a/test/bench_SUITE.erl
+++ b/test/bench_SUITE.erl
@@ -344,7 +344,7 @@
 	 {[node_selection, {default, 2}, 2, "topon.s5s8.pgw.$ORIGIN"],
 	  {fun node_sel_update/2, final_gsn}},
 	 {[node_selection, {default, 2}, 2, "topon.sx.prox01.$ORIGIN"],
-	  {fun node_sel_update/2, pgw_u_sx}}
+	  {fun node_sel_update/2, pgw_u01_sx}}
 	]).
 
 node_sel_update(Node, {_,_,_,_} = IP) ->
@@ -377,7 +377,7 @@ bench_init_per_group(Config0) ->
     [application:load(App) || App <- [cowboy, ergw, ergw_aaa]],
     load_config(AppCfg),
     {ok, _} = application:ensure_all_started(ergw),
-    {ok, _} = ergw_test_sx_up:start('pgw-u', proplists:get_value(pgw_u_sx, Config)),
+    {ok, _} = ergw_test_sx_up:start('pgw-u01', proplists:get_value(pgw_u01_sx, Config)),
     {ok, _} = ergw_test_sx_up:start('sgw-u', proplists:get_value(sgw_u_sx, Config)),
     {ok, AppsCfg} = application:get_env(ergw_aaa, apps),
     [{aaa_cfg, AppsCfg} |Config].
@@ -395,7 +395,7 @@ init_per_group(ipv4, Config0) ->
     bench_init_per_group(Config).
 
 bench_end_per_group(Config) ->
-    ok = ergw_test_sx_up:stop('pgw-u'),
+    ok = ergw_test_sx_up:stop('pgw-u01'),
     ok = ergw_test_sx_up:stop('sgw-u'),
     ?config(table_owner, Config) ! stop,
     [application:stop(App) || App <- [ranch, cowboy, ergw, ergw_aaa]],
@@ -421,8 +421,8 @@ all() ->
 %%%===================================================================
 
 init_per_testcase(Config) ->
-    ergw_test_sx_up:reset('pgw-u'),
-    ergw_test_sx_up:history('pgw-u', false),
+    ergw_test_sx_up:reset('pgw-u01'),
+    ergw_test_sx_up:history('pgw-u01', false),
     start_gtpc_server(Config),
     reconnect_all_sx_nodes(),
     ok.

--- a/test/ergw_http_api_SUITE.erl
+++ b/test/ergw_http_api_SUITE.erl
@@ -21,7 +21,7 @@
 	 {[node_selection, {default, 2}, 2, "topon.gn.ggsn.$ORIGIN"],
 	  {fun node_sel_update/2, final_gsn}},
 	 {[node_selection, {default, 2}, 2, "topon.sx.prox01.$ORIGIN"],
-	  {fun node_sel_update/2, pgw_u_sx}}
+	  {fun node_sel_update/2, pgw_u01_sx}}
 	]).
 
 -define(TEST_CONFIG,
@@ -154,7 +154,7 @@ init_per_testcase(Config) ->
     meck_reset(Config).
 init_per_testcase(http_api_delete_sessions, Config) ->
     ct:pal("Sockets: ~p", [ergw_gtp_socket_reg:all()]),
-    ergw_test_sx_up:reset('pgw-u'),
+    ergw_test_sx_up:reset('pgw-u01'),
     meck_reset(Config),
     start_gtpc_server(Config),
     Config;

--- a/test/ergw_test_lib.erl
+++ b/test/ergw_test_lib.erl
@@ -184,10 +184,10 @@ meck_init(Config) ->
 				     meck:exception(throw, CtxErr)
 			     end
 		     end),
-    ok = meck:expect(ergw_gsn_lib, select_vrf_and_pool,
-		     fun(NodeCaps, Context) ->
+    ok = meck:expect(ergw_gsn_lib, select_upf,
+		     fun(Candidates, Context) ->
 			     try
-				 meck:passthrough([NodeCaps, Context])
+				 meck:passthrough([Candidates, Context])
 			     catch
 				 throw:#ctx_err{} = CtxErr ->
 				     meck:exception(throw, CtxErr)

--- a/test/ergw_test_lib.hrl
+++ b/test/ergw_test_lib.hrl
@@ -44,7 +44,8 @@
 -define(FINAL_GSN_IPv4, {127,0,200,1}).
 
 -define(SGW_U_SX_IPv4, {127,0,100,1}).
--define(PGW_U_SX_IPv4, {127,0,200,1}).
+-define(PGW_U01_SX_IPv4, {127,0,200,1}).
+-define(PGW_U02_SX_IPv4, {127,0,200,2}).
 -define(TDF_U_SX_IPv4, {127,0,210,1}).
 
 -define(LOCALHOST_IPv6, {0,0,0,0,0,0,0,1}).
@@ -54,8 +55,9 @@
 -define(FINAL_GSN_IPv6, {16#fd96, 16#dcd2, 16#efdb, 16#41c3, 0, 0, 0, 16#30}).
 
 -define(SGW_U_SX_IPv6, {16#fd96, 16#dcd2, 16#efdb, 16#41c3, 0, 0, 0, 16#20}).
--define(PGW_U_SX_IPv6, {16#fd96, 16#dcd2, 16#efdb, 16#41c3, 0, 0, 0, 16#30}).
--define(TDF_U_SX_IPv6, {16#fd96, 16#dcd2, 16#efdb, 16#41c3, 0, 0, 0, 16#40}).
+-define(PGW_U01_SX_IPv6, {16#fd96, 16#dcd2, 16#efdb, 16#41c3, 0, 0, 0, 16#30}).
+-define(PGW_U02_SX_IPv6, {16#fd96, 16#dcd2, 16#efdb, 16#41c3, 0, 0, 0, 16#40}).
+-define(TDF_U_SX_IPv6, {16#fd96, 16#dcd2, 16#efdb, 16#41c3, 0, 0, 0, 16#50}).
 
 -define('APN-EXAMPLE', [<<"example">>, <<"net">>]).
 -define('APN-ExAmPlE', [<<"eXaMpLe">>, <<"net">>]).

--- a/test/ggsn_SUITE.erl
+++ b/test/ggsn_SUITE.erl
@@ -348,7 +348,7 @@
 	 {[node_selection, {default, 2}, 2, "topon.gn.ggsn.$ORIGIN"],
 	  {fun node_sel_update/2, final_gsn}},
 	 {[node_selection, {default, 2}, 2, "topon.sx.prox01.$ORIGIN"],
-	  {fun node_sel_update/2, pgw_u_sx}},
+	  {fun node_sel_update/2, pgw_u01_sx}},
 	 {[node_selection, {default, 2}, 2, "topon.sx.prox02.$ORIGIN"],
 	  {fun node_sel_update/2, sgw_u_sx}}
 	]).
@@ -455,11 +455,11 @@ setup_per_testcase(Config) ->
 
 setup_per_testcase(Config, ClearSxHist) ->
     ct:pal("Sockets: ~p", [ergw_gtp_socket_reg:all()]),
-    ergw_test_sx_up:reset('pgw-u'),
+    ergw_test_sx_up:reset('pgw-u01'),
     meck_reset(Config),
     start_gtpc_server(Config),
     reconnect_all_sx_nodes(),
-    ClearSxHist andalso ergw_test_sx_up:history('pgw-u', true),
+    ClearSxHist andalso ergw_test_sx_up:history('pgw-u01', true),
     ok.
 
 init_per_testcase(create_pdp_context_request_aaa_reject, Config) ->
@@ -951,7 +951,7 @@ error_indication() ->
 error_indication(Config) ->
     {GtpC, _, _} = create_pdp_context(Config),
 
-    ergw_test_sx_up:send('pgw-u', make_error_indication_report(GtpC)),
+    ergw_test_sx_up:send('pgw-u01', make_error_indication_report(GtpC)),
 
     ct:sleep(100),
     delete_pdp_context(not_found, GtpC),
@@ -1146,7 +1146,7 @@ update_pdp_context_request_tei_update(Config) ->
     [SMR0|_] = lists:filter(
 		 fun(#pfcp{type = session_modification_request}) -> true;
 		    (_) -> false
-		 end, ergw_test_sx_up:history('pgw-u')),
+		 end, ergw_test_sx_up:history('pgw-u01')),
     SMR = pfcp_packet:to_map(SMR0),
     #{update_far :=
 	  #update_far{
@@ -1448,14 +1448,14 @@ session_accounting(Config) ->
     #{context := Context, pfcp:= PCtx} = gtp_context:info(Pid),
 
     %% make sure we handle that the Sx node is not returning any accounting
-    ergw_test_sx_up:accounting('pgw-u', off),
+    ergw_test_sx_up:accounting('pgw-u01', off),
 
     SessionOpts1 = ergw_test_lib:query_usage_report(Context, PCtx),
     ?equal(false, maps:is_key('InPackets', SessionOpts1)),
     ?equal(false, maps:is_key('InOctets', SessionOpts1)),
 
     %% enable accouting again....
-    ergw_test_sx_up:accounting('pgw-u', on),
+    ergw_test_sx_up:accounting('pgw-u01', on),
 
     SessionOpts2 = ergw_test_lib:query_usage_report(Context, PCtx),
     ?match(#{'InPackets' := 3, 'OutPackets' := 1,
@@ -1540,7 +1540,7 @@ simple_aaa(Config) ->
     [SER|_] = lists:filter(
 		fun(#pfcp{type = session_establishment_request}) -> true;
 		   (_) ->false
-		end, ergw_test_sx_up:history('pgw-u')),
+		end, ergw_test_sx_up:history('pgw-u01')),
 
     URR = lists:sort(maps:get(create_urr, SER#pfcp.ie)),
     ?match(
@@ -1571,7 +1571,7 @@ simple_aaa(Config) ->
 	[#usage_report_trigger{perio = 1},
 	 #volume_measurement{total = 5, uplink = 2, downlink = 3},
 	 #tp_packet_measurement{total = 12, uplink = 5, downlink = 7}],
-    ergw_test_sx_up:usage_report('pgw-u', PCtx, MatchSpec, Report),
+    ergw_test_sx_up:usage_report('pgw-u01', PCtx, MatchSpec, Report),
 
     ct:sleep(100),
     delete_pdp_context(GtpC),
@@ -1638,7 +1638,7 @@ simple_ofcs(Config) ->
     [SER|_] = lists:filter(
 		fun(#pfcp{type = session_establishment_request}) -> true;
 		   (_) ->false
-		end, ergw_test_sx_up:history('pgw-u')),
+		end, ergw_test_sx_up:history('pgw-u01')),
 
     URR = maps:get(create_urr, SER#pfcp.ie),
     ?match(
@@ -1660,7 +1660,7 @@ simple_ofcs(Config) ->
 	[#usage_report_trigger{perio = 1},
 	 #volume_measurement{total = 5, uplink = 2, downlink = 3},
 	 #tp_packet_measurement{total = 12, uplink = 5, downlink = 7}],
-    ergw_test_sx_up:usage_report('pgw-u', PCtx, MatchSpec, Report),
+    ergw_test_sx_up:usage_report('pgw-u01', PCtx, MatchSpec, Report),
 
     ct:sleep(100),
     delete_pdp_context(GtpC),
@@ -1714,7 +1714,7 @@ simple_ocs(Config) ->
     [SER|_] = lists:filter(
 		fun(#pfcp{type = session_establishment_request}) -> true;
 		   (_) ->false
-		end, ergw_test_sx_up:history('pgw-u')),
+		end, ergw_test_sx_up:history('pgw-u01')),
 
     URR = lists:sort(maps:get(create_urr, SER#pfcp.ie)),
     ?match(
@@ -1753,7 +1753,7 @@ simple_ocs(Config) ->
 	[#usage_report_trigger{volqu = 1},
 	 #volume_measurement{total = 5, uplink = 2, downlink = 3},
 	 #tp_packet_measurement{total = 12, uplink = 5, downlink = 7}],
-    ergw_test_sx_up:usage_report('pgw-u', PCtx, MatchSpec, Report),
+    ergw_test_sx_up:usage_report('pgw-u01', PCtx, MatchSpec, Report),
 
     ct:sleep(100),
     delete_pdp_context(GtpC),
@@ -1948,8 +1948,8 @@ volume_threshold(Config) ->
 
     MatchSpec = ets:fun2ms(fun({Id, {'online', _}}) -> Id end),
 
-    ergw_test_sx_up:usage_report('pgw-u', PCtx, MatchSpec, [#usage_report_trigger{volth = 1}]),
-    ergw_test_sx_up:usage_report('pgw-u', PCtx, MatchSpec, [#usage_report_trigger{volqu = 1}]),
+    ergw_test_sx_up:usage_report('pgw-u01', PCtx, MatchSpec, [#usage_report_trigger{volth = 1}]),
+    ergw_test_sx_up:usage_report('pgw-u01', PCtx, MatchSpec, [#usage_report_trigger{volqu = 1}]),
 
     ct:sleep({seconds, 1}),
 
@@ -1959,7 +1959,7 @@ volume_threshold(Config) ->
 	lists:filter(
 	  fun(#pfcp{type = session_modification_request}) -> true;
 	     (_) ->false
-	  end, ergw_test_sx_up:history('pgw-u')),
+	  end, ergw_test_sx_up:history('pgw-u01')),
 
     ?equal([0, 0, 0, 0, 0, 1, 0, 0, 0],
 	   [maps_key_length(X1, Sx1#pfcp.ie)
@@ -2163,7 +2163,7 @@ gx_rar(Config) ->
 	lists:filter(
 	  fun(#pfcp{type = session_modification_request}) -> true;
 	     (_) ->false
-	  end, ergw_test_sx_up:history('pgw-u')),
+	  end, ergw_test_sx_up:history('pgw-u01')),
 
     ct:pal("Sx1: ~p", [Sx1]),
     ?equal([2, 2, 1, 0, 0, 0, 0, 0, 0],

--- a/test/ggsn_proxy_SUITE.erl
+++ b/test/ggsn_proxy_SUITE.erl
@@ -428,7 +428,7 @@
 	 {[node_selection, {default, 2}, 2, "topon.sx.sgw-u01.$ORIGIN"],
 	  {fun node_sel_update/2, sgw_u_sx}},
 	 {[node_selection, {default, 2}, 2, "topon.sx.pgw-u01.$ORIGIN"],
-	  {fun node_sel_update/2, pgw_u_sx}},
+	  {fun node_sel_update/2, pgw_u01_sx}},
 	 {[node_selection, {default, 2}, 2, "topon.pgw-1.nodes.$ORIGIN"],
 	  {fun node_sel_update/2, final_gsn}},
 	 {[node_selection, {default, 2}, 2, "topon.upf-1.nodes.$ORIGIN"],
@@ -445,7 +445,7 @@
 	 {[node_selection, {default, 2}, 2, "topon.sx.sgw-u01.$ORIGIN"],
 	  {fun node_sel_update/2, sgw_u_sx}},
 	 {[node_selection, {default, 2}, 2, "topon.sx.pgw-u01.$ORIGIN"],
-	  {fun node_sel_update/2, pgw_u_sx}},
+	  {fun node_sel_update/2, pgw_u01_sx}},
 	 {[node_selection, {default, 2}, 2, "topon.pgw-1.nodes.$ORIGIN"],
 	  {fun node_sel_update/2, final_gsn}},
 	 {[node_selection, {default, 2}, 2, "topon.upf-1.nodes.$ORIGIN"],
@@ -557,12 +557,12 @@ setup_per_testcase(Config) ->
 
 setup_per_testcase(Config, ClearSxHist) ->
     ct:pal("Sockets: ~p", [ergw_gtp_socket_reg:all()]),
-    ergw_test_sx_up:reset('pgw-u'),
+    ergw_test_sx_up:reset('pgw-u01'),
     ergw_test_sx_up:reset('sgw-u'),
     meck_reset(Config),
     start_gtpc_server(Config),
     reconnect_all_sx_nodes(),
-    ClearSxHist andalso ergw_test_sx_up:history('pgw-u', true),
+    ClearSxHist andalso ergw_test_sx_up:history('pgw-u01', true),
     ok.
 
 init_per_testcase(path_restart, Config) ->

--- a/test/pgw_SUITE.erl
+++ b/test/pgw_SUITE.erl
@@ -2318,7 +2318,7 @@ sx_connect_fail(Config) ->
 	    Ref <- Expect],
     [?equal(dead, R) || R <- Result],
 
-    create_session(system_failure, Config),
+    create_session(overload , Config),
 
     ?equal([], outstanding_requests()),
     ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),
@@ -3591,29 +3591,15 @@ apn_lookup(_Config) ->
 		[]},
 
     ct:pal("VRF: ~p", [ergw_gsn_lib:select_vrf(NodeCaps, ?'APN-EXAMPLE')]),
-    ?match({ok, <<3, "sgi">>, _}, ergw_gsn_lib:select_vrf(NodeCaps, ?'APN-EXAMPLE')),
-    ?match({ok, <<3, "sgi">>, _}, ergw_gsn_lib:select_vrf(NodeCaps, [<<"exa">>, <<"mple">>, <<"net">>])),
-    ?match({ok, <<3, "sgi">>, _}, ergw_gsn_lib:select_vrf(NodeCaps, [<<"APN1">>])),
-    ?match({ok, <<3, "sgi">>, _}, ergw_gsn_lib:select_vrf(NodeCaps, [<<"APN1">>, <<"mnc001">>, <<"mcc001">>, <<"gprs">>])),
-    ?match({ok, <<3, "sgi">>, _}, ergw_gsn_lib:select_vrf(NodeCaps, [<<"APN2">>])),
-    ?match({ok, <<3, "sgi">>, _}, ergw_gsn_lib:select_vrf(NodeCaps, [<<"APN2">>, <<"mnc001">>, <<"mcc001">>, <<"gprs">>])),
-    %% ?match({ok, <<8, "wildcard">>, _}, ergw_gsn_lib:select_vrf(NodeCaps, [<<"APN3">>])),
-    %% ?match({ok, <<8, "wildcard">>, _}, ergw_gsn_lib:select_vrf(NodeCaps, [<<"APN3">>, <<"mnc001">>, <<"mcc001">>, <<"gprs">>])),
-    %% ?match({ok, <<8, "wildcard">>, _}, ergw_gsn_lib:select_vrf(NodeCaps, [<<"APN4">>, <<"mnc001">>, <<"mcc901">>, <<"gprs">>])),
-
-    ct:pal("VRF: ~p", [ergw_gsn_lib:select_vrf_and_pool(NodeCaps, #context{apn = ?'APN-EXAMPLE'})]),
-    ?match({#context{vrf = #vrf{name = <<3, "sgi">>}}, _},
-	   ergw_gsn_lib:select_vrf_and_pool(NodeCaps, #context{apn = ?'APN-EXAMPLE'})),
-    ?match({#context{vrf = #vrf{name = <<3, "sgi">>}}, _},
-	   ergw_gsn_lib:select_vrf_and_pool(NodeCaps, #context{apn = [<<"exa">>, <<"mple">>, <<"net">>]})),
-    ?match({#context{vrf = #vrf{name = <<3, "sgi">>}}, _},
-	   ergw_gsn_lib:select_vrf_and_pool(NodeCaps, #context{apn = [<<"APN1">>]})),
-    ?match({#context{vrf = #vrf{name = <<3, "sgi">>}}, _},
-	   ergw_gsn_lib:select_vrf_and_pool(NodeCaps, #context{apn = [<<"APN1">>, <<"mnc001">>, <<"mcc001">>, <<"gprs">>]})),
-    ?match({#context{vrf = #vrf{name = <<3, "sgi">>}}, _},
-	   ergw_gsn_lib:select_vrf_and_pool(NodeCaps, #context{apn = [<<"APN2">>]})),
-    ?match({#context{vrf = #vrf{name = <<3, "sgi">>}}, _},
-	   ergw_gsn_lib:select_vrf_and_pool(NodeCaps, #context{apn = [<<"APN2">>, <<"mnc001">>, <<"mcc001">>, <<"gprs">>]})),
+    ?match(<<3, "sgi">>, ergw_gsn_lib:select_vrf(NodeCaps, ?'APN-EXAMPLE')),
+    ?match(<<3, "sgi">>, ergw_gsn_lib:select_vrf(NodeCaps, [<<"exa">>, <<"mple">>, <<"net">>])),
+    ?match(<<3, "sgi">>, ergw_gsn_lib:select_vrf(NodeCaps, [<<"APN1">>])),
+    ?match(<<3, "sgi">>, ergw_gsn_lib:select_vrf(NodeCaps, [<<"APN1">>, <<"mnc001">>, <<"mcc001">>, <<"gprs">>])),
+    ?match(<<3, "sgi">>, ergw_gsn_lib:select_vrf(NodeCaps, [<<"APN2">>])),
+    ?match(<<3, "sgi">>, ergw_gsn_lib:select_vrf(NodeCaps, [<<"APN2">>, <<"mnc001">>, <<"mcc001">>, <<"gprs">>])),
+    %% ?match(<<8, "wildcard">>, ergw_gsn_lib:select_vrf(NodeCaps, [<<"APN3">>])),
+    %% ?match(<<8, "wildcard">>, ergw_gsn_lib:select_vrf(NodeCaps, [<<"APN3">>, <<"mnc001">>, <<"mcc001">>, <<"gprs">>])),
+    %% ?match(<<8, "wildcard">>, ergw_gsn_lib:select_vrf(NodeCaps, [<<"APN4">>, <<"mnc001">>, <<"mcc901">>, <<"gprs">>])),
     ok.
 
 %%--------------------------------------------------------------------

--- a/test/pgw_proxy_SUITE.erl
+++ b/test/pgw_proxy_SUITE.erl
@@ -448,7 +448,7 @@
 	 {[node_selection, {default, 2}, 2, "topon.sx.sgw-u01.$ORIGIN"],
 	  {fun node_sel_update/2, sgw_u_sx}},
 	 {[node_selection, {default, 2}, 2, "topon.sx.pgw-u01.$ORIGIN"],
-	  {fun node_sel_update/2, pgw_u_sx}},
+	  {fun node_sel_update/2, pgw_u01_sx}},
 	 {[node_selection, {default, 2}, 2, "topon.pgw-1.nodes.$ORIGIN"],
 	  {fun node_sel_update/2, final_gsn}},
 	 {[node_selection, {default, 2}, 2, "topon.upf-1.nodes.$ORIGIN"],
@@ -465,7 +465,7 @@
 	 {[node_selection, {default, 2}, 2, "topon.sx.sgw-u01.$ORIGIN"],
 	  {fun node_sel_update/2, sgw_u_sx}},
 	 {[node_selection, {default, 2}, 2, "topon.sx.pgw-u01.$ORIGIN"],
-	  {fun node_sel_update/2, pgw_u_sx}},
+	  {fun node_sel_update/2, pgw_u01_sx}},
 	 {[node_selection, {default, 2}, 2, "topon.pgw-1.nodes.$ORIGIN"],
 	  {fun node_sel_update/2, final_gsn}},
 	 {[node_selection, {default, 2}, 2, "topon.upf-1.nodes.$ORIGIN"],
@@ -587,12 +587,12 @@ setup_per_testcase(Config) ->
     setup_per_testcase(Config, true).
 
 setup_per_testcase(Config, ClearSxHist) ->
-    ergw_test_sx_up:reset('pgw-u'),
+    ergw_test_sx_up:reset('pgw-u01'),
     ergw_test_sx_up:reset('sgw-u'),
     meck_reset(Config),
     start_gtpc_server(Config),
     reconnect_all_sx_nodes(),
-    ClearSxHist andalso ergw_test_sx_up:history('pgw-u', true),
+    ClearSxHist andalso ergw_test_sx_up:history('pgw-u01', true),
     ok.
 
 init_per_testcase(delete_session_request_resend, Config) ->

--- a/test/saegw_s11_SUITE.erl
+++ b/test/saegw_s11_SUITE.erl
@@ -338,7 +338,7 @@
 	 {[node_selection, {default, 2}, 2, "topon.s5s8.pgw.$ORIGIN"],
 	  {fun node_sel_update/2, final_gsn}},
 	 {[node_selection, {default, 2}, 2, "topon.sx.prox01.$ORIGIN"],
-	  {fun node_sel_update/2, pgw_u_sx}},
+	  {fun node_sel_update/2, pgw_u01_sx}},
 	 {[node_selection, {default, 2}, 2, "topon.sx.prox02.$ORIGIN"],
 	  {fun node_sel_update/2, sgw_u_sx}}
 	]).

--- a/test/saegw_s11_SUITE.erl
+++ b/test/saegw_s11_SUITE.erl
@@ -439,11 +439,11 @@ setup_per_testcase(Config) ->
 
 setup_per_testcase(Config, ClearSxHist) ->
     ct:pal("Sockets: ~p", [ergw_gtp_socket_reg:all()]),
-    ergw_test_sx_up:reset('pgw-u'),
+    ergw_test_sx_up:reset('pgw-u01'),
     meck_reset(Config),
     start_gtpc_server(Config),
     reconnect_all_sx_nodes(),
-    ClearSxHist andalso ergw_test_sx_up:history('pgw-u', true),
+    ClearSxHist andalso ergw_test_sx_up:history('pgw-u01', true),
     ok.
 
 init_per_testcase(create_session_request_aaa_reject, Config) ->
@@ -839,7 +839,7 @@ modify_bearer_request_tei_update(Config) ->
     [_, SMR0|_] = lists:filter(
 		    fun(#pfcp{type = session_modification_request}) -> true;
 		       (_) -> false
-		    end, ergw_test_sx_up:history('pgw-u')),
+		    end, ergw_test_sx_up:history('pgw-u01')),
 
     SMR = pfcp_packet:to_map(SMR0),
     #{update_far :=
@@ -1149,7 +1149,7 @@ enb_connection_suspend(Config) ->
     [_, SMR0|_] = lists:filter(
 		    fun(#pfcp{type = session_modification_request}) -> true;
 		       (_) -> false
-		    end, ergw_test_sx_up:history('pgw-u')),
+		    end, ergw_test_sx_up:history('pgw-u01')),
     SMR = pfcp_packet:to_map(SMR0),
     ?match(#{remove_far := #remove_far{}}, SMR#pfcp.ie),
 
@@ -1226,7 +1226,7 @@ simple_aaa(Config) ->
     [SER|_] = lists:filter(
 		fun(#pfcp{type = session_establishment_request}) -> true;
 		   (_) ->false
-		end, ergw_test_sx_up:history('pgw-u')),
+		end, ergw_test_sx_up:history('pgw-u01')),
 
     URR = lists:sort(maps:get(create_urr, SER#pfcp.ie)),
     ?match(
@@ -1257,7 +1257,7 @@ simple_aaa(Config) ->
 	[#usage_report_trigger{perio = 1},
 	 #volume_measurement{total = 5, uplink = 2, downlink = 3},
 	 #tp_packet_measurement{total = 12, uplink = 5, downlink = 7}],
-    ergw_test_sx_up:usage_report('pgw-u', PCtx, MatchSpec, Report),
+    ergw_test_sx_up:usage_report('pgw-u01', PCtx, MatchSpec, Report),
 
     ct:sleep(100),
     delete_session(GtpC),
@@ -1324,7 +1324,7 @@ simple_ofcs(Config) ->
     [SER|_] = lists:filter(
 		fun(#pfcp{type = session_establishment_request}) -> true;
 		   (_) ->false
-		end, ergw_test_sx_up:history('pgw-u')),
+		end, ergw_test_sx_up:history('pgw-u01')),
 
     URR = maps:get(create_urr, SER#pfcp.ie),
     ?match(
@@ -1346,7 +1346,7 @@ simple_ofcs(Config) ->
 	[#usage_report_trigger{perio = 1},
 	 #volume_measurement{total = 5, uplink = 2, downlink = 3},
 	 #tp_packet_measurement{total = 12, uplink = 5, downlink = 7}],
-    ergw_test_sx_up:usage_report('pgw-u', PCtx, MatchSpec, Report),
+    ergw_test_sx_up:usage_report('pgw-u01', PCtx, MatchSpec, Report),
 
     ct:sleep(100),
     delete_session(GtpC),
@@ -1400,7 +1400,7 @@ simple_ocs(Config) ->
     [SER|_] = lists:filter(
 		fun(#pfcp{type = session_establishment_request}) -> true;
 		   (_) ->false
-		end, ergw_test_sx_up:history('pgw-u')),
+		end, ergw_test_sx_up:history('pgw-u01')),
 
     URR = lists:sort(maps:get(create_urr, SER#pfcp.ie)),
     ?match(
@@ -1439,7 +1439,7 @@ simple_ocs(Config) ->
 	[#usage_report_trigger{volqu = 1},
 	 #volume_measurement{total = 5, uplink = 2, downlink = 3},
 	 #tp_packet_measurement{total = 12, uplink = 5, downlink = 7}],
-    ergw_test_sx_up:usage_report('pgw-u', PCtx, MatchSpec, Report),
+    ergw_test_sx_up:usage_report('pgw-u01', PCtx, MatchSpec, Report),
 
     ct:sleep(100),
     delete_session(GtpC),
@@ -1631,8 +1631,8 @@ volume_threshold(Config) ->
 
     MatchSpec = ets:fun2ms(fun({Id, {'online', _}}) -> Id end),
 
-    ergw_test_sx_up:usage_report('pgw-u', PCtx, MatchSpec, [#usage_report_trigger{volth = 1}]),
-    ergw_test_sx_up:usage_report('pgw-u', PCtx, MatchSpec, [#usage_report_trigger{volqu = 1}]),
+    ergw_test_sx_up:usage_report('pgw-u01', PCtx, MatchSpec, [#usage_report_trigger{volth = 1}]),
+    ergw_test_sx_up:usage_report('pgw-u01', PCtx, MatchSpec, [#usage_report_trigger{volqu = 1}]),
 
     ct:sleep({seconds, 1}),
 
@@ -1642,7 +1642,7 @@ volume_threshold(Config) ->
 	lists:filter(
 	  fun(#pfcp{type = session_modification_request}) -> true;
 	     (_) ->false
-	  end, ergw_test_sx_up:history('pgw-u')),
+	  end, ergw_test_sx_up:history('pgw-u01')),
 
     ?equal([0, 0, 0, 0, 0, 1, 0, 0, 0],
 	   [maps_key_length(X1, Sx1#pfcp.ie)
@@ -1847,7 +1847,7 @@ gx_rar(Config) ->
 	lists:filter(
 	  fun(#pfcp{type = session_modification_request}) -> true;
 	     (_) ->false
-	  end, ergw_test_sx_up:history('pgw-u')),
+	  end, ergw_test_sx_up:history('pgw-u01')),
 
     ct:pal("Sx1: ~p", [Sx1]),
     ?equal([2, 2, 1, 0, 0, 0, 0, 0, 0],

--- a/test/tdf_SUITE.erl
+++ b/test/tdf_SUITE.erl
@@ -431,7 +431,7 @@ setup_per_testcase(Config, ClearSxHist) ->
     ergw_test_sx_up:reset('tdf-u'),
     meck_reset(Config),
     reconnect_all_sx_nodes(),
-    ClearSxHist andalso ergw_test_sx_up:history('pgw-u', true),
+    ClearSxHist andalso ergw_test_sx_up:history('pgw-u01', true),
     [{seid, tdf_seid()},
      {tdf_node, tdf_node_pid()},
      {aaa_cfg, AppsCfg} | Config].


### PR DESCRIPTION
The first A in AAA might overrule our IP pool selection either through the Framed-{IPv6}-Pool attribute or by assigning IPs itself. That new pool or IP might reside on a different UPF node.

This implements the UPF re-selection based on IP pools only. When IPs are assigned, the matching pools *has* to be supplied in Framed-{IPv6}-Pool.