### PR TITLE
add tini PID 1 to ercdf container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,7 +33,7 @@ FROM alpine:3.10
 WORKDIR /
 RUN     apk update && \
 		apk --no-cache upgrade && \
-		apk --no-cache add zlib ncurses-libs libcrypto1.1 lksctp-tools
+		apk --no-cache add zlib ncurses-libs libcrypto1.1 lksctp-tools tini
 COPY    docker/docker-entrypoint.sh /
 COPY    config/ergw-c-node.config /etc/ergw-c-node/
 
@@ -42,5 +42,5 @@ RUN     mkdir -p /var/lib/ergw/ && \
 
 COPY    --from=build-env /build/_build/prod/rel/ /opt/
 
-ENTRYPOINT ["/docker-entrypoint.sh"]
+ENTRYPOINT ["tini", "--", "/docker-entrypoint.sh"]
 CMD     ["/opt/ergw-c-node/bin/ergw-c-node", "foreground"]


### PR DESCRIPTION
Usually, a process spawning subprocesses is responsible for cleaning
them up once they finish. This responsibility propagates down to PID 1.

When finished subprocesses ("childs") are not reaped, they become zombies
which are never vanish. Over time, they can starve the system. Erlang and
Elixir does not take care of spawned children on its own. Thus, any
"remote console" interaction with a running Erlang node will leave behind
a couple of zombies when PID 1 is not taking care of them.
Inside the container, Erlang / Elixir is usually run as PID 1.

This commit adds tini as the new PID 1 of the containers. As a result, all
child processes will be reaped properly.