### PR TITLE
Fix dev.config

### DIFF
--- a/priv/dev.config
+++ b/priv/dev.config
@@ -12,7 +12,7 @@
 	     #{single_line => true,
 	       legacy_header => false,
 	       template => [time," ",pid," ",level,": ",msg,"\n"]
-	      }}
+	      }},
 	config =>
 	    #{sync_mode_qlen => 10000,
 	      drop_mode_qlen => 10000,


### PR DESCRIPTION
Added comma to map of `logger` section in `dev.config` configuration