### PR TITLE
Configurable TEID-Ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ This requires a suitable ergw.config, e.g.:
            {[<<"APN1">>], [{vrf, sgi}]}
           ]},
 
+         {teid, {3, 6}}, % {teid, {Prefix, Length}}
+
          {node_selection,
           [{default,
             {static,

--- a/config/ergw-c-node.config
+++ b/config/ergw-c-node.config
@@ -74,6 +74,8 @@
 	   {[<<"apn02">>,<<"example">>,<<"net">>], [{vrf, sgi}]}
 	  ]},
 
+	 {teid, {3, 6}}, % {teid, {Prefix, Length}}
+
 	 {node_selection,
 	  [{default,
 	    {static,

--- a/simulator/ergw_sim.erl
+++ b/simulator/ergw_sim.erl
@@ -98,8 +98,8 @@ s11(IP, modify_bearer, RemoteCntlTEI, DpTEI) ->
 
 s11(IP, initial_attachment, APN, IMEI, IMSI, MSISDN, PdnType) ->
     CntlPort = #gtp_port{ip = LocalIP} = gtp_socket_reg:lookup('gtp-c'),
-    {ok, CpTEI} = gtp_context_reg:alloc_tei(CntlPort),
-    {ok, DpTEI} = gtp_context_reg:alloc_tei(CntlPort),
+    {ok, CpTEI} = ergw_tei_mngr:alloc_tei(CntlPort),
+    {ok, DpTEI} = ergw_tei_mngr:alloc_tei(CntlPort),
     Peer = parse_ip(IP),
     SeqNo = 1,
 

--- a/src/ergw.erl
+++ b/src/ergw.erl
@@ -79,7 +79,8 @@ load_config([{Key, Value} | T])
        Key =:= ip_pools;
        Key =:= apns;
        Key =:= charging;
-       Key =:= proxy_map ->
+       Key =:= proxy_map;
+       Key =:= teid ->
     ok = application:set_env(ergw, Key, Value),
     load_config(T);
 load_config([_ | T]) ->

--- a/src/ergw_config.erl
+++ b/src/ergw_config.erl
@@ -22,6 +22,7 @@
 	 to_map/1]).
 
 -define(DefaultOptions, [{plmn_id, {<<"001">>, <<"01">>}},
+			 {teid, {0, 0}},
 			 {accept_new, true},
 			 {sockets, []},
 			 {handlers, []},
@@ -254,6 +255,8 @@ validate_option(proxy_map, Opts) ->
     gtp_proxy_ds:validate_options(Opts);
 validate_option(path_management, Opts) when ?is_opts(Opts) ->
     gtp_path:validate_options(Opts);
+validate_option(teid, Value) ->
+    ergw_tei_mngr:validate_option(Value);
 validate_option(Opt, Value)
   when Opt == plmn_id;
        Opt == accept_new;

--- a/src/ergw_pfcp.erl
+++ b/src/ergw_pfcp.erl
@@ -107,7 +107,7 @@ assign_data_teid(PCtx, {VRFs, _} = _NodeCaps,
 	get_port_vrf(ControlPort, VRFs),
 
     IP = ergw_gsn_lib:choose_context_ip(IP4, IP6, Context),
-    {ok, DataTEI} = gtp_context_reg:alloc_tei(PCtx),
+    {ok, DataTEI} = ergw_tei_mngr:alloc_tei(PCtx),
     Context#context{
       local_data_endp = #gtp_endp{vrf = Name, ip = ergw_inet:bin2ip(IP), teid = DataTEI}
      }.

--- a/src/ergw_sup.erl
+++ b/src/ergw_sup.erl
@@ -31,6 +31,7 @@ start_link() ->
 
 init([]) ->
     {ok, {{one_for_one, 5, 10}, [?CHILD(gtp_path_reg, worker, []),
+				 ?CHILD(ergw_tei_mngr, worker, []),
 				 ?CHILD(gtp_path_sup, supervisor, []),
 				 ?CHILD(gtp_context_reg, worker, []),
 				 ?CHILD(gtp_context_sup, supervisor, []),

--- a/src/ergw_sx_node.erl
+++ b/src/ergw_sx_node.erl
@@ -188,7 +188,7 @@ init([Parent, Node, NodeSelect, IP4, IP6, NotifyUp]) ->
 
     {ok, CP, GtpPort} = ergw_sx_socket:id(),
     #gtp_port{name = CntlPortName} = GtpPort,
-    {ok, TEI} = gtp_context_reg:alloc_tei(GtpPort),
+    {ok, TEI} = ergw_tei_mngr:alloc_tei(GtpPort),
     SEID = ergw_sx_socket:seid(),
     PCtx = #pfcp_ctx{
 	      name = Node,
@@ -765,7 +765,7 @@ create_data_endp(PCtx, Node, VRFs) ->
 	lists:filter(fun(#vrf{features = Features}) ->
 			     lists:member('CP-Function', Features)
 		     end, maps:values(VRFs)),
-    {ok, DataTEI} = gtp_context_reg:alloc_tei(PCtx),
+    {ok, DataTEI} = ergw_tei_mngr:alloc_tei(PCtx),
     #gtp_endp{
        vrf = VRF#vrf.name,
        ip = choose_up_ip(Node, VRF),

--- a/src/ergw_tei_mngr.erl
+++ b/src/ergw_tei_mngr.erl
@@ -1,0 +1,148 @@
+%% Copyright 2020, Travelping GmbH <info@travelping.com>
+
+%% This program is free software; you can redistribute it and/or
+%% modify it under the terms of the GNU General Public License
+%% as published by the Free Software Foundation; either version
+%% 2 of the License, or (at your option) any later version.
+
+%% simple implementation of 3GPP TS 29.598 Nudsf service
+%% - functional API according to TS
+%% - not optimized for anything
+
+-module(ergw_tei_mngr).
+
+-behavior(gen_statem).
+
+-compile({parse_transform, cut}).
+
+%% API
+-export([start_link/0, alloc_tei/1, release_tei/2]).
+
+%% gen_statem callbacks
+-export([callback_mode/0, init/1, handle_event/4, terminate/3, code_change/4]).
+
+-export([validate_option/1]).
+
+-include("include/ergw.hrl").
+
+-define(SERVER, ?MODULE).
+-define(SAVE_TIMEOUT, 1000).
+-define(MAX_TRIES, 10).
+-define(POW(X, Y), trunc(math:pow(X, Y))).
+
+-record(data, {node_id, block_id, prefix, prefix_len, tid, save_cnt}).
+
+%%%=========================================================================
+%%%  API
+%%%=========================================================================
+
+start_link() ->
+    gen_statem:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+%% with_keyfun/2
+with_keyfun(#request{gtp_port = Port}, Fun) ->
+    with_keyfun(Port, Fun);
+with_keyfun(#gtp_port{name = Name} = Port, Fun) ->
+    Fun(Name, gtp_context:port_teid_key(Port, _));
+with_keyfun(#pfcp_ctx{name = Name} = PCtx, Fun) ->
+    Fun(Name, ergw_pfcp:ctx_teid_key(PCtx, _)).
+
+%% alloc_tei/1
+alloc_tei(Port) ->
+    with_keyfun(Port, fun alloc_tei/2).
+
+%% alloc_tei/2
+alloc_tei(Name, KeyFun) ->
+    gen_server:call(?SERVER, {alloc_tei, Name, KeyFun}).
+
+%% release_tei/2
+release_tei(Port, TEI) ->
+    with_keyfun(Port, release_tei(_, TEI, _)).
+
+%% release_tei/3
+release_tei(Name, TEI, KeyFun) ->
+    gen_server:call(?SERVER, {release_tei, Name, TEI, KeyFun}).
+
+%%%===================================================================
+%%% Options Validation
+%%%===================================================================
+
+validate_option({Prefix, Len} = Value)
+  when is_integer(Prefix), is_integer(Len),
+       Len >= 0, Len =< 8, Prefix >= 0 ->
+    case ?POW(2, Len) of
+	X when X > Prefix -> Value;
+	_ ->
+	    throw({error, {options, {teid, Value}}})
+    end;
+validate_option(Value) ->
+    throw({error, {options, {teid, Value}}}).
+
+%%%===================================================================
+%%% gen_statem callbacks
+%%%===================================================================
+
+callback_mode() -> handle_event_function.
+
+init([]) ->
+    TID = ets:new(?SERVER, [ordered_set, {keypos, 1}]),
+
+    Data = #data{tid = TID},
+
+    {ok, #{}, Data}.
+
+handle_event({call, From}, {alloc_tei, Name, KeyFun}, State, Data) ->
+    RndState = maybe_init_rnd(Name, State),
+    alloc_tei(From, Name, KeyFun, ?MAX_TRIES, RndState, State, Data);
+
+handle_event({call, From}, {release_tei, _Name, TEI, KeyFun}, _State, #data{tid = TID}) ->
+    ets:delete(TID, KeyFun(TEI)),
+    Actions = [{reply, From, ok}],
+    {keep_state_and_data, Actions};
+
+handle_event({call, From}, Request, _State, _Data) ->
+    Reply = {error, {badarg, Request}},
+    {keep_state_and_data, [{reply, From, Reply}]};
+
+handle_event(_, _Msg, _State, _Data) ->
+    keep_state_and_data.
+
+terminate(_Reason, _State, _Data) ->
+    ok.
+
+code_change(_OldVsn, State, Data, _Extra) ->
+    {ok, State, Data}.
+
+%%%=========================================================================
+%%%  internal functions
+%%%=========================================================================
+
+maybe_init_rnd(Name, State) when is_map_key(Name, State) ->
+    maps:get(Name, State);
+maybe_init_rnd(_, _) ->
+    rand:seed_s(exrop).
+
+alloc_tei_reply(From, Reply, Name, RndState, State, Data) ->
+    Actions = [{reply, From, Reply}],
+    {next_state, State#{Name => RndState}, Data, Actions}.
+
+alloc_tei(From, Name, _KeyFun, 0, RndState, State, Data) ->
+    alloc_tei_reply(From, {error, no_tei}, Name, RndState, State, Data);
+alloc_tei(From, Name, KeyFun, Cnt, RndState0, State, #data{tid = TID} = Data0) ->
+    Data = #data{prefix = Prefix0, prefix_len = PrefixLen} = maybe_update_data(Data0),
+    Prefix = Prefix0 bsl (32 - PrefixLen),
+    Mask = 16#ffffffff bsr PrefixLen,
+    {TEI0, RndState} = rand:uniform_s(16#fffffffe, RndState0),
+    TEI = Prefix + (TEI0 band Mask),
+    case ets:insert_new(TID, {KeyFun(TEI), Name}) of
+	true ->
+	    alloc_tei_reply(From, {ok, TEI}, Name, RndState, State, Data);
+	false ->
+	    alloc_tei(From, Name, KeyFun, Cnt - 1, RndState, State, Data)
+    end.
+
+maybe_update_data(#data{prefix = undefined, prefix_len = undefined} = Data) ->
+    {ok, {Prefix, PrefixLen}} = application:get_env(ergw, teid),
+    Data#data{prefix = Prefix, prefix_len = PrefixLen};
+maybe_update_data(Data) ->
+    Data.

--- a/src/ggsn_gn_proxy.erl
+++ b/src/ggsn_gn_proxy.erl
@@ -524,7 +524,7 @@ handle_sgsn_change(#context{remote_control_teid = NewFqTEID},
 		  #context{remote_control_teid = OldFqTEID},
 		  #context{control_port = CntlPort} = ProxyContext0)
   when OldFqTEID /= NewFqTEID ->
-    {ok, CntlTEI} = gtp_context_reg:alloc_tei(CntlPort),
+    {ok, CntlTEI} = ergw_tei_mngr:alloc_tei(CntlPort),
     ProxyContext = ProxyContext0#context{local_control_tei = CntlTEI},
     gtp_context:remote_context_update(ProxyContext0, ProxyContext),
     ProxyContext;
@@ -544,7 +544,7 @@ init_proxy_context(CntlPort,
 			    control_interface = Interface, state = CState},
 		   #{imsi := IMSI, msisdn := MSISDN, apn := DstAPN}, {_GwNode, GGSN}) ->
     {APN, _OI} = ergw_node_selection:split_apn(DstAPN),
-    {ok, CntlTEI} = gtp_context_reg:alloc_tei(CntlPort),
+    {ok, CntlTEI} = ergw_tei_mngr:alloc_tei(CntlPort),
     #context{
        apn               = APN,
        imsi              = IMSI,

--- a/src/gtp_context.erl
+++ b/src/gtp_context.erl
@@ -316,7 +316,7 @@ init([CntlPort, Version, Interface,
     ?LOG(debug, "init(~p)", [[CntlPort, Interface]]),
     process_flag(trap_exit, true),
 
-    {ok, CntlTEI} = gtp_context_reg:alloc_tei(CntlPort),
+    {ok, CntlTEI} = ergw_tei_mngr:alloc_tei(CntlPort),
 
     Context = #context{
 		 charging_identifier = ergw_gtp_c_socket:get_uniq_id(CntlPort),

--- a/src/pgw_s5s8_proxy.erl
+++ b/src/pgw_s5s8_proxy.erl
@@ -608,7 +608,7 @@ handle_sgw_change(#context{remote_control_teid = NewFqTEID},
 		  #context{remote_control_teid = OldFqTEID},
 		  #context{control_port = CntlPort} = ProxyContext0)
   when OldFqTEID /= NewFqTEID ->
-    {ok, CntlTEI} = gtp_context_reg:alloc_tei(CntlPort),
+    {ok, CntlTEI} = ergw_tei_mngr:alloc_tei(CntlPort),
     ProxyContext = ProxyContext0#context{local_control_tei = CntlTEI},
     gtp_context:remote_context_update(ProxyContext0, ProxyContext),
     ProxyContext;
@@ -628,7 +628,7 @@ init_proxy_context(CntlPort,
 			    control_interface = Interface, state = CState},
 		   #{imsi := IMSI, msisdn := MSISDN, apn := DstAPN}, {_GwNode, PGW}) ->
     APN = ergw_node_selection:expand_apn(DstAPN, IMSI),
-    {ok, CntlTEI} = gtp_context_reg:alloc_tei(CntlPort),
+    {ok, CntlTEI} = ergw_tei_mngr:alloc_tei(CntlPort),
     #context{
        apn               = APN,
        imsi              = IMSI,

--- a/test/config_SUITE.erl
+++ b/test/config_SUITE.erl
@@ -571,6 +571,11 @@ config(_Config)  ->
     ?error_option(set_cfg_value([plmn_id], {<<"abc">>, <<"ab">>}, ?GGSN_CONFIG)),
     ?error_option(set_cfg_value([sockets], undefined, ?GGSN_CONFIG)),
 
+    ?ok_option(set_cfg_value([teid], {2, 4}, ?GGSN_CONFIG)),
+    ?error_option(set_cfg_value([teid], 1, ?GGSN_CONFIG)),
+    ?error_option(set_cfg_value([teid], {8, 2}, ?GGSN_CONFIG)),
+    ?error_option(set_cfg_value([teid], {atom, 8}, ?GGSN_CONFIG)),
+
     %% pass-through of unexpected options
     ?ok_option(set_cfg_value([invalid], [], ?GGSN_CONFIG)),
 

--- a/test/pgw_SUITE.erl
+++ b/test/pgw_SUITE.erl
@@ -5094,7 +5094,7 @@ set_online_charging(Set) ->
     {ok, Cfg0} = application:get_env(ergw, charging),
     Cfg = set_online_charging(['_', rulebase, '_'], Set, Cfg0),
 	ok = application:set_env(ergw, charging, Cfg).
-	
+
 %% Set APN key data
 set_apn_key(Key, Value) ->
     {ok, APNs0} = application:get_env(ergw, apns),


### PR DESCRIPTION
Implementation of TDD which allows to define the available prefix of Tunnel Endpoint IDs by configuration.
------------------
Implementation of `TEI` calculation was get from [experimental branch](https://github.com/travelping/ergw/blob/exp/stateless/src/ergw_tei_mngr.erl#L177-L188) what was implemented by @RoadRunnr