### PR TITLE
ensure ergw_aaa invocation order

### DIFF
--- a/src/ggsn_gn.erl
+++ b/src/ggsn_gn.erl
@@ -200,11 +200,11 @@ handle_event(info, #aaa_request{procedure = {gx, 'RAR'},
     {Online, Offline, Monitor} =
 	ergw_gsn_lib:usage_report_to_charging_events(UsageReport, ChargeEv, PCtx1),
 
+    ergw_gsn_lib:process_accounting_monitor_events(ChargeEv, Monitor, Now, Session),
     GyReqServices = ergw_gsn_lib:gy_credit_request(Online, PCC0, PCC2),
     {ok, _, GyEvs} =
 	ergw_gsn_lib:process_online_charging_events(ChargeEv, GyReqServices, Session, ReqOps),
     ergw_gsn_lib:process_offline_charging_events(ChargeEv, Offline, Now, Session),
-    ergw_gsn_lib:process_accounting_monitor_events(ChargeEv, Monitor, Now, Session),
 
 %%% step 5:
     {PCC4, PCCErrors4} = ergw_gsn_lib:gy_events_to_pcc_ctx(Now, GyEvs, PCC2),
@@ -296,10 +296,10 @@ handle_sx_report(#pfcp{type = session_report_request,
     ChargeEv = interim,
     {Online, Offline, Monitor} =
 	ergw_gsn_lib:usage_report_to_charging_events(UsageReport, ChargeEv, PCtx),
+    ergw_gsn_lib:process_accounting_monitor_events(ChargeEv, Monitor, Now, Session),
     GyReqServices = ergw_gsn_lib:gy_credit_request(Online, PCC),
     ergw_gsn_lib:process_online_charging_events(ChargeEv, GyReqServices, Session, ReqOpts),
     ergw_gsn_lib:process_offline_charging_events(ChargeEv, Offline, Now, Session),
-    ergw_gsn_lib:process_accounting_monitor_events(ChargeEv, Monitor, Now, Session),
 
     {ok, Data};
 
@@ -613,10 +613,10 @@ close_pdp_context(Reason, #{context := Context, pfcp := PCtx, 'Session' := Sessi
     ChargeEv = {terminate, TermCause},
     {Online, Offline, Monitor} =
 	ergw_gsn_lib:usage_report_to_charging_events(URRs, ChargeEv, PCtx),
+    ergw_gsn_lib:process_accounting_monitor_events(ChargeEv, Monitor, Now, Session),
     GyReqServices = ergw_gsn_lib:gy_credit_report(Online),
     ergw_gsn_lib:process_online_charging_events(ChargeEv, GyReqServices, Session, ReqOpts),
     ergw_gsn_lib:process_offline_charging_events(ChargeEv, Offline, Now, Session),
-    ergw_gsn_lib:process_accounting_monitor_events(ChargeEv, Monitor, Now, Session),
 
     %% ===========================================================================
     ok.
@@ -638,10 +638,10 @@ triggered_charging_event(ChargeEv, Now, Request,
 	{Online, Offline, Monitor} =
 	    ergw_gsn_lib:usage_report_to_charging_events(UsageReport, ChargeEv, PCtx),
 
+	ergw_gsn_lib:process_accounting_monitor_events(ChargeEv, Monitor, Now, Session),
 	GyReqServices = ergw_gsn_lib:gy_credit_request(Online, PCC),
 	ergw_gsn_lib:process_online_charging_events(ChargeEv, GyReqServices, Session, ReqOpts),
-	ergw_gsn_lib:process_offline_charging_events(ChargeEv, Offline, Now, Session),
-	ergw_gsn_lib:process_accounting_monitor_events(ChargeEv, Monitor, Now, Session)
+	ergw_gsn_lib:process_offline_charging_events(ChargeEv, Offline, Now, Session)
     catch
 	throw:#ctx_err{} = CtxErr ->
 	    ?LOG(error, "Triggered Charging Event failed with ~p", [CtxErr])

--- a/src/pgw_s5s8.erl
+++ b/src/pgw_s5s8.erl
@@ -208,11 +208,11 @@ handle_event(info, #aaa_request{procedure = {gx, 'RAR'},
     {Online, Offline, Monitor} =
 	ergw_gsn_lib:usage_report_to_charging_events(UsageReport, ChargeEv, PCtx1),
 
+    ergw_gsn_lib:process_accounting_monitor_events(ChargeEv, Monitor, Now, Session),
     GyReqServices = ergw_gsn_lib:gy_credit_request(Online, PCC0, PCC2),
     {ok, _, GyEvs} =
 	ergw_gsn_lib:process_online_charging_events(ChargeEv, GyReqServices, Session, ReqOps),
     ergw_gsn_lib:process_offline_charging_events(ChargeEv, Offline, Now, Session),
-    ergw_gsn_lib:process_accounting_monitor_events(ChargeEv, Monitor, Now, Session),
 
 %%% step 5:
     {PCC4, PCCErrors4} = ergw_gsn_lib:gy_events_to_pcc_ctx(Now, GyEvs, PCC2),
@@ -790,10 +790,10 @@ close_pdn_context(Reason, #{context := Context, pfcp := PCtx, 'Session' := Sessi
 
     ChargeEv = {terminate, TermCause},
     {Online, Offline, Monitor} = ergw_gsn_lib:usage_report_to_charging_events(URRs, ChargeEv, PCtx),
+    ergw_gsn_lib:process_accounting_monitor_events(ChargeEv, Monitor, Now, Session),
     GyReqServices = ergw_gsn_lib:gy_credit_report(Online),
     ergw_gsn_lib:process_online_charging_events(ChargeEv, GyReqServices, Session, ReqOpts),
     ergw_gsn_lib:process_offline_charging_events(ChargeEv, Offline, Now, Session),
-    ergw_gsn_lib:process_accounting_monitor_events(ChargeEv, Monitor, Now, Session),
 
     %% ===========================================================================
     ok.
@@ -814,10 +814,10 @@ triggered_charging_event(ChargeEv, Now, Request,
 	    query_usage_report(Request, Context, PCtx),
 	{Online, Offline, Monitor} =
 	    ergw_gsn_lib:usage_report_to_charging_events(UsageReport, ChargeEv, PCtx),
+	ergw_gsn_lib:process_accounting_monitor_events(ChargeEv, Monitor, Now, Session),
 	GyReqServices = ergw_gsn_lib:gy_credit_request(Online, PCC),
 	ergw_gsn_lib:process_online_charging_events(ChargeEv, GyReqServices, Session, ReqOpts),
-	ergw_gsn_lib:process_offline_charging_events(ChargeEv, Offline, Now, Session),
-	ergw_gsn_lib:process_accounting_monitor_events(ChargeEv, Monitor, Now, Session)
+	ergw_gsn_lib:process_offline_charging_events(ChargeEv, Offline, Now, Session)
     catch
 	throw:#ctx_err{} = CtxErr ->
 	    ?LOG(error, "Triggered Charging Event failed with ~p", [CtxErr])

--- a/src/saegw_s11.erl
+++ b/src/saegw_s11.erl
@@ -209,11 +209,11 @@ handle_event(info, #aaa_request{procedure = {gx, 'RAR'},
     {Online, Offline, Monitor} =
 	ergw_gsn_lib:usage_report_to_charging_events(UsageReport, ChargeEv, PCtx1),
 
+    ergw_gsn_lib:process_accounting_monitor_events(ChargeEv, Monitor, Now, Session),
     GyReqServices = ergw_gsn_lib:gy_credit_request(Online, PCC0, PCC2),
     {ok, _, GyEvs} =
 	ergw_gsn_lib:process_online_charging_events(ChargeEv, GyReqServices, Session, ReqOps),
     ergw_gsn_lib:process_offline_charging_events(ChargeEv, Offline, Now, Session),
-    ergw_gsn_lib:process_accounting_monitor_events(ChargeEv, Monitor, Now, Session),
 
 %%% step 5:
     {PCC4, PCCErrors4} = ergw_gsn_lib:gy_events_to_pcc_ctx(Now, GyEvs, PCC2),
@@ -297,10 +297,10 @@ handle_sx_report(#pfcp{type = session_report_request,
     ChargeEv = interim,
     {Online, Offline, Monitor} =
 	ergw_gsn_lib:usage_report_to_charging_events(UsageReport, ChargeEv, PCtx),
+    ergw_gsn_lib:process_accounting_monitor_events(ChargeEv, Monitor, Now, Session),
     GyReqServices = ergw_gsn_lib:gy_credit_request(Online, PCC),
     ergw_gsn_lib:process_online_charging_events(ChargeEv, GyReqServices, Session, ReqOpts),
     ergw_gsn_lib:process_offline_charging_events(ChargeEv, Offline, Now, Session),
-    ergw_gsn_lib:process_accounting_monitor_events(ChargeEv, Monitor, Now, Session),
 
     {ok, Data};
 
@@ -734,10 +734,10 @@ close_pdn_context(Reason, #{context := Context, pfcp := PCtx, 'Session' := Sessi
     ChargeEv = {terminate, TermCause},
     {Online, Offline, Monitor} =
 	ergw_gsn_lib:usage_report_to_charging_events(URRs, ChargeEv, PCtx),
+    ergw_gsn_lib:process_accounting_monitor_events(ChargeEv, Monitor, Now, Session),
     GyReqServices = ergw_gsn_lib:gy_credit_report(Online),
     ergw_gsn_lib:process_online_charging_events(ChargeEv, GyReqServices, Session, ReqOpts),
     ergw_gsn_lib:process_offline_charging_events(ChargeEv, Offline, Now, Session),
-    ergw_gsn_lib:process_accounting_monitor_events(ChargeEv, Monitor, Now, Session),
 
     %% ===========================================================================
     ok.
@@ -759,10 +759,10 @@ triggered_charging_event(ChargeEv, Now, Request,
 	{Online, Offline, Monitor} =
 	    ergw_gsn_lib:usage_report_to_charging_events(UsageReport, ChargeEv, PCtx),
 
+	ergw_gsn_lib:process_accounting_monitor_events(ChargeEv, Monitor, Now, Session),
 	GyReqServices = ergw_gsn_lib:gy_credit_request(Online, PCC),
 	ergw_gsn_lib:process_online_charging_events(ChargeEv, GyReqServices, Session, ReqOpts),
-	ergw_gsn_lib:process_offline_charging_events(ChargeEv, Offline, Now, Session),
-	ergw_gsn_lib:process_accounting_monitor_events(ChargeEv, Monitor, Now, Session)
+	ergw_gsn_lib:process_offline_charging_events(ChargeEv, Offline, Now, Session)
     catch
 	throw:#ctx_err{} = CtxErr ->
 	    ?LOG(error, "Triggered Charging Event failed with ~p", [CtxErr])

--- a/test/ggsn_SUITE.erl
+++ b/test/ggsn_SUITE.erl
@@ -1759,15 +1759,19 @@ simple_ofcs(Config) ->
 	lists:filter(
 	  fun({_, {ergw_aaa_session, invoke, [_, _, {rf, _}, _]}, _}) ->
 		  true;
+	     ({_, {ergw_aaa_session, invoke, [_, _, stop, _]}, _}) ->
+		  true;
 	     (_) ->
 		  false
 	  end, H),
-    ?match(X when X == 3, length(SInv)),
+    ?match(X when X == 4, length(SInv)),
 
-    [Start, SInterim, Stop] =
+    [Start, SInterim, AcctStop, Stop] =
 	lists:map(fun({_, {_, _, [_, SOpts, _, _]}, _}) -> SOpts end, SInv),
 
     ?equal(false, maps:is_key('service_data', Start)),
+    ?equal(false, maps:is_key('service_data', AcctStop)),
+    ?equal(true, maps:is_key('service_data', Stop)),
 
     ?match_map(
        #{service_data =>
@@ -1852,10 +1856,12 @@ simple_ocs(Config) ->
 	lists:filter(
 	  fun({_, {ergw_aaa_session, invoke, [_, _, {gy,_}, _]}, _}) ->
 		  true;
+	     ({_, {ergw_aaa_session, invoke, [_, _, stop, _]}, _}) ->
+		  true;
 	     (_) ->
 		  false
 	  end, H),
-    ?match(X when X == 3, length(CCR)),
+    ?match(X when X == 4, length(CCR)),
 
     {_, {_, _, [_, _, {gy,'CCR-Initial'}, _]},
      {ok, Session, _Events}} = hd(CCR),
@@ -1931,8 +1937,11 @@ simple_ocs(Config) ->
 	 },
     ?match_map(Expected, Session),
 
-    [Start, SInterim, Stop] =
+    [Start, SInterim, AcctStop, Stop] =
 	lists:map(fun({_, {_, _, [_, SOpts, _, _]}, _}) -> SOpts end, CCR),
+
+    ?equal(false, maps:is_key('credits', AcctStop)),
+    ?equal(false, maps:is_key('used_credits', AcctStop)),
 
     ?match_map(
        #{credits => #{3000 => empty}}, Start),

--- a/test/pgw_SUITE.erl
+++ b/test/pgw_SUITE.erl
@@ -2669,15 +2669,19 @@ simple_ofcs(Config) ->
 	lists:filter(
 	  fun({_, {ergw_aaa_session, invoke, [_, _, {rf, _}, _]}, _}) ->
 		  true;
+	     ({_, {ergw_aaa_session, invoke, [_, _, stop, _]}, _}) ->
+		  true;
 	     (_) ->
 		  false
 	  end, H),
-    ?match(X when X == 3, length(SInv)),
+    ?match(X when X == 4, length(SInv)),
 
-    [Start, SInterim, Stop] =
+    [Start, SInterim, AcctStop, Stop] =
 	lists:map(fun({_, {_, _, [_, SOpts, _, _]}, _}) -> SOpts end, SInv),
 
     ?equal(false, maps:is_key('service_data', Start)),
+    ?equal(false, maps:is_key('service_data', AcctStop)),
+    ?equal(true, maps:is_key('service_data', Stop)),
 
     ?match_map(
        #{service_data =>
@@ -2762,10 +2766,12 @@ simple_ocs(Config) ->
 	lists:filter(
 	  fun({_, {ergw_aaa_session, invoke, [_, _, {gy,_}, _]}, _}) ->
 		  true;
+	     ({_, {ergw_aaa_session, invoke, [_, _, stop, _]}, _}) ->
+		  true;
 	     (_) ->
 		  false
 	  end, H),
-    ?match(X when X == 3, length(CCR)),
+    ?match(X when X == 4, length(CCR)),
 
     {_, {_, _, [_, _, {gy,'CCR-Initial'}, _]},
      {ok, Session, _Events}} = hd(CCR),
@@ -2839,8 +2845,11 @@ simple_ocs(Config) ->
 	 },
     ?match_map(Expected, Session),
 
-    [Start, SInterim, Stop] =
+    [Start, SInterim, AcctStop, Stop] =
 	lists:map(fun({_, {_, _, [_, SOpts, _, _]}, _}) -> SOpts end, CCR),
+
+    ?equal(false, maps:is_key('credits', AcctStop)),
+    ?equal(false, maps:is_key('used_credits', AcctStop)),
 
     ?match_map(
        #{credits => #{3000 => empty}}, Start),

--- a/test/saegw_s11_SUITE.erl
+++ b/test/saegw_s11_SUITE.erl
@@ -1370,15 +1370,19 @@ simple_ofcs(Config) ->
 	lists:filter(
 	  fun({_, {ergw_aaa_session, invoke, [_, _, {rf, _}, _]}, _}) ->
 		  true;
+	     ({_, {ergw_aaa_session, invoke, [_, _, stop, _]}, _}) ->
+		  true;
 	     (_) ->
 		  false
 	  end, H),
-    ?match(X when X == 3, length(SInv)),
+    ?match(X when X == 4, length(SInv)),
 
-    [Start, SInterim, Stop] =
+    [Start, SInterim, AcctStop, Stop] =
 	lists:map(fun({_, {_, _, [_, SOpts, _, _]}, _}) -> SOpts end, SInv),
 
     ?equal(false, maps:is_key('service_data', Start)),
+    ?equal(false, maps:is_key('service_data', AcctStop)),
+    ?equal(true, maps:is_key('service_data', Stop)),
 
     ?match_map(
        #{service_data =>
@@ -1463,10 +1467,12 @@ simple_ocs(Config) ->
 	lists:filter(
 	  fun({_, {ergw_aaa_session, invoke, [_, _, {gy,_}, _]}, _}) ->
 		  true;
+	     ({_, {ergw_aaa_session, invoke, [_, _, stop, _]}, _}) ->
+		  true;
 	     (_) ->
 		  false
 	  end, H),
-    ?match(X when X == 3, length(CCR)),
+    ?match(X when X == 4, length(CCR)),
 
     {_, {_, _, [_, _, {gy,'CCR-Initial'}, _]},
      {ok, Session, _Events}} = hd(CCR),
@@ -1540,8 +1546,11 @@ simple_ocs(Config) ->
 	 },
     ?match_map(Expected, Session),
 
-    [Start, SInterim, Stop] =
+    [Start, SInterim, AcctStop, Stop] =
 	lists:map(fun({_, {_, _, [_, SOpts, _, _]}, _}) -> SOpts end, CCR),
+
+    ?equal(false, maps:is_key('credits', AcctStop)),
+    ?equal(false, maps:is_key('used_credits', AcctStop)),
 
     ?match_map(
        #{credits => #{3000 => empty}}, Start),


### PR DESCRIPTION
AAA actionion like 'stop' need to go before Gx, Gy or Rf actions to
ensure proper sidereffect propagation.