### PR TITLE
update travis build matrix and gitlab builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,7 +34,7 @@ build:otp-22.1:
 
 build:otp-22.2:
   <<: *build_otp
-  image: erlang:22.2.7-alpine
+  image: erlang:22.2.8-alpine
 
 .check:otp: &check_otp
   stage: test
@@ -70,7 +70,7 @@ check:otp-22.1:
 
 check:otp-22.2:
   <<: *check_otp
-  image: erlang:22.2.7-alpine
+  image: erlang:22.2.8-alpine
   dependencies:
     - build:otp-22.2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+arch: amd64
 dist: bionic
 services:
   - docker
@@ -8,10 +9,9 @@ git:
 language: erlang
 
 otp_release:
- - 21.3.8.1
  - 22.0.7
  - 22.1.8.1
- - 22.2.7
+ - 22.2.8
 
 install: "true"
 
@@ -46,8 +46,15 @@ script:
 
 jobs:
   include:
+    -
+    - dist: xenial
+      otp_release: 21.3.8.1
+    # this fails, disable it for the moment
+    # - dist: xenial
+    #   arch: arm64
+    #   otp_release: 22.0.5
     - stage: docker
-      otp_release: 22.2.7
+      otp_release: 22.2.8
       script:
         - docker build -t $BUILD_IMAGE -f docker/Dockerfile .
       after_success:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # -- build-environment --
 # see https://docs.docker.com/engine/userguide/eng-image/multistage-build/
 
-FROM erlang:22.2.7-alpine AS build-env
+FROM erlang:22.2.8-alpine AS build-env
 
 WORKDIR /build
 RUN     apk update && apk --no-cache upgrade && \


### PR DESCRIPTION
- on Travis:
  - use Xenial for OTP 21.3 checks
  - briefly test ARM64
- on gitlab, upgrade to 22.2.8