### PR TITLE
Switch to Erlang/OTP-23.0.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,7 +35,7 @@ build:otp-22.3:
 build:otp-23.0:
   <<: *build_otp
   allow_failure: true
-  image: erlang:23.0-alpine
+  image: erlang:23.0.1-alpine
 
 .check:otp: &check_otp
   stage: test
@@ -77,7 +77,7 @@ check:otp-22.3:
 
 check:otp-23.0:
   <<: *check_otp
-  image: erlang:23.0-alpine
+  image: erlang:23.0.1-alpine
   dependencies:
     - build:otp-23.0
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # -- build-environment --
 # see https://docs.docker.com/engine/userguide/eng-image/multistage-build/
 
-FROM erlang:23.0-alpine AS build-env
+FROM erlang:23.0.1-alpine AS build-env
 
 ARG     REBAR3_URL="https://github.com/erlang/rebar3/releases/download/3.13.1/rebar3"
 


### PR DESCRIPTION
Upstream released a new version of Erlang/OTP to address several issues,
see [1]. Among those are compiler fixes which could produce faulty code
and improvements in handling UDP (and SCTP) sockets. To avoid hunting
ghost issues fixed already upstream, this commit switches to the new
available OTP.

[1]: https://erlang.org/pipermail/erlang-announce/2020-May/000112.html