### PR TITLE
rework IP pool to be asynchronous and reusable

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -24,8 +24,8 @@ The following metrics exist:
 | gtp\_c\_socket\_errors\_total                   | counter   | name, direction, error                         | Total number of GTP errors on socket                     |
 | gtp\_c\_socket\_request\_duration\_microseconds | histogram | name, version, type                            | GTP Request execution time.                              |
 | gtp\_u\_socket\_messages\_processed\_total      | counter   | name, direction, version, type                 | Total number of GTP message processed on socket          |
-| ergw\_ip\_pool\_free                            | gauge     | name, type, id                                 | Number of free IPs                                       |
-| ergw\_ip\_pool\_used                            | gauge     | name, type, id                                 | Number of used IPs                                       |
+| ergw\_local\_pool\_free                         | gauge     | name, type, id                                 | Number of free IPs                                       |
+| ergw\_local\_pool\_used                         | gauge     | name, type, id                                 | Number of used IPs                                       |
 
 The label `name` is is taken from the configuration of the GTP socket and PeerIP is the IP address of
 the peer GSN.

--- a/src/ergw_config.erl
+++ b/src/ergw_config.erl
@@ -18,6 +18,7 @@
 	 check_unique_keys/2,
 	 validate_ip_cfg_opt/2,
 	 opts_fold/3,
+	 get_opt/3,
 	 to_map/1]).
 
 -define(DefaultOptions, [{plmn_id, {<<"001">>, <<"01">>}},
@@ -425,8 +426,7 @@ validate_apn_option({prefered_bearer_type = Opt, Type})
     {Opt, Type};
 validate_apn_option({ipv6_ue_interface_id = Opt, Type})
   when Type =:= default;
-       Type =:= random;
-       Type =:= sgsnemu ->
+       Type =:= random ->
     {Opt, Type};
 validate_apn_option({ipv6_ue_interface_id, {0,0,0,0,E,F,G,H}} = Opt)
   when E >= 0, E < 65536, F >= 0, F < 65536,

--- a/src/ergw_inet.erl
+++ b/src/ergw_inet.erl
@@ -7,7 +7,8 @@
 
 -module(ergw_inet).
 
--export([ip2bin/1, bin2ip/1, ipv6_interface_id/2, ipv6_interface_id/3,
+-export([ip2bin/1, bin2ip/1,
+	 ipv6_interface_id/1, ipv6_interface_id/2, ipv6_interface_id/3,
 	 ipv6_prefix/1, ipv6_prefix/2]).
 -export([ip_csum/1, make_udp/5]).
 
@@ -47,10 +48,13 @@ ipv6_interface_id(Prefix, PrefixLen, InterfaceId)
     <<_:PrefixLen/bits, IntIdPart/bits>> = InterfaceId,
     <<PrefixPart/bits, IntIdPart/bits>>.
 
+ipv6_interface_id({{_,_,_,_,A,B,C,D}, _}) ->
+    {0,0,0,0,A,B,C,D}.
+
 ipv6_prefix({_, Len} = Prefix) when Len =:= 0, Len =:= 128 ->
     Prefix;
 ipv6_prefix({Prefix, Len}) ->
-    <<IP:Len/bits, _/binary>> = ergw_inet:ip2bin(Prefix),
+    <<IP:Len/bits, _/bitstring>> = ergw_inet:ip2bin(Prefix),
     {ergw_inet:bin2ip(<<IP/bitstring, 0:(128 - Len)>>), Len}.
 
 ipv6_prefix({Prefix, _}, Len) ->

--- a/src/ergw_ip_pool.erl
+++ b/src/ergw_ip_pool.erl
@@ -1,4 +1,4 @@
-%% Copyright 2015-2019, Travelping GmbH <info@travelping.com>
+%% Copyright 2015-2020, Travelping GmbH <info@travelping.com>
 
 %% This program is free software; you can redistribute it and/or
 %% modify it under the terms of the GNU General Public License
@@ -7,127 +7,70 @@
 
 -module(ergw_ip_pool).
 
--behavior(gen_server).
-
 %% API
--export([start_ip_pool/2, get/4, release/3, opts/2]).
--export([start_link/3, start_link/4]).
--export([validate_options/1, validate_option/2, validate_name/2]).
-
-%% gen_server callbacks
--export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-	 terminate/2, code_change/3]).
-
--record(state, {name, pools}).
--record(pool,  {name, type, id, first, last, shift, used, free, used_pool, free_pool}).
--record(lease, {ip, client_id}).
+-export([start_ip_pool/2, send_request/2, wait_response/1, release/1,
+	 requested/1, addr/1, ip/1, opts/1]).
+-export([static_ip/2]).
+-export([get/5]).
+-export([validate_options/1, validate_name/2]).
 
 -include_lib("kernel/include/logger.hrl").
--include_lib("stdlib/include/ms_transform.hrl").
 
 -define(IS_IPv4(X), (is_tuple(X) andalso tuple_size(X) == 4)).
 -define(IS_IPv6(X), (is_tuple(X) andalso tuple_size(X) == 8)).
 
--define(ZERO_IPv4, {0,0,0,0}).
--define(ZERO_IPv6, {0,0,0,0,0,0,0,0}).
--define(UE_INTERFACE_ID, {0,0,0,0,0,0,0,1}).
-
--define(DefaultOptions, [{ranges, []}]).
--define(IPv4Opts, ['Framed-Pool',
-		   'MS-Primary-DNS-Server',
-		   'MS-Secondary-DNS-Server',
-		   'MS-Primary-NBNS-Server',
-		   'MS-Secondary-NBNS-Server']).
--define(IPv6Opts, ['Framed-IPv6-Pool',
-		   'DNS-Server-IPv6-Address',
-		   '3GPP-IPv6-DNS-Servers']).
-
 %%====================================================================
 %% API
 %%====================================================================
 
-start_ip_pool(Name, Opts0)
-  when is_binary(Name) ->
-    Opts = validate_options(Opts0),
-    ergw_ip_pool_sup:start_ip_pool(Name, Opts).
+start_ip_pool(Name, Opts) ->
+    with_pool(Name, fun(Handler) -> apply(Handler, ?FUNCTION_NAME, [Name, Opts]) end).
 
-start_link(PoolName, Pool, Opts) ->
-    gen_server:start_link(?MODULE, [PoolName, Pool], Opts).
+send_request(ClientId, Requests) ->
+    [send_pool_request(ClientId, R) || R <- Requests].
 
-start_link(ServerName, PoolName, Pool, Opts) ->
-    gen_server:start_link(ServerName, ?MODULE, [PoolName, Pool], Opts).
+wait_response(RequestIds) ->
+    [wait_pool_response(R) || R <- RequestIds].
 
-get(Server, ClientId, IP, PrefixLen) when is_pid(Server) ->
-    gen_server:call(Server, {get, ClientId, IP, PrefixLen});
-get(Pool, ClientId, IP, PrefixLen) ->
-    call(ergw_ip_pool_reg:lookup(Pool), {get, ClientId, IP, PrefixLen}, {error, undefined}).
+release(AllocInfos) ->
+    [pool_release(AI) || AI <- AllocInfos].
 
-release(Server, IP, PrefixLen) when is_pid(Server) ->
-    gen_server:call(Server, {release, IP, PrefixLen});
-release(Pool, IP, PrefixLen) ->
-    call(ergw_ip_pool_reg:lookup(Pool), {release, IP, PrefixLen}, ok).
+requested(AllocInfo) ->
+    AllocInfo:requested().
 
-call(Server, Call, _) when is_pid(Server) ->
-    gen_server:call(Server, Call);
-call(_S, _, Default) ->
-    Default.
-
-opts(Type, Pool) ->
-    try
-	{ok, Pools} = application:get_env(ergw, ip_pools),
-	PoolOpts0 = maps:get(Pool, Pools),
-	PoolOpts = PoolOpts0#{name => Pool},
-	case Type of
-	    ipv4 -> maps:with(?IPv4Opts, PoolOpts);
-	    ipv6 -> maps:with(?IPv6Opts, PoolOpts)
-	end
-    catch
-	error:{badkey, _} ->
-	    #{}
+addr(AllocInfo) ->
+    case ip(AllocInfo) of
+	{IP, _} -> IP;
+	Other -> Other
     end.
 
-%%====================================================================
+ip(AllocInfo) ->
+    alloc_info(AllocInfo, ip).
+
+opts(AllocInfo) ->
+    alloc_info(AllocInfo, opts).
+
+%% compat wrapper
+get(Pool, ClientId, IP, PrefixLen, Opts) ->
+    ReqId = send_request(ClientId, [{Pool, IP, PrefixLen, Opts}]),
+    [AllocInfo] = wait_response(ReqId),
+    AllocInfo.
+
+static_ip(IP, PrefixLen) ->
+    {'$static', {IP, PrefixLen}}.
+
+%%%====================================================================
 %%% Options Validation
 %%%===================================================================
 
 validate_options(Options) ->
     ?LOG(debug, "IP Pool Options: ~p", [Options]),
-    ergw_config:validate_options(fun validate_option/2, Options, ?DefaultOptions, map).
-
-validate_ip_range({Start, End, PrefixLen} = Range)
-  when ?IS_IPv4(Start), ?IS_IPv4(End), End > Start,
-       is_integer(PrefixLen), PrefixLen > 0, PrefixLen =< 32 ->
-    Range;
-validate_ip_range({Start, End, PrefixLen} = Range)
-  when ?IS_IPv6(Start), ?IS_IPv6(End), End > Start,
-       is_integer(PrefixLen), PrefixLen > 0, PrefixLen =< 128 ->
-    if PrefixLen =:= 127 ->
-	    ?LOG(warning, "a /127 IPv6 prefix is not supported"),
-	    throw({error, {options, {range, Range}}});
-       PrefixLen =/= 64 ->
-	    ?LOG(warning, "3GPP only supports /64 IPv6 prefix assigment, "
-		 "/~w might not work, USE AT YOUR OWN RISK!", [PrefixLen]),
-	    Range;
-       true ->
-	    Range
-    end;
-validate_ip_range(Range) ->
-    throw({error, {options, {range, Range}}}).
-
-validate_option(ranges, Ranges)
-  when is_list(Ranges), length(Ranges) /= 0 ->
-    [validate_ip_range(X) || X <- Ranges];
-validate_option(Opt, Value)
-  when Opt == 'MS-Primary-DNS-Server';   Opt == 'MS-Secondary-DNS-Server';
-       Opt == 'MS-Primary-NBNS-Server';  Opt == 'MS-Secondary-NBNS-Server';
-       Opt == 'DNS-Server-IPv6-Address'; Opt == '3GPP-IPv6-DNS-Servers' ->
-    ergw_config:validate_ip_cfg_opt(Opt, Value);
-validate_option(Opt, Pool)
-  when Opt =:= 'Framed-Pool';
-       Opt =:= 'Framed-IPv6-Pool' ->
-    validate_name(Opt, Pool);
-validate_option(Opt, Value) ->
-    throw({error, {options, {Opt, Value}}}).
+    case ergw_config:get_opt(handler, Options, ergw_local_pool) of
+	ergw_local_pool ->
+	    ergw_local_pool:validate_options(Options);
+	Handler ->
+	    throw({error, {options, {handler, Handler}}})
+    end.
 
 validate_name(_, Name) when is_binary(Name) ->
     Name;
@@ -139,204 +82,39 @@ validate_name(Opt, Name) ->
    throw({error, {options, {Opt, Name}}}).
 
 %%%===================================================================
-%%% gen_server callbacks
-%%%===================================================================
-
-init([Name, #{ranges := Ranges}]) ->
-    ergw_ip_pool_reg:register(Name),
-    Pools = init_pools(Name, Ranges),
-    ?LOG(debug, "init Pool state: ~p", [Pools]),
-    {ok, #state{name = Name, pools = Pools}}.
-
-init_pools(Name, Ranges) ->
-    lists:foldl(
-      fun({First, Last, PrefixLen}, Pools)
-	    when ?IS_IPv4(First), ?IS_IPv4(Last),
-		 is_integer(PrefixLen), PrefixLen =< 32,
-		 not is_map_key({ipv4, PrefixLen}, Pools) ->
-	      Pools#{{ipv4, PrefixLen} =>
-			 init_pool(Name, ipv4, ip2int(First), ip2int(Last), 32 - PrefixLen)};
-	 ({First, Last, PrefixLen}, Pools)
-	    when ?IS_IPv6(First), ?IS_IPv6(Last),
-		 is_integer(PrefixLen), PrefixLen =< 128,
-		 not is_map_key({ipv6, PrefixLen}, Pools) ->
-	      Pools#{{ipv6, PrefixLen} =>
-			 init_pool(Name, ipv6, ip2int(First), ip2int(Last), 128 - PrefixLen)};
-	 (_, Pools) ->
-	      Pools
-      end, #{}, Ranges).
-
-init_table(_tetTid, Start, End)
-  when Start > End ->
-    ok;
-init_table(Tid, Start, End) ->
-    ets:insert(Tid, #lease{ip = Start}),
-    init_table(Tid, Start + 1, End).
-
-handle_call({get, ClientId, Type, PrefixLen}, _From, #state{pools = Pools} = State)
-  when is_atom(Type), is_map_key({Type, PrefixLen}, Pools) ->
-    Key = {Type, PrefixLen},
-    {Response, Pool} = allocate_ip(ClientId, maps:get(Key, Pools)),
-    ?LOG(debug, "~w: Allocate IPv: ~p -> ~p, Pool: ~p", [self(), ClientId, Response, Pool]),
-    {reply, Response, State#state{pools = maps:put(Key, Pool, Pools)}};
-
-handle_call({get, ClientId, ReqIP, PrefixLen}, _From, #state{pools = Pools} = State)
-  when is_tuple(ReqIP) ->
-    Key = {type(ReqIP), PrefixLen},
-    {Reply, Pool} = take_ip(ClientId, ip2int(ReqIP), maps:get(Key, Pools, undefined)),
-    {reply, Reply, State#state{pools = maps:put(Key, Pool, Pools)}};
-
-%% WTF???
-%% handle_call({get, _ClientId, _Type, _PrefixLen}, _From, State) ->
-%%     {reply, {error, invalid}, State};
-
-handle_call({release, IP, PrefixLen}, _From, #state{pools = Pools} = State) ->
-    Key = {type(IP), PrefixLen},
-    Pool = release_ip(ip2int(IP), maps:get(Key, Pools, undefined)),
-    {reply, ok, State#state{pools = maps:put(Key, Pool, Pools)}};
-
-handle_call(Request, _From, State) ->
-    ?LOG(warning, "handle_call: ~p", [Request]),
-    {reply, error, State}.
-
-handle_cast(Msg, State) ->
-    ?LOG(debug, "handle_cast: ~p", [Msg]),
-    {noreply, State}.
-
-handle_info(Info, State) ->
-    ?LOG(debug, "handle_info: ~p", [Info]),
-    {noreply, State}.
-
-terminate(_Reason, _State) ->
-    ok.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
-
-%%%===================================================================
 %%% Internal functions
 %%%===================================================================
-ip2int({A, B, C, D}) ->
-    (A bsl 24) + (B bsl 16) + (C bsl 8) + D;
-ip2int({A, B, C, D, E, F, G, H}) ->
-    (A bsl 112) + (B bsl 96) + (C bsl 80) + (D bsl 64) +
-	(E bsl 48) + (F bsl 32) + (G bsl 16) + H.
 
-int2ip(ipv4, IP) ->
-    <<A:8, B:8, C:8, D:8>> = <<IP:32>>,
-    {A, B, C, D};
-int2ip(ipv6, IP) ->
-    <<A:16, B:16, C:16, D:16, E:16, F:16, G:16, H:16>> = <<IP:128>>,
-    {A, B, C, D, E, F, G, H}.
+alloc_info(Info, F) when element(1, Info) =:= '$static' ->
+    static_ip_info(F, Info);
+alloc_info(Tuple, F) when is_tuple(Tuple) ->
+    apply(element(1, Tuple), F, [Tuple]);
+alloc_info(_, _) ->
+    undefined.
 
-id2ip(Id, #pool{type = ipv4, shift = Shift}) ->
-    {int2ip(ipv4, Id bsl Shift), 32 - Shift};
-id2ip(Id, #pool{type = ipv6, shift = Shift}) ->
-    {int2ip(ipv6, Id bsl Shift), 128 - Shift}.
+static_ip_info(ip, {_, Addr}) -> Addr;
+static_ip_info(opts,   _) -> #{};
+static_ip_info(release, _) -> ok.
 
-type(IP) when ?IS_IPv4(IP) -> ipv4;
-type(IP) when ?IS_IPv6(IP) -> ipv6.
-
-%%%===================================================================
-%%% Pool functions
-%%%===================================================================
-
-init_pool(Name, Type, First, Last, Shift) ->
-    UsedTid = ets:new(used_pool, [set, {keypos, #lease.ip}]),
-    FreeTid = ets:new(free_pool, [set, {keypos, #lease.ip}]),
-
-    Id = inet:ntoa(int2ip(Type, First)),
-    Start = First bsr Shift,
-    End = Last bsr Shift,
-    Size = End - Start + 1,
-    ?LOG(debug, "init Pool ~w ~p - ~p (~p)", [Id, Start, End, Size]),
-    init_table(FreeTid, Start, End),
-
-    prometheus_gauge:declare([{name, ergw_ip_pool_free},
-			      {labels, [name, type, id]},
-			      {help, "Free IP addresses in pool"}]),
-    prometheus_gauge:declare([{name, ergw_ip_pool_used},
-			      {labels, [name, type, id]},
-			      {help, "Used IP addresses in pool"}]),
-
-    Pool = #pool{
-	      name = Name, type = Type, id = Id,
-	      first = First, last = Last, shift = Shift,
-	      used = 0, free = Size,
-	      used_pool = UsedTid, free_pool = FreeTid},
-    metrics_sync_gauges(Pool),
-    ?LOG(debug, "init Pool state: ~p", [Pool]),
-    Pool.
-
-allocate_ip(ClientId, #pool{used = Used, free = Free,
-			 used_pool = UsedTid, free_pool = FreeTid} = Pool0)
-  when Free =/= 0 ->
-    ?LOG(debug, "~w: Allocate Pool: ~p", [self(), Pool0]),
-
-    Id = ets:first(FreeTid),
-    ets:delete(FreeTid, Id),
-    ets:insert(UsedTid, #lease{ip = Id, client_id = ClientId}),
-    IP = id2ip(Id, Pool0),
-    Pool = Pool0#pool{used = Used + 1, free = Free - 1},
-    metrics_sync_gauges(Pool),
-    {{ok, IP}, Pool};
-allocate_ip(_ClientId, Pool) ->
-    {{error, empty}, Pool}.
-
-release_ip(IP, #pool{first = First, last = Last,
-		      shift = Shift,
-		      used = Used, free = Free,
-		      used_pool = UsedTid, free_pool = FreeTid} = Pool0)
-  when IP >= First andalso IP =< Last ->
-    Id = IP bsr Shift,
-
-    case ets:take(UsedTid, Id) of
-	[_] ->
-	    ets:insert(FreeTid, #lease{ip = Id}),
-	    Pool = Pool0#pool{used = Used - 1, free = Free + 1},
-	    metrics_sync_gauges(Pool),
-	    Pool;
+with_pool(Pool, Fun) ->
+    case application:get_env(ip_pools) of
+	{ok, #{Pool := #{handler := Handler}}} ->
+	    Fun(Handler);
 	_ ->
-	    ?LOG(warning, "release of unallocated IP: ~p", [id2ip(Id, Pool0)]),
-	    Pool0
-    end;
-release_ip(IP, #pool{type = Type, first = First, last = Last} = Pool) ->
-    ?LOG(warning, "release of out-of-pool IP: ~w < ~w < ~w",
-	 [int2ip(Type, First), int2ip(Type, IP), int2ip(Type, Last)]),
-    Pool;
-release_ip(_IP, Pool) ->
-    Pool.
+	    {error, not_found}
+    end.
 
-take_ip(ClientId, IP, #pool{first = First, last = Last,
-			     shift = Shift,
-			     used = Used, free = Free,
-			     used_pool = UsedTid, free_pool = FreeTid} = Pool0)
-  when IP >= First andalso IP =< Last ->
-    Id = IP bsr Shift,
+send_pool_request(_ClientId, skip) ->
+    skip;
+send_pool_request(ClientId, {Pool, _, _, _} = Req) ->
+    with_pool(Pool, fun(Handler) -> {Handler, apply(Handler, ?FUNCTION_NAME, [ClientId, Req])} end).
 
-    case ets:take(FreeTid, Id) of
-	[_] ->
-	    ets:insert(UsedTid, #lease{ip = Id, client_id = ClientId}),
-	    Pool = Pool0#pool{used = Used + 1, free = Free - 1},
-	    metrics_sync_gauges(Pool),
-	    {{ok, id2ip(Id, Pool)}, Pool};
-	_ ->
-	    ?LOG(warning, "attempt to take already allocated IP: ~p", [id2ip(Id, Pool0)]),
-	    {{error, taken}, Pool0}
-    end;
-take_ip(_ClientId, IP, #pool{type = Type, first = First, last = Last} = Pool) ->
-    ?LOG(warning, "attempt to take of out-of-pool IP: ~w < ~w < ~w",
-	 [int2ip(Type, First), int2ip(Type, IP), int2ip(Type, Last)]),
-    {{error, out_of_pool}, Pool};
-take_ip(_ClientId, _IP, Pool) ->
-    {{error, out_of_pool}, Pool}.
+wait_pool_response(skip) ->
+    skip;
+wait_pool_response({error, _Reason} = Error) ->
+    Error;
+wait_pool_response({Handler, ReqId}) ->
+    Handler:wait_pool_response(ReqId).
 
-%%%===================================================================
-%%% metrics functions
-%%%===================================================================
-
-metrics_sync_gauges(#pool{name = Name, type = Type, id = Id,
-		       used = Used, free = Free}) ->
-    prometheus_gauge:set(ergw_ip_pool_free, [Name, Type, Id], Free),
-    prometheus_gauge:set(ergw_ip_pool_used, [Name, Type, Id], Used),
-    ok.
+pool_release(AI) ->
+    alloc_info(AI, release).

--- a/src/ergw_local_pool.erl
+++ b/src/ergw_local_pool.erl
@@ -1,0 +1,351 @@
+%% Copyright 2015-2020, Travelping GmbH <info@travelping.com>
+
+%% This program is free software; you can redistribute it and/or
+%% modify it under the terms of the GNU General Public License
+%% as published by the Free Software Foundation; either version
+%% 2 of the License, or (at your option) any later version.
+
+-module(ergw_local_pool).
+
+-behavior(gen_server).
+
+%% API
+-export([start_ip_pool/2, send_pool_request/2, wait_pool_response/1, release/1, ip/1, opts/1]).
+-export([start_link/3, start_link/4]).
+-export([validate_options/1, validate_option/2]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+	 terminate/2, code_change/3]).
+
+-record(state, {name, pools, ipv4_opts, ipv6_opts}).
+-record(pool,  {name, type, id, first, last, shift, used, free, used_pool, free_pool}).
+-record(lease, {ip, client_id}).
+
+-include_lib("kernel/include/logger.hrl").
+-include_lib("stdlib/include/ms_transform.hrl").
+
+-define(IS_IPv4(X), (is_tuple(X) andalso tuple_size(X) == 4)).
+-define(IS_IPv6(X), (is_tuple(X) andalso tuple_size(X) == 8)).
+
+-define(ZERO_IPv4, {0,0,0,0}).
+-define(ZERO_IPv6, {0,0,0,0,0,0,0,0}).
+-define(UE_INTERFACE_ID, {0,0,0,0,0,0,0,1}).
+
+-define(DefaultOptions, [{handler, ?MODULE}, {ranges, []}]).
+-define(IPv4Opts, ['Framed-Pool',
+		   'MS-Primary-DNS-Server',
+		   'MS-Secondary-DNS-Server',
+		   'MS-Primary-NBNS-Server',
+		   'MS-Secondary-NBNS-Server']).
+-define(IPv6Opts, ['Framed-IPv6-Pool',
+		   'DNS-Server-IPv6-Address',
+		   '3GPP-IPv6-DNS-Servers']).
+
+%%====================================================================
+%% API
+%%====================================================================
+
+start_ip_pool(Name, Opts0)
+  when is_binary(Name) ->
+    Opts = validate_options(Opts0),
+    ergw_ip_pool_sup:start_local_pool_sup(),
+    ergw_local_pool_sup:start_ip_pool(Name, Opts).
+
+start_link(PoolName, Pool, Opts) ->
+    gen_server:start_link(?MODULE, [PoolName, Pool], Opts).
+
+start_link(ServerName, PoolName, Pool, Opts) ->
+    gen_server:start_link(ServerName, ?MODULE, [PoolName, Pool], Opts).
+
+send_pool_request(ClientId, {Pool, IP, PrefixLen, Opts}) when is_pid(Pool) ->
+    gen_server:send_request(Pool, {get, ClientId, IP, PrefixLen, Opts});
+send_pool_request(ClientId, {Pool, IP, PrefixLen, Opts}) ->
+    send_request(ergw_local_pool_reg:lookup(Pool), {get, ClientId, IP, PrefixLen, Opts}).
+
+wait_pool_response(ReqId) ->
+    case gen_server:wait_response(ReqId, 1000) of
+	%% {reply, {error, _}} ->
+	%%     undefined;
+	{reply, Reply} ->
+	    Reply;
+	timeout ->
+	    undefined;
+	{error, _} ->
+	    undefined
+    end.
+
+release({_, Server, {IP, _}, Pool, _Opts}) ->
+    %% see alloc_reply
+    gen_server:cast(Server, {release, IP, Pool}).
+
+send_request(Server, Request) ->
+    gen_server:send_request(Server, Request).
+
+ip({?MODULE, _, IP, _, _}) -> IP.
+opts({?MODULE, _, _, _, Opts}) -> Opts.
+
+%%====================================================================
+%%% Options Validation
+%%%===================================================================
+
+validate_options(Options) ->
+    ?LOG(debug, "IP Pool Options: ~p", [Options]),
+    ergw_config:validate_options(fun validate_option/2, Options, ?DefaultOptions, map).
+
+validate_ip_range({Start, End, PrefixLen} = Range)
+  when ?IS_IPv4(Start), ?IS_IPv4(End), End > Start,
+       is_integer(PrefixLen), PrefixLen > 0, PrefixLen =< 32 ->
+    Range;
+validate_ip_range({Start, End, PrefixLen} = Range)
+  when ?IS_IPv6(Start), ?IS_IPv6(End), End > Start,
+       is_integer(PrefixLen), PrefixLen > 0, PrefixLen =< 128 ->
+    if PrefixLen =:= 127 ->
+	    ?LOG(warning, "a /127 IPv6 prefix is not supported"),
+	    throw({error, {options, {range, Range}}});
+       PrefixLen =/= 64 ->
+	    ?LOG(warning, "3GPP only supports /64 IPv6 prefix assigment, "
+		 "/~w might not work, USE AT YOUR OWN RISK!", [PrefixLen]),
+	    Range;
+       true ->
+	    Range
+    end;
+validate_ip_range(Range) ->
+    throw({error, {options, {range, Range}}}).
+
+validate_option(ranges, Ranges)
+  when is_list(Ranges), length(Ranges) /= 0 ->
+    [validate_ip_range(X) || X <- Ranges];
+validate_option(Opt, Value)
+  when Opt == 'MS-Primary-DNS-Server';   Opt == 'MS-Secondary-DNS-Server';
+       Opt == 'MS-Primary-NBNS-Server';  Opt == 'MS-Secondary-NBNS-Server';
+       Opt == 'DNS-Server-IPv6-Address'; Opt == '3GPP-IPv6-DNS-Servers' ->
+    ergw_config:validate_ip_cfg_opt(Opt, Value);
+validate_option(Opt, Pool)
+  when Opt =:= 'Framed-Pool';
+       Opt =:= 'Framed-IPv6-Pool' ->
+    ergw_ip_pool:validate_name(Opt, Pool);
+validate_option(handler, Value) ->
+    Value;
+validate_option(Opt, Value) ->
+    throw({error, {options, {Opt, Value}}}).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+init([Name, #{ranges := Ranges} = Opts]) ->
+    ergw_local_pool_reg:register(Name),
+    Pools = init_pools(Name, Ranges),
+    ?LOG(debug, "init Pool state: ~p", [Pools]),
+    State = #state{
+	       name = Name,
+	       pools = Pools,
+	       ipv4_opts = maps:with(?IPv4Opts, Opts),
+	       ipv6_opts = maps:with(?IPv6Opts, Opts)
+	      },
+    {ok, State}.
+
+init_pools(Name, Ranges) ->
+    lists:foldl(
+      fun({First, Last, PrefixLen}, Pools)
+	    when ?IS_IPv4(First), ?IS_IPv4(Last),
+		 is_integer(PrefixLen), PrefixLen =< 32,
+		 not is_map_key({ipv4, PrefixLen}, Pools) ->
+	      Pools#{{ipv4, PrefixLen} =>
+			 init_pool(Name, ipv4, ip2int(First), ip2int(Last), 32 - PrefixLen)};
+	 ({First, Last, PrefixLen}, Pools)
+	    when ?IS_IPv6(First), ?IS_IPv6(Last),
+		 is_integer(PrefixLen), PrefixLen =< 128,
+		 not is_map_key({ipv6, PrefixLen}, Pools) ->
+	      Pools#{{ipv6, PrefixLen} =>
+			 init_pool(Name, ipv6, ip2int(First), ip2int(Last), 128 - PrefixLen)};
+	 (_, Pools) ->
+	      Pools
+      end, #{}, Ranges).
+
+init_table(_tetTid, Start, End)
+  when Start > End ->
+    ok;
+init_table(Tid, Start, End) ->
+    ets:insert(Tid, #lease{ip = Start}),
+    init_table(Tid, Start + 1, End).
+
+handle_call({get, ClientId, Type, PrefixLen, ReqOpts}, _From, #state{pools = Pools} = State)
+  when is_atom(Type), is_map_key({Type, PrefixLen}, Pools) ->
+    Key = {Type, PrefixLen},
+    {Result, Pool} = allocate_ip(ClientId, ReqOpts, maps:get(Key, Pools)),
+    ?LOG(debug, "~w: Allocate IPv: ~p -> ~p, Pool: ~p", [self(), ClientId, Result, Pool]),
+    Reply = alloc_reply(Result, Key, State),
+    {reply, Reply, State#state{pools = maps:put(Key, Pool, Pools)}};
+
+handle_call({get, ClientId, ReqIP, PrefixLen, ReqOpts}, _From, #state{pools = Pools} = State)
+  when is_tuple(ReqIP) ->
+    Key = {type(ReqIP), PrefixLen},
+    {Result, Pool} =
+	take_ip(ClientId, ip2int(ReqIP), ReqOpts, maps:get(Key, Pools, undefined)),
+    Reply = alloc_reply(Result, Key, State),
+    {reply, Reply, State#state{pools = maps:put(Key, Pool, Pools)}};
+
+handle_call(Request, _From, State) ->
+    ?LOG(warning, "handle_call: ~p", [Request]),
+    {reply, error, State}.
+
+handle_cast({release, IP, Key}, #state{pools = Pools} = State) ->
+    Pool = release_ip(ip2int(IP), maps:get(Key, Pools, undefined)),
+    {noreply, State#state{pools = maps:put(Key, Pool, Pools)}};
+
+handle_cast(Msg, State) ->
+    ?LOG(debug, "handle_cast: ~p", [Msg]),
+    {noreply, State}.
+
+handle_info(Info, State) ->
+    ?LOG(debug, "handle_info: ~p", [Info]),
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+ip2int({A, B, C, D}) ->
+    (A bsl 24) + (B bsl 16) + (C bsl 8) + D;
+ip2int({A, B, C, D, E, F, G, H}) ->
+    (A bsl 112) + (B bsl 96) + (C bsl 80) + (D bsl 64) +
+	(E bsl 48) + (F bsl 32) + (G bsl 16) + H.
+
+int2ip(ipv4, IP) ->
+    <<A:8, B:8, C:8, D:8>> = <<IP:32>>,
+    {A, B, C, D};
+int2ip(ipv6, IP) ->
+    <<A:16, B:16, C:16, D:16, E:16, F:16, G:16, H:16>> = <<IP:128>>,
+    {A, B, C, D, E, F, G, H}.
+
+id2ip(Id, _ReqOpts, #pool{type = ipv4, shift = Shift}) ->
+    {int2ip(ipv4, Id bsl Shift), 32 - Shift};
+id2ip(Id, #{'Framed-Interface-Id' := IfId}, #pool{type = ipv6, shift = Shift}) ->
+    IP = {int2ip(ipv6, Id bsl Shift), 128 - Shift},
+    ergw_inet:ipv6_interface_id(IP, IfId);
+id2ip(Id, _ReqOpts, #pool{type = ipv6, shift = Shift}) ->
+    {int2ip(ipv6, Id bsl Shift), 128 - Shift}.
+
+type(IP) when ?IS_IPv4(IP) -> ipv4;
+type(IP) when ?IS_IPv6(IP) -> ipv6.
+
+%%%===================================================================
+%%% Pool functions
+%%%===================================================================
+
+alloc_reply({ok, {IP, _} = IPv4}, Pool, #state{ipv4_opts = Opts}) when ?IS_IPv4(IP) ->
+    {?MODULE, self(), IPv4, Pool, Opts};
+alloc_reply({ok, {IP, _} = IPv6}, Pool, #state{ipv6_opts = Opts}) when ?IS_IPv6(IP) ->
+    {?MODULE, self(), IPv6, Pool, Opts};
+alloc_reply({error, _} = Error, _, _) ->
+    Error.
+
+init_pool(Name, Type, First, Last, Shift) ->
+    UsedTid = ets:new(used_pool, [set, {keypos, #lease.ip}]),
+    FreeTid = ets:new(free_pool, [set, {keypos, #lease.ip}]),
+
+    Id = inet:ntoa(int2ip(Type, First)),
+    Start = First bsr Shift,
+    End = Last bsr Shift,
+    Size = End - Start + 1,
+    ?LOG(debug, "init Pool ~w ~p - ~p (~p)", [Id, Start, End, Size]),
+    init_table(FreeTid, Start, End),
+
+    prometheus_gauge:declare([{name, ergw_local_pool_free},
+			      {labels, [name, type, id]},
+			      {help, "Free IP addresses in pool"}]),
+    prometheus_gauge:declare([{name, ergw_local_pool_used},
+			      {labels, [name, type, id]},
+			      {help, "Used IP addresses in pool"}]),
+
+    Pool = #pool{
+	      name = Name, type = Type, id = Id,
+	      first = First, last = Last, shift = Shift,
+	      used = 0, free = Size,
+	      used_pool = UsedTid, free_pool = FreeTid},
+    metrics_sync_gauges(Pool),
+    ?LOG(debug, "init Pool state: ~p", [Pool]),
+    Pool.
+
+allocate_ip(ClientId, ReqOpts,
+	    #pool{used = Used, free = Free,
+		  used_pool = UsedTid, free_pool = FreeTid} = Pool0)
+  when Free =/= 0 ->
+    ?LOG(debug, "~w: Allocate Pool: ~p", [self(), Pool0]),
+
+    Id = ets:first(FreeTid),
+    ets:delete(FreeTid, Id),
+    ets:insert(UsedTid, #lease{ip = Id, client_id = ClientId}),
+    IP = id2ip(Id, ReqOpts, Pool0),
+    Pool = Pool0#pool{used = Used + 1, free = Free - 1},
+    metrics_sync_gauges(Pool),
+    {{ok, IP}, Pool};
+allocate_ip(_ClientId, _ReqOpts, Pool) ->
+    {{error, empty}, Pool}.
+
+release_ip(IP, #pool{first = First, last = Last,
+		      shift = Shift,
+		      used = Used, free = Free,
+		      used_pool = UsedTid, free_pool = FreeTid} = Pool0)
+  when IP >= First andalso IP =< Last ->
+    Id = IP bsr Shift,
+
+    case ets:take(UsedTid, Id) of
+	[_] ->
+	    ets:insert(FreeTid, #lease{ip = Id}),
+	    Pool = Pool0#pool{used = Used - 1, free = Free + 1},
+	    metrics_sync_gauges(Pool),
+	    Pool;
+	_ ->
+	    ?LOG(warning, "release of unallocated IP: ~p", [id2ip(Id, #{}, Pool0)]),
+	    Pool0
+    end;
+release_ip(IP, #pool{type = Type, first = First, last = Last} = Pool) ->
+    ?LOG(warning, "release of out-of-pool IP: ~w < ~w < ~w",
+	 [int2ip(Type, First), int2ip(Type, IP), int2ip(Type, Last)]),
+    Pool;
+release_ip(_IP, Pool) ->
+    Pool.
+
+take_ip(ClientId, IP, ReqOpts,
+	#pool{first = First, last = Last,
+	      shift = Shift,
+	      used = Used, free = Free,
+	      used_pool = UsedTid, free_pool = FreeTid} = Pool0)
+  when IP >= First andalso IP =< Last ->
+    Id = IP bsr Shift,
+
+    case ets:take(FreeTid, Id) of
+	[_] ->
+	    ets:insert(UsedTid, #lease{ip = Id, client_id = ClientId}),
+	    Pool = Pool0#pool{used = Used + 1, free = Free - 1},
+	    metrics_sync_gauges(Pool),
+	    {{ok, id2ip(Id, ReqOpts, Pool)}, Pool};
+	_ ->
+	    ?LOG(warning, "attempt to take already allocated IP: ~p",
+		 [id2ip(Id, ReqOpts, Pool0)]),
+	    {{error, taken}, Pool0}
+    end;
+take_ip(_ClientId, IP, _ReqOpts, #pool{type = Type, first = First, last = Last} = Pool) ->
+    ?LOG(warning, "attempt to take of out-of-pool IP: ~w < ~w < ~w",
+	 [int2ip(Type, First), int2ip(Type, IP), int2ip(Type, Last)]),
+    {{error, out_of_pool}, Pool};
+take_ip(_ClientId, _IP, _ReqOpts, Pool) ->
+    {{error, out_of_pool}, Pool}.
+
+%%%===================================================================
+%%% metrics functions
+%%%===================================================================
+
+metrics_sync_gauges(#pool{name = Name, type = Type, id = Id,
+		       used = Used, free = Free}) ->
+    prometheus_gauge:set(ergw_local_pool_free, [Name, Type, Id], Free),
+    prometheus_gauge:set(ergw_local_pool_used, [Name, Type, Id], Used),
+    ok.

--- a/src/ergw_local_pool_reg.erl
+++ b/src/ergw_local_pool_reg.erl
@@ -1,11 +1,11 @@
-%% Copyright 2016-2019, Travelping GmbH <info@travelping.com>
+%% Copyright 2016-2020, Travelping GmbH <info@travelping.com>
 
 %% This program is free software; you can redistribute it and/or
 %% modify it under the terms of the GNU General Public License
 %% as published by the Free Software Foundation; either version
 %% 2 of the License, or (at your option) any later version.
 
--module(ergw_ip_pool_reg).
+-module(ergw_local_pool_reg).
 
 -behaviour(regine_server).
 

--- a/src/ergw_local_pool_sup.erl
+++ b/src/ergw_local_pool_sup.erl
@@ -1,16 +1,16 @@
-%% Copyright 2015-2019, Travelping GmbH <info@travelping.com>
+%% Copyright 2015-2020, Travelping GmbH <info@travelping.com>
 
 %% This program is free software; you can redistribute it and/or
 %% modify it under the terms of the GNU General Public License
 %% as published by the Free Software Foundation; either version
 %% 2 of the License, or (at your option) any later version.
 
--module(ergw_ip_pool_sup).
+-module(ergw_local_pool_sup).
 
 -behaviour(supervisor).
 
 %% API
--export([start_link/0, start_local_pool_sup/0]).
+-export([start_link/0, start_ip_pool/2]).
 
 %% Supervisor callbacks
 -export([init/1]).
@@ -24,24 +24,19 @@
 start_link() ->
     supervisor:start_link({local, ?SERVER}, ?MODULE, []).
 
-start_local_pool_sup() ->
-    ChildSpecs =
-	[#{id      => ergw_local_pool_reg,
-	   start   => {ergw_local_pool_reg, start_link, []},
-	   restart => permanent,
-	   type    => worker,
-	   modules => [ergw_local_pool_reg]},
-	 #{id      => ergw_local_pool_sup,
-	   start   => {ergw_local_pool_sup, start_link, []},
-	   restart => permanent,
-	   type    => supervisor,
-	   modules => [ergw_local_pool_sup]}],
-    [supervisor:start_child(?SERVER, Cs) || Cs <- ChildSpecs],
-    ok.
+start_ip_pool(Pool, Opts) ->
+    supervisor:start_child(?SERVER, [Pool, Opts, []]).
 
 %% ===================================================================
 %% Supervisor callbacks
 %% ===================================================================
 
 init([]) ->
-    {ok, {{one_for_one, 5, 10}, []}}.
+    ChildSpec =
+	#{id       => local_pool,
+	  start    => {ergw_local_pool, start_link, []},
+	  restart  => temporary,
+	  shutdown => 1000,
+	  type     => worker,
+	  modules  => [ergw_local_pool]},
+    {ok, {{simple_one_for_one, 5, 10}, [ChildSpec]}}.

--- a/src/ergw_pfcp.erl
+++ b/src/ergw_pfcp.erl
@@ -38,21 +38,24 @@
 %%% Helper functions
 %%%===================================================================
 
-ue_ip_address(Direction, #context{ms_v4 = {MSv4,_}, ms_v6 = {MSv6,_}}) ->
-    #ue_ip_address{type = Direction, ipv4 = ergw_inet:ip2bin(MSv4),
-		   ipv6 = ergw_inet:ip2bin(MSv6)};
-ue_ip_address(Direction, #context{ms_v4 = {MSv4,_}}) ->
-    #ue_ip_address{type = Direction, ipv4 = ergw_inet:ip2bin(MSv4)};
-ue_ip_address(Direction, #context{ms_v6 = {MSv6,_}}) ->
-    #ue_ip_address{type = Direction, ipv6 = ergw_inet:ip2bin(MSv6)};
+alloc_info_addr(AI) ->
+    ergw_inet:ip2bin(ergw_ip_pool:addr(AI)).
 
-%% ue_ip_address(Direction, #tdf_ctx{ms_v4 = {MSv4,_}, ms_v6 = {MSv6,_}}) ->
-%%     #ue_ip_address{type = Direction, ipv4 = ergw_inet:ip2bin(MSv4),
-%%		   ipv6 = ergw_inet:ip2bin(MSv6)};
-ue_ip_address(Direction, #tdf_ctx{ms_v4 = {MSv4,_}}) ->
-    #ue_ip_address{type = Direction, ipv4 = ergw_inet:ip2bin(MSv4)};
-ue_ip_address(Direction, #tdf_ctx{ms_v6 = {MSv6,_}}) ->
-    #ue_ip_address{type = Direction, ipv6 = ergw_inet:ip2bin(MSv6)}.
+ue_ip_address(Direction, #context{ms_v4 = MSv4, ms_v6 = undefined})
+  when MSv4 /= undefined ->
+    #ue_ip_address{type = Direction, ipv4 = alloc_info_addr(MSv4)};
+ue_ip_address(Direction, #context{ms_v4 = undefined, ms_v6 = MSv6})
+  when MSv6 /= undefined ->
+    #ue_ip_address{type = Direction, ipv6 = alloc_info_addr(MSv6)};
+ue_ip_address(Direction, #context{ms_v4 = MSv4, ms_v6 = MSv6})
+  when MSv4 /= undefined, MSv6 /= undefined ->
+    #ue_ip_address{type = Direction, ipv4 = alloc_info_addr(MSv4),
+		   ipv6 = alloc_info_addr(MSv6)};
+
+ue_ip_address(Direction, #tdf_ctx{ms_v4 = MSv4}) when MSv4 /= undefined ->
+    #ue_ip_address{type = Direction, ipv4 = alloc_info_addr(MSv4)};
+ue_ip_address(Direction, #tdf_ctx{ms_v6 = MSv6}) when MSv6 /= undefined ->
+    #ue_ip_address{type = Direction, ipv6 = alloc_info_addr(MSv6)}.
 
 network_instance(Name)
   when is_binary(Name) ->

--- a/src/ergw_sup.erl
+++ b/src/ergw_sup.erl
@@ -44,7 +44,6 @@ init([]) ->
 				 ?CHILD(ergw_sx_node_sup, supervisor, []),
 				 ?CHILD(ergw_sx_node_mngr, worker, []),
 				 ?CHILD(gtp_proxy_ds, worker, []),
-				 ?CHILD(ergw_ip_pool_reg, worker, []),
 				 ?CHILD(ergw_ip_pool_sup, supervisor, []),
 				 ?CHILD(ergw, worker, [])
 				]} }.

--- a/src/gtp_context.erl
+++ b/src/gtp_context.erl
@@ -588,9 +588,9 @@ context2keys(#context{
       [port_teid_key(CntlPort, 'gtp-c', LocalCntlTEI),
        port_teid_key(CntlPort, 'gtp-c', RemoteCntlTEID)]
       ++ [port_key(CntlPort, ContextId) || ContextId /= undefined]
-      ++ [#bsf{dnn = APN, ip_domain = VRF, ip = MSv4} || MSv4 /= undefined]
+      ++ [#bsf{dnn = APN, ip_domain = VRF, ip = ergw_ip_pool:ip(MSv4)} || MSv4 /= undefined]
       ++ [#bsf{dnn = APN, ip_domain = VRF,
-	       ip = ergw_inet:ipv6_prefix(MSv6)} || MSv6 /= undefined]);
+	       ip = ergw_inet:ipv6_prefix(ergw_ip_pool:ip(MSv6))} || MSv6 /= undefined]);
 context2keys(#context{
 		context_id          = ContextId,
 		control_port        = CntlPort,

--- a/src/sbi_nbsf_handler.erl
+++ b/src/sbi_nbsf_handler.erl
@@ -115,9 +115,10 @@ context2binding(msisdn, #context{msisdn = MSISDN}, B) ->
 context2binding(vrf, #context{vrf = #vrf{name = VRF}}, B) ->
     B#{ipDomain =>
 	   iolist_to_binary(lists:join($. , [ Part || <<Len:8, Part:Len/bytes>> <= VRF ]))};
-context2binding(ms_v4, #context{ms_v4 = {IP, _}}, B) ->
-    B#{'ipv4Addr' => iolist_to_binary(inet:ntoa(IP))};
-context2binding(ms_v6, #context{ms_v6 = {IP, Len}}, B) ->
+context2binding(ms_v4, #context{ms_v4 = AI}, B) when AI /= undefined ->
+    B#{'ipv4Addr' => iolist_to_binary(inet:ntoa(ergw_ip_pool:addr(AI)))};
+context2binding(ms_v6, #context{ms_v6 = AI}, B) when AI /= undefined ->
+    {IP, Len} = ergw_ip_pool:ip(AI),
     B#{'ipv6Prefix' => iolist_to_binary([inet:ntoa(IP), $/, integer_to_list(Len)])};
 context2binding(_, _, B) ->
     B.

--- a/test/config_SUITE.erl
+++ b/test/config_SUITE.erl
@@ -781,7 +781,6 @@ config(_Config)  ->
     ?error_option(set_cfg_value([apns, ?'APN-EXAMPLE', prefered_bearer_type], undefined, ?GGSN_CONFIG)),
 
     ?ok_option(set_cfg_value([apns, ?'APN-EXAMPLE', ipv6_ue_interface_id], default, ?GGSN_CONFIG)),
-    ?ok_option(set_cfg_value([apns, ?'APN-EXAMPLE', ipv6_ue_interface_id], sgsnemu, ?GGSN_CONFIG)),
     ?ok_option(set_cfg_value([apns, ?'APN-EXAMPLE', ipv6_ue_interface_id], random, ?GGSN_CONFIG)),
     ?ok_option(set_cfg_value([apns, ?'APN-EXAMPLE', ipv6_ue_interface_id], {0,0,0,0,0,0,0,2}, ?GGSN_CONFIG)),
     ?error_option(set_cfg_value([apns, ?'APN-EXAMPLE', ipv6_ue_interface_id], undefined, ?GGSN_CONFIG)),

--- a/test/ergw_http_api_SUITE.erl
+++ b/test/ergw_http_api_SUITE.erl
@@ -251,7 +251,7 @@ http_api_prometheus_metrics_req(_Config) ->
     Lines = binary:split(Body, <<"\n">>, [global]),
     ct:pal("Lines: ~p", [Lines]),
     Result =
-	lists:filter(fun(<<"ergw_ip_pool_free", _/binary>>) ->
+	lists:filter(fun(<<"ergw_local_pool_free", _/binary>>) ->
 			     true;
 			(_) -> false
 		     end, Lines),


### PR DESCRIPTION
* allow IPv4 and IPv6 request to run in parallel
* keep all pool information in the allocated lease
* use stored information when releasing the IP later