### PR TITLE
support late DNS A record lookup

### DIFF
--- a/src/ergw.erl
+++ b/src/ergw.erl
@@ -117,7 +117,7 @@ attach_tdf(SxNode, #{node_selection := NodeSelections} = Opts, _, true) ->
 	     NodeLookup([NodeSelection | NextSelection]) ->
 		 case ergw_node_selection:lookup(SxNode, NodeSelection) of
 		     {Node, IP4, IP6} ->
-			 ergw_sx_node_mngr:connect(Node, IP4, IP6);
+			 ergw_sx_node_mngr:connect(Node, NodeSelection, IP4, IP6);
 		     _Other ->
 			 ?LOG(warning, "TDF lookup for ~p failed ~p", [SxNode, _Other]),
 			 NodeLookup(NextSelection)
@@ -131,13 +131,13 @@ attach_tdf(SxNode, #{node_selection := NodeSelections} = Opts, _, true) ->
 connect_sx_node(_Node, #{connect := false}) ->
     ok;
 connect_sx_node(Node, #{raddr := IP4} = _Opts) when tuple_size(IP4) =:= 4 ->
-    ergw_sx_node_mngr:connect(Node, [IP4], []);
+    ergw_sx_node_mngr:connect(Node, default, [IP4], []);
 connect_sx_node(Node, #{raddr := IP6} = _Opts) when tuple_size(IP6) =:= 8 ->
-    ergw_sx_node_mngr:connect(Node, [], [IP6]);
+    ergw_sx_node_mngr:connect(Node, default, [], [IP6]);
 connect_sx_node(Node, #{node_selection := NodeSelect} = Opts) ->
     case ergw_node_selection:lookup(Node, NodeSelect) of
 	{_, IP4, IP6} ->
-	    ergw_sx_node_mngr:connect(Node, IP4, IP6);
+	    ergw_sx_node_mngr:connect(Node, NodeSelect, IP4, IP6);
 	_Other ->
 	    %% TBD:
 	    erlang:error(badarg, [Node, Opts])

--- a/src/ergw_gsn_lib.erl
+++ b/src/ergw_gsn_lib.erl
@@ -1511,6 +1511,7 @@ apn_opts(APN, Context) ->
 	Other -> Other
     end.
 
+%% select/2
 select(_, []) -> undefined;
 select(first, L) -> hd(L);
 select(random, L) when is_list(L) ->
@@ -1596,8 +1597,7 @@ filter_by_caps(Candidates, Wanted, AnyPool, Context) ->
     Eligible = common_caps(Wanted, Candidates, Available, AnyPool, []),
     length(Eligible) /= 0 orelse
 	throw(?CTX_ERR(?FATAL, no_resources_available, Context)),
-    Prio1 = hd(ergw_node_selection:candidates_by_preference(Eligible)),
-    {Node, _, _} = select(random, Prio1),
+    {{Node, _, _}, _} = ergw_node_selection:snaptr_candidate(Eligible),
     {Pid, NodeCaps} = maps:get(Node, Available),
     {_, SVRFs, SPools} = common_caps(Wanted, NodeCaps, AnyPool),
     VRF = maps:get(select(random, maps:keys(SVRFs)), SVRFs),

--- a/src/ergw_sx_node.erl
+++ b/src/ergw_sx_node.erl
@@ -602,26 +602,19 @@ connect_node({Node, _, _, IP4, IP6}, NodeSelect, _Available, Expects) ->
 
 %% connect_sx_candidates/1
 connect_sx_candidates(Candidates) ->
-    PrefC = ergw_node_selection:candidates_by_preference(Candidates),
     Available = ergw_sx_node_reg:available(),
-    connect_sx_candidates(PrefC, Available).
+    connect_sx_candidates(Candidates, Available).
 
 %% connect_sx_candidates/2
 connect_sx_candidates([], _Available) ->
     {error, not_found};
-connect_sx_candidates([H|T], Available) ->
-    connect_sx_candidates(H, T, Available).
-
-%% connect_sx_candidates/3
-connect_sx_candidates([], NextPrio, Available) ->
-    connect_sx_candidates(NextPrio, Available);
-connect_sx_candidates(List, NextPrio, Available) ->
-    case lb(random, List) of
+connect_sx_candidates(Candidates0, Available) ->
+    case ergw_node_selection:snaptr_candidate(Candidates0) of
 	{{Node, _, _}, _} when is_map_key(Node, Available) ->
 	    {Pid, _} = maps:get(Node, Available),
 	    {ok, Pid};
 	{_, Next} ->
-	    connect_sx_candidates(Next, NextPrio, Available)
+	    connect_sx_candidates(Next, Available)
     end.
 
 notify_up(Server, [{Pid, Ref}|_] = NotifyUp) when is_pid(Pid), is_reference(Ref) ->

--- a/src/ergw_sx_node_mngr.erl
+++ b/src/ergw_sx_node_mngr.erl
@@ -10,7 +10,7 @@
 -behaviour(gen_server).
 
 %% API
--export([start_link/0, connect/3, connect/4]).
+-export([start_link/0, connect/4, connect/5]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -27,17 +27,17 @@
 start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
-connect(Node, IP4, IP6) ->
-    connect(Node, IP4, IP6, []).
+connect(Node, NodeSelect, IP4, IP6) ->
+    connect(Node, NodeSelect, IP4, IP6, []).
 
-connect(Node, IP4, IP6, NotifyUp)
+connect(Node, NodeSelect, IP4, IP6, NotifyUp)
   when is_list(NotifyUp) ->
     case ergw_sx_node_reg:lookup(Node) of
 	{ok, Pid} = Result ->
 	    ergw_sx_node:notify_up(Pid, NotifyUp),
 	    Result;
 	_ ->
-	    gen_server:call(?SERVER, {connect, Node, IP4, IP6, NotifyUp})
+	    gen_server:call(?SERVER, {connect, Node, NodeSelect, IP4, IP6, NotifyUp})
     end.
 
 %%%===================================================================
@@ -49,13 +49,13 @@ init([]) ->
     {ok, #state{}}.
 
 %% serialize lockup/new
-handle_call({connect, Node, IP4, IP6, NotifyUp}, _From, State) ->
+handle_call({connect, Node, NodeSelect, IP4, IP6, NotifyUp}, _From, State) ->
     case ergw_sx_node_reg:lookup(Node) of
 	{ok, Pid} = Result ->
 	    ergw_sx_node:notify_up(Pid, NotifyUp),
 	    {reply, Result, State};
 	_ ->
-	    Result = ergw_sx_node_sup:new(Node, IP4, IP6, NotifyUp),
+	    Result = ergw_sx_node_sup:new(Node, NodeSelect, IP4, IP6, NotifyUp),
 	    {reply, Result, State}
     end;
 handle_call(_Request, _From, State) ->

--- a/src/ergw_sx_node_sup.erl
+++ b/src/ergw_sx_node_sup.erl
@@ -10,7 +10,7 @@
 -behaviour(supervisor).
 
 %% API
--export([start_link/0, new/3, new/4]).
+-export([start_link/0, new/4, new/5]).
 
 %% Supervisor callbacks
 -export([init/1]).
@@ -24,11 +24,11 @@
 start_link() ->
     supervisor:start_link({local, ?SERVER}, ?MODULE, []).
 
-new(Node, IP4, IP6)->
-    new(Node, IP4, IP6, []).
+new(Node, NodeSelect, IP4, IP6)->
+    new(Node, NodeSelect, IP4, IP6, []).
 
-new(Node, IP4, IP6, NotifyUp)->
-    supervisor:start_child(?SERVER, [Node, IP4, IP6, NotifyUp]).
+new(Node, NodeSelect, IP4, IP6, NotifyUp)->
+    supervisor:start_child(?SERVER, [Node, NodeSelect, IP4, IP6, NotifyUp]).
 
 %% ===================================================================
 %% Supervisor callbacks

--- a/src/ggsn_gn.erl
+++ b/src/ggsn_gn.erl
@@ -332,7 +332,7 @@ handle_request(ReqKey,
     APN_FQDN = ergw_node_selection:apn_to_fqdn(APN),
     Services = [{"x-3gpp-upf", "x-sxb"}],
     Candidates = ergw_node_selection:topology_select(APN_FQDN, [], Services, NodeSelect),
-    SxConnectId = ergw_sx_node:request_connect(Candidates, 1000),
+    SxConnectId = ergw_sx_node:request_connect(Candidates, NodeSelect, 1000),
 
     EUA = maps:get(?'End User Address', IEs, undefined),
     DAF = proplists:get_bool('Dual Address Bearer Flag', gtp_v1_c:get_common_flags(IEs)),

--- a/src/ggsn_gn_proxy.erl
+++ b/src/ggsn_gn_proxy.erl
@@ -291,7 +291,7 @@ handle_request(ReqKey,
 
     {ProxyGtpPort, DPCandidates} =
 	ergw_proxy_lib:select_proxy_sockets(ProxyGGSN, ProxyInfo, Data),
-    SxConnectId = ergw_sx_node:request_connect(DPCandidates, 1000),
+    SxConnectId = ergw_sx_node:request_connect(DPCandidates, NodeSelect, 1000),
 
     {ok, _} = ergw_aaa_session:invoke(Session, SessionOpts, start, #{async => true}),
 

--- a/src/pgw_s5s8.erl
+++ b/src/pgw_s5s8.erl
@@ -364,7 +364,7 @@ handle_request(ReqKey,
 	    _ -> []
 	end,
     Candidates = ergw_node_selection:topology_select(APN_FQDN, SGWuNode, Services, NodeSelect),
-    SxConnectId = ergw_sx_node:request_connect(Candidates, 1000),
+    SxConnectId = ergw_sx_node:request_connect(Candidates, NodeSelect, 1000),
 
     Context1 = update_context_tunnel_ids(FqCntlTEID, FqDataTEID, Context0),
     Context2 = update_context_from_gtp_req(Request, Context1),

--- a/src/pgw_s5s8_proxy.erl
+++ b/src/pgw_s5s8_proxy.erl
@@ -298,7 +298,7 @@ handle_request(ReqKey,
 
     {ProxyGtpPort, DPCandidates} =
 	ergw_proxy_lib:select_proxy_sockets(ProxyGGSN, ProxyInfo, Data),
-    SxConnectId = ergw_sx_node:request_connect(DPCandidates, 1000),
+    SxConnectId = ergw_sx_node:request_connect(DPCandidates, NodeSelect, 1000),
 
     {ok, _} = ergw_aaa_session:invoke(Session, SessionOpts, start, #{async =>true}),
 

--- a/src/saegw_s11.erl
+++ b/src/saegw_s11.erl
@@ -345,7 +345,7 @@ handle_request(ReqKey,
     APN_FQDN = ergw_node_selection:apn_to_fqdn(APN),
     Services = [{"x-3gpp-upf", "x-sxb"}],
     Candidates = ergw_node_selection:topology_select(APN_FQDN, [], Services, NodeSelect),
-    SxConnectId = ergw_sx_node:request_connect(Candidates, 1000),
+    SxConnectId = ergw_sx_node:request_connect(Candidates, NodeSelect, 1000),
 
     PAA = maps:get(?'PDN Address Allocation', IEs, undefined),
     IndF = maps:get(?'Indication', IEs, #v2_indication{flags = []}),


### PR DESCRIPTION
A DNS server might return the A records a NAPTR rr points to in the
AR section or it might not. When the A record is not available, do
a DNS lookup as part of the connect procedure (GTP and PFCP sockets).