### PR TITLE
make the IPv6 UE interface id configurable

### DIFF
--- a/src/ergw_config.erl
+++ b/src/ergw_config.erl
@@ -31,7 +31,10 @@
 			 {apns, []},
 			 {charging, [{default, []}]}]).
 -define(VrfDefaults, [{features, invalid}]).
--define(ApnDefaults, [{ip_pools, []}, {bearer_type, 'IPv4v6'}, {prefered_bearer_type, 'IPv6'}]).
+-define(ApnDefaults, [{ip_pools, []},
+		      {bearer_type, 'IPv4v6'},
+		      {prefered_bearer_type, 'IPv6'},
+		      {ipv6_ue_interface_id, default}]).
 -define(DefaultsNodesDefaults, [{vrfs, invalid}, {node_selection, default}]).
 
 -define(is_opts(X), (is_list(X) orelse is_map(X))).
@@ -410,6 +413,16 @@ validate_apn_option({bearer_type = Opt, Type})
 validate_apn_option({prefered_bearer_type = Opt, Type})
   when Type =:= 'IPv4'; Type =:= 'IPv6' ->
     {Opt, Type};
+validate_apn_option({ipv6_ue_interface_id = Opt, Type})
+  when Type =:= default;
+       Type =:= random;
+       Type =:= sgsnemu ->
+    {Opt, Type};
+validate_apn_option({ipv6_ue_interface_id, {0,0,0,0,E,F,G,H}} = Opt)
+  when E >= 0, E < 65536, F >= 0, F < 65536,
+       G >= 0, G < 65536, H >= 0, H < 65536,
+       (E + F + G + H) =/= 0 ->
+    Opt;
 validate_apn_option({Opt, Value})
   when Opt == 'MS-Primary-DNS-Server';   Opt == 'MS-Secondary-DNS-Server';
        Opt == 'MS-Primary-NBNS-Server';  Opt == 'MS-Secondary-NBNS-Server';

--- a/test/config_SUITE.erl
+++ b/test/config_SUITE.erl
@@ -756,6 +756,15 @@ config(_Config)  ->
     ?error_option(set_cfg_value([apns, ?'APN-EXAMPLE', prefered_bearer_type], 'Non-IP', ?GGSN_CONFIG)),
     ?error_option(set_cfg_value([apns, ?'APN-EXAMPLE', prefered_bearer_type], undefined, ?GGSN_CONFIG)),
 
+    ?ok_option(set_cfg_value([apns, ?'APN-EXAMPLE', ipv6_ue_interface_id], default, ?GGSN_CONFIG)),
+    ?ok_option(set_cfg_value([apns, ?'APN-EXAMPLE', ipv6_ue_interface_id], sgsnemu, ?GGSN_CONFIG)),
+    ?ok_option(set_cfg_value([apns, ?'APN-EXAMPLE', ipv6_ue_interface_id], random, ?GGSN_CONFIG)),
+    ?ok_option(set_cfg_value([apns, ?'APN-EXAMPLE', ipv6_ue_interface_id], {0,0,0,0,0,0,0,2}, ?GGSN_CONFIG)),
+    ?error_option(set_cfg_value([apns, ?'APN-EXAMPLE', ipv6_ue_interface_id], undefined, ?GGSN_CONFIG)),
+    ?error_option(set_cfg_value([apns, ?'APN-EXAMPLE', ipv6_ue_interface_id], {0,0,0,0,0,0,0,0}, ?GGSN_CONFIG)),
+    ?error_option(set_cfg_value([apns, ?'APN-EXAMPLE', ipv6_ue_interface_id], {1,0,0,0,0,0,0,0}, ?GGSN_CONFIG)),
+    ?error_option(set_cfg_value([apns, ?'APN-EXAMPLE', ipv6_ue_interface_id], {0,0,0,0,0,0,0,65536}, ?GGSN_CONFIG)),
+
     ?error_option(set_cfg_value([apns, ?'APN-EXAMPLE', 'MS-Primary-DNS-Server'],
 				invalid, ?GGSN_CONFIG)),
     ?error_option(set_cfg_value([apns, ?'APN-EXAMPLE', 'MS-Primary-DNS-Server'],


### PR DESCRIPTION
Using a hard code IPv6 interface of 1 for the UE is not always
desirable. Make it configurable, choices default (1), random,
a give value or sgsnemu.

The sgsnemu option uses the 64 bit IPv6 prefix as the interface id.
This is concession to the way that sgsnemu handles it IPv6 contest
lookup and should allow IPv6 only bearers with sgsnemu.