### PR TITLE
demote many log output from info, error and warning to debug

### DIFF
--- a/src/ergw_context.erl
+++ b/src/ergw_context.erl
@@ -61,7 +61,7 @@ apply2context(Key, F, A) ->
 	{Handler, Server} when is_atom(Handler), is_pid(Server) ->
 	    apply(Handler, F, [Server | A]);
 	_Other ->
-	    ?LOG(error, "unable to find context ~p", [Key]),
+	    ?LOG(debug, "unable to find context ~p", [Key]),
 	    {error, not_found}
     end.
 

--- a/src/ergw_gsn_lib.erl
+++ b/src/ergw_gsn_lib.erl
@@ -136,13 +136,13 @@ session_establishment_request(PCC, PCtx0, Ctx) ->
 
     PCtx1 = pctx_update_from_ctx(PCtx0, Ctx),
     {SxRules, SxErrors, PCtx} = build_sx_rules(PCC, #{}, PCtx1, Ctx),
-    ?LOG(info, "SxRules: ~p~n", [SxRules]),
-    ?LOG(info, "SxErrors: ~p~n", [SxErrors]),
-    ?LOG(info, "CtxPending: ~p~n", [Ctx]),
+    ?LOG(debug, "SxRules: ~p~n", [SxRules]),
+    ?LOG(debug, "SxErrors: ~p~n", [SxErrors]),
+    ?LOG(debug, "CtxPending: ~p~n", [Ctx]),
 
     IEs0 = pfcp_pctx_update(PCtx, PCtx0, SxRules),
     IEs = update_m_rec(ergw_pfcp:f_seid(PCtx, CntlNode), IEs0),
-    ?LOG(info, "IEs: ~p~n", [IEs]),
+    ?LOG(debug, "IEs: ~p~n", [IEs]),
 
     Req = #pfcp{version = v1, type = session_establishment_request, ie = IEs},
     case ergw_sx_node:call(PCtx, Req, Ctx) of
@@ -528,7 +528,7 @@ build_sx_offline_charging_rule(Name,
     OCP = maps:get('Default', OCPcfg, #{}),
     URR = apply_charging_profile(URR1, OCP),
 
-    ?LOG(warning, "Offline URR: ~p", [URR]),
+    ?LOG(debug, "Offline URR: ~p", [URR]),
     Update#sx_upd{
       pctx = ergw_pfcp_rules:add(urr, ChargingKey, URR, PCtx)};
 
@@ -969,7 +969,7 @@ build_sx_usage_rule(_K, #{'Rating-Group' := [RatingGroup],
 		       total_quota_threshold, input_quota_threshold, output_quota_threshold,
 		       monitoring_time]),
 
-    ?LOG(warning, "URR: ~p", [URR]),
+    ?LOG(debug, "URR: ~p", [URR]),
     Update#sx_upd{
       pctx = ergw_pfcp_rules:add(urr, ChargingKey, URR, PCtx)};
 build_sx_usage_rule(_, _, Update) ->
@@ -989,7 +989,7 @@ build_ipcan_rule(true, #sx_upd{pctx = PCtx0} = Update) ->
 	   #measurement_method{volum = 1, durat = 1},
 	   #reporting_triggers{}],
 
-    ?LOG(warning, "URR: ~p", [URR]),
+    ?LOG(debug, "URR: ~p", [URR]),
     Update#sx_upd{pctx = ergw_pfcp_rules:add(urr, RuleName, URR, PCtx)};
 build_ipcan_rule(_, Update) ->
     Update.
@@ -1000,7 +1000,7 @@ build_sx_monitor_rule(Level, Monitors, Update) ->
 %% TBD: merging offline rules with identical timeout.... maybe
 build_sx_monitor_rule('IP-CAN', Service, {periodic, Time, _Opts} = _Definition,
 		      #sx_upd{monitors = Monitors0, pctx = PCtx0} = Update) ->
-    ?LOG(info, "Sx Monitor Rule: ~p", [_Definition]),
+    ?LOG(debug, "Sx Monitor Rule: ~p", [_Definition]),
 
     RuleName = {monitor, 'IP-CAN', Service},
     {UrrId, PCtx} = ergw_pfcp:get_urr_id(RuleName, ['IP-CAN'], RuleName, PCtx0),
@@ -1010,7 +1010,7 @@ build_sx_monitor_rule('IP-CAN', Service, {periodic, Time, _Opts} = _Definition,
 	   #reporting_triggers{periodic_reporting = 1},
 	   #measurement_period{period = Time}],
 
-    ?LOG(warning, "URR: ~p", [URR]),
+    ?LOG(debug, "URR: ~p", [URR]),
     Monitors1 = update_m_key('IP-CAN', UrrId, Monitors0),
     Monitors = Monitors1#{{urr, UrrId}  => Service},
     Update#sx_upd{
@@ -1030,7 +1030,7 @@ build_sx_monitor_rule('Offline', Service, {periodic, Time, _Opts} = Definition,
 	   #measurement_method{volum = 1, durat = 1},
 	   #reporting_triggers{periodic_reporting = 1},
 	   #measurement_period{period = Time}],
-    ?LOG(warning, "URR: ~p", [URR]),
+    ?LOG(debug, "URR: ~p", [URR]),
     URRUpd =
 	fun (X0) ->
 		X = X0#{measurement_period => #measurement_period{period = Time}},
@@ -1084,9 +1084,9 @@ modify_sgi_session(PCC, URRActions, Opts, Ctx, PCtx0)
 		  SxR
 	  end, SxRules0, URRActions),
 
-    ?LOG(info, "SxRules: ~p~n", [SxRules]),
-    ?LOG(info, "SxErrors: ~p~n", [SxErrors]),
-    ?LOG(info, "PCtx: ~p~n", [PCtx]),
+    ?LOG(debug, "SxRules: ~p~n", [SxRules]),
+    ?LOG(debug, "SxErrors: ~p~n", [SxErrors]),
+    ?LOG(debug, "PCtx: ~p~n", [PCtx]),
     session_modification_request(PCtx, SxRules, Ctx).
 
 create_tdf_session(PCtx, _NodeCaps, PCC, Ctx)

--- a/src/ergw_gtp_c_socket.erl
+++ b/src/ergw_gtp_c_socket.erl
@@ -475,7 +475,7 @@ handle_response(ArrivalTS, IP, _Port, Msg, #state{gtp_port = GtpPort} = State0) 
 	    State;
 
 	#send_req{} = SendReq ->
-	    ?LOG(info, "~p: found response: ~p", [self(), SeqId]),
+	    ?LOG(debug, "~p: found response: ~p", [self(), SeqId]),
 	    measure_reply(GtpPort, SendReq, ArrivalTS),
 	    send_request_reply(SendReq, Msg),
 	    State

--- a/src/ergw_node_selection.erl
+++ b/src/ergw_node_selection.erl
@@ -257,7 +257,7 @@ lookup_host(Name, dns, NameServers) ->
 	    Error
     end;
 lookup_host(Name, static, RR) ->
-    ?LOG(info, "Host ~p, RR ~p", [Name, RR]),
+    ?LOG(debug, "Host ~p, RR ~p", [Name, RR]),
     case lists:keyfind(Name, 1, RR) of
 	{_, _, _} = R ->
 	    R;
@@ -302,7 +302,7 @@ do_lookup(Selection, DoFun, NodeSelection) when is_atom(Selection) ->
     do_lookup([Selection], DoFun, NodeSelection).
 
 do_lookup(Selection, DoFun) ->
-    ?LOG(info, "Selection ~p in ~p", [Selection, application:get_env(ergw, node_selection, #{})]),
+    ?LOG(debug, "Selection ~p in ~p", [Selection, application:get_env(ergw, node_selection, #{})]),
     do_lookup(Selection, DoFun, application:get_env(ergw, node_selection, #{})).
 
 lookup(Name, Selection) ->

--- a/src/ergw_sx_socket.erl
+++ b/src/ergw_sx_socket.erl
@@ -537,7 +537,7 @@ cancel_timer(Ref) ->
     end.
 
 prepare_send_req(#send_req{msg = Msg0} = SendReq, State0) ->
-    ?LOG(info, "PrepSend: ~p", [SendReq]),
+    ?LOG(debug, "PrepSend: ~p", [SendReq]),
     {Msg, State} = new_sequence_number(Msg0, State0),
     ?log_pfcp(info, "PrepSend: ", [], Msg),
     BinMsg = pfcp_packet:encode(Msg),
@@ -594,10 +594,10 @@ send_request(#send_req{address = DstIP, data = Data} = SendReq, State) ->
     end.
 
 send_request_reply(#send_req{cb_info = {M, F, A}} = SendReq, Reply) ->
-    ?LOG(info, "send_request_reply: ~p", [SendReq]),
+    ?LOG(debug, "send_request_reply: ~p", [SendReq]),
     apply(M, F, A ++ [Reply]);
 send_request_reply(#send_req{from = {_, _} = From} = SendReq, Reply) ->
-    ?LOG(info, "send_request_reply: ~p", [SendReq]),
+    ?LOG(debug, "send_request_reply: ~p", [SendReq]),
     gen_server:reply(From, Reply).
 
 enqueue_response(ReqKey, Data, DoCache,

--- a/src/ggsn_gn.erl
+++ b/src/ggsn_gn.erl
@@ -389,8 +389,8 @@ handle_request(ReqKey,
 
     {ok, GySessionOpts, GyEvs} =
 	ccr_initial(ContextPending, Session, gy, GyReqServices, SOpts, Request),
-    ?LOG(info, "GySessionOpts: ~p", [GySessionOpts]),
-    ?LOG(info,"Initial GyEvs: ~p", [GyEvs]),
+    ?LOG(debug, "GySessionOpts: ~p", [GySessionOpts]),
+    ?LOG(debug,"Initial GyEvs: ~p", [GyEvs]),
 
     ergw_aaa_session:invoke(Session, #{}, start, SOpts),
     {_, _, RfSEvs} = ergw_aaa_session:invoke(Session, #{}, {rf, 'Initial'}, SOpts),
@@ -515,13 +515,13 @@ session_failure_to_gtp_cause(_) ->
     system_failure.
 
 authenticate(Context, Session, SessionOpts, Request) ->
-    ?LOG(info, "SessionOpts: ~p", [SessionOpts]),
+    ?LOG(debug, "SessionOpts: ~p", [SessionOpts]),
     case ergw_aaa_session:invoke(Session, SessionOpts, authenticate, [inc_session_id]) of
 	{ok, _, _} = Result ->
-	    ?LOG(info, "AuthResult: success"),
+	    ?LOG(debug, "AuthResult: success"),
 	    Result;
 	Other ->
-	    ?LOG(info, "AuthResult: ~p", [Other]),
+	    ?LOG(debug, "AuthResult: ~p", [Other]),
 	    ?ABORT_CTX_REQUEST(Context, Request, create_pdp_context_response,
 			       user_authentication_failed)
     end.
@@ -612,7 +612,7 @@ close_pdp_context(Reason, #{context := Context, pfcp := PCtx, 'Session' := Sessi
     ReqOpts = #{now => Now, async => true},
     case ergw_aaa_session:invoke(Session, #{}, {gx, 'CCR-Terminate'}, ReqOpts#{async => false}) of
 	{ok, _GxSessionOpts, _} ->
-	    ?LOG(info, "GxSessionOpts: ~p", [_GxSessionOpts]);
+	    ?LOG(debug, "GxSessionOpts: ~p", [_GxSessionOpts]);
 	GxOther ->
 	    ?LOG(warning, "Gx terminate failed with: ~p", [GxOther])
     end,
@@ -1153,7 +1153,7 @@ pdp_ppp_pco(SessionOpts, {?'PCO-DNS-Server-IPv4-Address', <<>>}, Opts) ->
 			end
 		end, Opts, ['MS-Secondary-DNS-Server', 'MS-Primary-DNS-Server']);
 pdp_ppp_pco(_SessionOpts, PPPReqOpt, Opts) ->
-    ?LOG(info, "Apply PPP Opt: ~p", [PPPReqOpt]),
+    ?LOG(debug, "Apply PPP Opt: ~p", [PPPReqOpt]),
     Opts.
 
 pdp_pco(SessionOpts, #{?'Protocol Configuration Options' :=

--- a/src/ggsn_gn_proxy.erl
+++ b/src/ggsn_gn_proxy.erl
@@ -402,7 +402,7 @@ handle_response(#proxy_request{direction = sgsn2ggsn} = ProxyRequest,
 		#{context := PendingContext,
 		  proxy_context := PrevProxyCtx,
 		  pfcp := PCtx0} = Data) ->
-    ?LOG(warning, "OK Proxy Response ~p", [Response]),
+    ?LOG(debug, "OK Proxy Response ~p", [Response]),
 
     ProxyContext1 = update_context_from_gtp_req(Response, PrevProxyCtx),
     ProxyContext = gtp_path:bind(Response, true, ProxyContext1),
@@ -431,7 +431,7 @@ handle_response(#proxy_request{direction = sgsn2ggsn,
 		#{context := Context,
 		  proxy_context := OldProxyContext,
 		  pfcp := PCtx0} = Data) ->
-    ?LOG(warning, "OK Proxy Response ~p", [Response]),
+    ?LOG(debug, "OK Proxy Response ~p", [Response]),
 
     ProxyContext = update_context_from_gtp_req(Response, OldProxyContext),
     gtp_context:remote_context_update(OldProxyContext, ProxyContext),
@@ -445,7 +445,7 @@ handle_response(#proxy_request{direction = sgsn2ggsn,
 handle_response(#proxy_request{direction = ggsn2sgsn} = ProxyRequest,
 		#gtp{type = update_pdp_context_response} = Response,
 		_Request, _State, #{proxy_context := ProxyContext}) ->
-    ?LOG(warning, "OK SGSN Response ~p", [Response]),
+    ?LOG(debug, "OK SGSN Response ~p", [Response]),
 
     forward_response(ProxyRequest, Response, ProxyContext),
     keep_state_and_data;
@@ -453,7 +453,7 @@ handle_response(#proxy_request{direction = ggsn2sgsn} = ProxyRequest,
 handle_response(#proxy_request{direction = sgsn2ggsn} = ProxyRequest,
 		#gtp{type = ms_info_change_notification_response} = Response,
 		_Request, _State, #{context := Context}) ->
-    ?LOG(warning, "OK Proxy Response ~p", [Response]),
+    ?LOG(debug, "OK Proxy Response ~p", [Response]),
 
     forward_response(ProxyRequest, Response, Context),
     keep_state_and_data;
@@ -462,7 +462,7 @@ handle_response(#proxy_request{direction = sgsn2ggsn} = ProxyRequest,
 		#gtp{type = delete_pdp_context_response} = Response,
 		_Request, _State,
 		#{context := Context} = Data0) ->
-    ?LOG(warning, "OK Proxy Response ~p", [Response]),
+    ?LOG(debug, "OK Proxy Response ~p", [Response]),
 
     forward_response(ProxyRequest, Response, Context),
     Data = cancel_timeout(Data0),
@@ -473,7 +473,7 @@ handle_response(#proxy_request{direction = ggsn2sgsn} = ProxyRequest,
 		#gtp{type = delete_pdp_context_response} = Response,
 		_Request, _State,
 		#{proxy_context := ProxyContext} = Data0) ->
-    ?LOG(warning, "OK SGSN Response ~p", [Response]),
+    ?LOG(debug, "OK SGSN Response ~p", [Response]),
 
     forward_response(ProxyRequest, Response, ProxyContext),
     Data = cancel_timeout(Data0),

--- a/src/gtp_context.erl
+++ b/src/gtp_context.erl
@@ -410,7 +410,7 @@ handle_event(cast, {handle_response, ReqInfo, Request, Response0}, State,
     end;
 
 handle_event(info, {update_session, Session, Events}, _State, _Data) ->
-    ?LOG(warning, "SessionEvents: ~p~n       Events: ~p", [Session, Events]),
+    ?LOG(debug, "SessionEvents: ~p~n       Events: ~p", [Session, Events]),
     Actions = [{next_event, internal, {session, Ev, Session}} || Ev <- Events],
     {keep_state_and_data, Actions};
 

--- a/src/pgw_s5s8.erl
+++ b/src/pgw_s5s8.erl
@@ -422,8 +422,8 @@ handle_request(ReqKey,
 
     {ok, GySessionOpts, GyEvs} =
 	ccr_initial(ContextPending, Session, gy, GyReqServices, SOpts, Request),
-    ?LOG(info, "GySessionOpts: ~p", [GySessionOpts]),
-    ?LOG(info, "Initial GyEvs: ~p", [GyEvs]),
+    ?LOG(debug, "GySessionOpts: ~p", [GySessionOpts]),
+    ?LOG(debug, "Initial GyEvs: ~p", [GyEvs]),
 
     ergw_aaa_session:invoke(Session, #{}, start, SOpts),
     {_, _, RfSEvs} = ergw_aaa_session:invoke(Session, #{}, {rf, 'Initial'}, SOpts),
@@ -704,12 +704,12 @@ session_failure_to_gtp_cause(_) ->
     system_failure.
 
 authenticate(Context, Session, SessionOpts, Request) ->
-    ?LOG(info, "SessionOpts: ~p", [SessionOpts]),
+    ?LOG(debug, "SessionOpts: ~p", [SessionOpts]),
     case ergw_aaa_session:invoke(Session, SessionOpts, authenticate, [inc_session_id]) of
 	{ok, _, _} = Result ->
 	    Result;
 	Other ->
-	    ?LOG(info, "AuthResult: ~p", [Other]),
+	    ?LOG(debug, "AuthResult: ~p", [Other]),
 	    ?ABORT_CTX_REQUEST(Context, Request, create_session_response,
 			       user_authentication_failed)
     end.
@@ -797,7 +797,7 @@ close_pdn_context(Reason, #{context := Context, pfcp := PCtx, 'Session' := Sessi
     ReqOpts = #{now => Now, async => true},
     case ergw_aaa_session:invoke(Session, #{}, {gx, 'CCR-Terminate'}, ReqOpts#{async => false}) of
 	{ok, _GxSessionOpts, _} ->
-	    ?LOG(info, "GxSessionOpts: ~p", [_GxSessionOpts]);
+	    ?LOG(debug, "GxSessionOpts: ~p", [_GxSessionOpts]);
 	GxOther ->
 	    ?LOG(warning, "Gx terminate failed with: ~p", [GxOther])
     end,
@@ -1268,7 +1268,7 @@ pdn_ppp_pco(SessionOpts, {?'PCO-DNS-Server-IPv4-Address', <<>>}, Opts) ->
 			end
 		end, Opts, ['MS-Secondary-DNS-Server', 'MS-Primary-DNS-Server']);
 pdn_ppp_pco(_SessionOpts, PPPReqOpt, Opts) ->
-    ?LOG(info, "Apply PPP Opt: ~p", [PPPReqOpt]),
+    ?LOG(debug, "Apply PPP Opt: ~p", [PPPReqOpt]),
     Opts.
 
 pdn_pco(SessionOpts, #{?'Protocol Configuration Options' :=

--- a/src/pgw_s5s8_proxy.erl
+++ b/src/pgw_s5s8_proxy.erl
@@ -443,7 +443,7 @@ handle_response(#proxy_request{direction = sgw2pgw} = ProxyRequest,
 		#{context := Context,
 		  proxy_context := PrevProxyCtx,
 		  pfcp := PCtx0} = Data) ->
-    ?LOG(warning, "OK Proxy Response ~p", [Response]),
+    ?LOG(debug, "OK Proxy Response ~p", [Response]),
 
     ProxyContext1 = update_context_from_gtp_req(Response, PrevProxyCtx),
     ProxyContext = gtp_path:bind(Response, true, ProxyContext1),
@@ -471,7 +471,7 @@ handle_response(#proxy_request{direction = sgw2pgw,
 		#{context := Context,
 		  proxy_context := OldProxyContext,
 		  pfcp := PCtx0} = Data) ->
-    ?LOG(warning, "OK Proxy Response ~p", [Response]),
+    ?LOG(debug, "OK Proxy Response ~p", [Response]),
 
     ProxyContext = update_context_from_gtp_req(Response, OldProxyContext),
     gtp_context:remote_context_update(OldProxyContext, ProxyContext),
@@ -488,7 +488,7 @@ handle_response(#proxy_request{direction = sgw2pgw,
 handle_response(#proxy_request{direction = sgw2pgw} = ProxyRequest,
 		#gtp{type = change_notification_response} = Response,
 		_Request, _State, #{context := Context}) ->
-    ?LOG(warning, "OK Proxy Response ~p", [Response]),
+    ?LOG(debug, "OK Proxy Response ~p", [Response]),
 
     forward_response(ProxyRequest, Response, Context),
     keep_state_and_data;
@@ -501,7 +501,7 @@ handle_response(#proxy_request{direction = sgw2pgw} = ProxyRequest,
 		_Request, _State, #{context := Context})
   when Type == suspend_acknowledge;
        Type == resume_acknowledge ->
-    ?LOG(warning, "OK Proxy Acknowledge ~p", [Response]),
+    ?LOG(debug, "OK Proxy Acknowledge ~p", [Response]),
 
     forward_response(ProxyRequest, Response, Context),
     keep_state_and_data;
@@ -513,7 +513,7 @@ handle_response(#proxy_request{direction = pgw2sgw} = ProxyRequest,
 		#gtp{type = update_bearer_response} = Response,
 		_Request, _State,
 		#{proxy_context := ProxyContext} = Data) ->
-    ?LOG(warning, "OK Response ~p", [Response]),
+    ?LOG(debug, "OK Response ~p", [Response]),
 
     forward_response(ProxyRequest, Response, ProxyContext),
     trigger_request_finished(Response, Data),
@@ -523,7 +523,7 @@ handle_response(#proxy_request{direction = pgw2sgw} = ProxyRequest,
 handle_response(#proxy_request{direction = sgw2pgw} = ProxyRequest,
 		Response0, #gtp{type = delete_session_request}, _State,
 		#{context := Context} = Data) ->
-    ?LOG(warning, "Proxy Response ~p", [Response0]),
+    ?LOG(debug, "Proxy Response ~p", [Response0]),
 
     Response =
 	if is_record(Response0, gtp) ->
@@ -543,7 +543,7 @@ handle_response(#proxy_request{direction = sgw2pgw} = ProxyRequest,
 handle_response(#proxy_request{direction = pgw2sgw} = ProxyRequest,
 		Response0, #gtp{type = delete_bearer_request}, _State,
 		#{proxy_context := ProxyContext} = Data) ->
-    ?LOG(warning, "Proxy Response ~p", [Response0]),
+    ?LOG(debug, "Proxy Response ~p", [Response0]),
 
     Response =
 	if is_record(Response0, gtp) ->

--- a/src/saegw_s11.erl
+++ b/src/saegw_s11.erl
@@ -413,8 +413,8 @@ handle_request(ReqKey,
 
     {ok, GySessionOpts, GyEvs} =
 	ccr_initial(ContextPending, Session, gy, GyReqServices, SOpts, Request),
-    ?LOG(info, "GySessionOpts: ~p", [GySessionOpts]),
-    ?LOG(info, "Initial GyEvs: ~p", [GyEvs]),
+    ?LOG(debug, "GySessionOpts: ~p", [GySessionOpts]),
+    ?LOG(debug, "Initial GyEvs: ~p", [GyEvs]),
 
     ergw_aaa_session:invoke(Session, #{}, start, SOpts),
     {_, _, RfSEvs} = ergw_aaa_session:invoke(Session, #{}, {rf, 'Initial'}, SOpts),
@@ -642,12 +642,12 @@ session_failure_to_gtp_cause(_) ->
     system_failure.
 
 authenticate(Context, Session, SessionOpts, Request) ->
-    ?LOG(info, "SessionOpts: ~p", [SessionOpts]),
+    ?LOG(debug, "SessionOpts: ~p", [SessionOpts]),
     case ergw_aaa_session:invoke(Session, SessionOpts, authenticate, [inc_session_id]) of
 	{ok, _, _} = Result ->
 	    Result;
 	Other ->
-	    ?LOG(info, "AuthResult: ~p", [Other]),
+	    ?LOG(debug, "AuthResult: ~p", [Other]),
 	    ?ABORT_CTX_REQUEST(Context, Request, create_session_response,
 			       user_authentication_failed)
     end.
@@ -733,7 +733,7 @@ close_pdn_context(Reason, #{context := Context, pfcp := PCtx, 'Session' := Sessi
     ReqOpts = #{now => Now, async => true},
     case ergw_aaa_session:invoke(Session, #{}, {gx, 'CCR-Terminate'}, ReqOpts#{async => false}) of
 	{ok, _GxSessionOpts, _} ->
-	    ?LOG(info, "GxSessionOpts: ~p", [_GxSessionOpts]);
+	    ?LOG(debug, "GxSessionOpts: ~p", [_GxSessionOpts]);
 	GxOther ->
 	    ?LOG(warning, "Gx terminate failed with: ~p", [GxOther])
     end,
@@ -1168,7 +1168,7 @@ pdn_ppp_pco(SessionOpts, {?'PCO-DNS-Server-IPv4-Address', <<>>}, Opts) ->
 			end
 		end, Opts, ['MS-Secondary-DNS-Server', 'MS-Primary-DNS-Server']);
 pdn_ppp_pco(_SessionOpts, PPPReqOpt, Opts) ->
-    ?LOG(info, "Apply PPP Opt: ~p", [PPPReqOpt]),
+    ?LOG(debug, "Apply PPP Opt: ~p", [PPPReqOpt]),
     Opts.
 
 pdn_pco(SessionOpts, #{?'Protocol Configuration Options' :=

--- a/src/tdf.erl
+++ b/src/tdf.erl
@@ -320,7 +320,7 @@ handle_event(internal, {session, Ev, _}, _State, _Data) ->
     keep_state_and_data;
 
 handle_event(info, {update_session, Session, Events}, _State, _Data) ->
-    ?LOG(warning, "SessionEvents: ~p~n       Events: ~p", [Session, Events]),
+    ?LOG(debug, "SessionEvents: ~p~n       Events: ~p", [Session, Events]),
     Actions = [{next_event, internal, {session, Ev, Session}} || Ev <- Events],
     {keep_state_and_data, Actions};
 
@@ -384,7 +384,7 @@ start_session(#data{apn = APN, context = Context0, dp_node = Node,
 
     {ok, GySessionOpts, GyEvs} =
 	ccr_initial(Session, gy, GyReqServices, SOpts),
-    ?LOG(info, "GySessionOpts: ~p", [GySessionOpts]),
+    ?LOG(debug, "GySessionOpts: ~p", [GySessionOpts]),
 
     ergw_aaa_session:invoke(Session, #{}, start, SOpts),
     {_, _, RfSEvs} = ergw_aaa_session:invoke(Session, #{}, {rf, 'Initial'}, SOpts),
@@ -441,12 +441,12 @@ init_session(#data{context = Context}) ->
 
 
 authenticate(Session, SessionOpts) ->
-    ?LOG(info, "SessionOpts: ~p", [SessionOpts]),
+    ?LOG(debug, "SessionOpts: ~p", [SessionOpts]),
     case ergw_aaa_session:invoke(Session, SessionOpts, authenticate, [inc_session_id]) of
 	{ok, _, _} = Result ->
 	    Result;
 	Other ->
-	    ?LOG(info, "AuthResult: ~p", [Other]),
+	    ?LOG(debug, "AuthResult: ~p", [Other]),
 	    throw({fail, authenticate, Other})
     end.
 
@@ -478,7 +478,7 @@ close_pdn_context(Reason, run, #data{context = Context, pfcp = PCtx,
 
     case ergw_aaa_session:invoke(Session, #{}, {gx, 'CCR-Terminate'}, ReqOpts#{async => false}) of
 	{ok, _GxSessionOpts, _} ->
-	    ?LOG(info, "GxSessionOpts: ~p", [_GxSessionOpts]);
+	    ?LOG(debug, "GxSessionOpts: ~p", [_GxSessionOpts]);
 	GxOther ->
 	    ?LOG(warning, "Gx terminate failed with: ~p", [GxOther])
     end,


### PR DESCRIPTION
The abuse of those log levels traces back to lager times where
level where color coded and would highlight messages.
This was very useful during debugging, but the log levels lead
to confusion when those message show up in production.