### PR TITLE
Feature: Switch to Erlang/OTP 23

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,7 +35,7 @@ build:otp-22.3:
 build:otp-23.0:
   <<: *build_otp
   allow_failure: true
-  image: erlang:23.0-rc3-alpine
+  image: erlang:23.0-alpine
 
 .check:otp: &check_otp
   stage: test
@@ -77,7 +77,7 @@ check:otp-22.3:
 
 check:otp-23.0:
   <<: *check_otp
-  image: erlang:23.0-rc3-alpine
+  image: erlang:23.0-alpine
   dependencies:
     - build:otp-23.0
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ build:otp-22.2:
 
 build:otp-22.3:
   <<: *build_otp
-  image: erlang:22.3.1-alpine
+  image: erlang:22.3.3-alpine
 
 build:otp-23.0:
   <<: *build_otp
@@ -71,14 +71,13 @@ check:otp-22.2:
 
 check:otp-22.3:
   <<: *check_otp
-  image: erlang:22.3.1-alpine
+  image: erlang:22.3.3-alpine
   dependencies:
     - build:otp-22.3
 
 check:otp-23.0:
   <<: *check_otp
   image: erlang:23.0-rc3-alpine
-  allow_failure: true
   dependencies:
     - build:otp-23.0
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # -- build-environment --
 # see https://docs.docker.com/engine/userguide/eng-image/multistage-build/
 
-FROM erlang:22.3.1-alpine AS build-env
+FROM erlang:23.0-rc3-alpine AS build-env
 
 WORKDIR /build
 RUN     apk update && apk --no-cache upgrade && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,27 +1,28 @@
 # -- build-environment --
 # see https://docs.docker.com/engine/userguide/eng-image/multistage-build/
 
-FROM erlang:23.0-rc3-alpine AS build-env
+FROM erlang:23.0-alpine AS build-env
+
+ARG     REBAR3_URL="https://github.com/erlang/rebar3/releases/download/3.13.1/rebar3"
 
 WORKDIR /build
 RUN     apk update && apk --no-cache upgrade && \
 		apk --no-cache add \
-		gcc \
-		git \
-		libc-dev libc-utils \
-		libgcc \
-		linux-headers \
-		make bash \
-		musl-dev musl-utils \
-		ncurses-dev \
-		pcre2 \
-		pkgconf \
-		scanelf \
-		wget \
-		zlib
+			gcc \
+			git \
+			libc-dev libc-utils \
+			libgcc \
+			linux-headers \
+			make bash \
+			musl-dev musl-utils \
+			ncurses-dev \
+			pcre2 \
+			pkgconf \
+			scanelf \
+			zlib
 
-RUN     wget -O /usr/local/bin/rebar3 https://s3.amazonaws.com/rebar3/rebar3 && \
-		chmod a+x /usr/local/bin/rebar3
+ADD     "$REBAR3_URL" /usr/local/bin/rebar3
+RUN     chmod a+x /usr/local/bin/rebar3
 
 ADD     . /build
 RUN     rebar3 as prod release


### PR DESCRIPTION
By using Erlang/OTP 23.0, the disfunctional "netdev" - config option becomes functional again, due to the upstream bugfix erlang/otp#2600.

In addition to use Erlang/OTP 23.0 as the runtime for the docker image,
this PR pins the used rebar3 version to a specific version. This provides less surprises upon build runs.