### PR TITLE
upgrade to OTP-23.0.2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,22 +20,14 @@ before_script:
     - wget https://s3.amazonaws.com/rebar3/rebar3 && chmod a+x rebar3
     - ./rebar3 compile
 
-build:otp-22.1:
-  <<: *build_otp
-  image: erlang:22.1.8-alpine
-
-build:otp-22.2:
-  <<: *build_otp
-  image: erlang:22.2.8-alpine
-
 build:otp-22.3:
   <<: *build_otp
-  image: erlang:22.3.3-alpine
+  image: erlang:22.3.4-alpine
 
 build:otp-23.0:
   <<: *build_otp
   allow_failure: true
-  image: erlang:23.0.1-alpine
+  image: erlang:23.0.3-alpine
 
 .check:otp: &check_otp
   stage: test
@@ -57,27 +49,15 @@ build:otp-23.0:
     - ./rebar3 do xref
     - ./rebar3 do ct
 
-check:otp-22.1:
-  <<: *check_otp
-  image: erlang:22.1.8-alpine
-  dependencies:
-    - build:otp-22.1
-
-check:otp-22.2:
-  <<: *check_otp
-  image: erlang:22.2.8-alpine
-  dependencies:
-    - build:otp-22.2
-
 check:otp-22.3:
   <<: *check_otp
-  image: erlang:22.3.3-alpine
+  image: erlang:22.3.4-alpine
   dependencies:
     - build:otp-22.3
 
 check:otp-23.0:
   <<: *check_otp
-  image: erlang:23.0.1-alpine
+  image: erlang:23.0.3-alpine
   dependencies:
     - build:otp-23.0
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,8 @@ git:
 language: erlang
 
 otp_release:
- - 22.1.8.1
- - 22.2.8
- - 22.3.1
+ - 22.3.4
+ - 23.0.2
 
 install: "true"
 
@@ -52,7 +51,7 @@ jobs:
     #   arch: arm64
     #   otp_release: 22.0.5
     - stage: docker
-      otp_release: 22.3.1
+      otp_release: 22.3.4
       script:
         - docker build -t $BUILD_IMAGE -f docker/Dockerfile .
       after_success:

--- a/README.md
+++ b/README.md
@@ -91,12 +91,10 @@ ERLANG Version Support
 ----------------------
 
 All minor version of the current major release and the highest minor version of
-the previous major release will be supported. As an exception to the rule stated
-in the previous paragraph is currently the minimum required version OTP 22.1.8.
-The reason is the move to the official OTP socket.erl module and the bug that
-has exposed in older versions. However, due to a bug in OTP 22.x, the `netdev`
-configuration option of *erGW* is broken ([see](https://github.com/erlang/otp/pull/2600)).
-If you need this feature, you must use OTP 23.x.
+the previous major release will be supported.
+Due to a bug in OTP 22.x, the `netdev` configuration option of *erGW* is broken
+([see](https://github.com/erlang/otp/pull/2600)). If you need this feature, you
+must use OTP 23.x.
 
 When in doubt check the `otp_release` section in [.travis.yml](.travis.yml) for tested
 versions.
@@ -110,9 +108,9 @@ and by gitlab.com and pushed to [quay.io](https://quay.io/repository/travelping/
 BUILDING
 --------
 
-*The minimum supported Erlang version is 22.1.8.*
+*The minimum supported Erlang version is 22.3.4.*
 
-Erlang 23.0.1 is the recommended version.
+Erlang 23.0.3 is the recommended version.
 
 Using rebar:
 
@@ -324,4 +322,4 @@ The configuration is documented in [CONFIG.md](CONFIG.md)
 [travis badge]: https://img.shields.io/travis/com/travelping/ergw/master.svg?style=flat-square
 [coveralls]: https://coveralls.io/github/travelping/ergw
 [coveralls badge]: https://img.shields.io/coveralls/travelping/ergw/master.svg?style=flat-square
-[erlang version badge]: https://img.shields.io/badge/erlang-R22.1.8%20to%2023.0.1-blue.svg?style=flat-square
+[erlang version badge]: https://img.shields.io/badge/erlang-R22.3.4%20to%2023.0.2-blue.svg?style=flat-square

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,7 @@
 # -- build-environment --
 # see https://docs.docker.com/engine/userguide/eng-image/multistage-build/
 
-FROM erlang:23.0.1-alpine AS build-env
-
-ARG     REBAR3_URL="https://github.com/erlang/rebar3/releases/download/3.13.1/rebar3"
+FROM erlang:23.0.3-alpine AS build-env
 
 WORKDIR /build
 RUN     apk update && apk --no-cache upgrade && \
@@ -20,9 +18,6 @@ RUN     apk update && apk --no-cache upgrade && \
 			pkgconf \
 			scanelf \
 			zlib
-
-ADD     "$REBAR3_URL" /usr/local/bin/rebar3
-RUN     chmod a+x /usr/local/bin/rebar3
 
 ADD     . /build
 RUN     rebar3 as prod release

--- a/rebar.config
+++ b/rebar.config
@@ -18,7 +18,7 @@
 	{prometheus_diameter_collector, {git, "https://github.com/travelping/prometheus_diameter_collector.git", {branch, "master"}}}
 ]}.
 
-{minimum_otp_vsn, "22.1"}.
+{minimum_otp_vsn, "22.3"}.
 
 {profiles, [
 	    {test, [


### PR DESCRIPTION
Now that 23.0 seems to be stable and in accordance with the version support statement,
drop support for everything before 22.3.