### PR TITLE
Update *recon* and *observer_cli* to support OTP23

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -36,8 +36,8 @@
 		       {include_src, false}
 		      ]},
 	       {deps, [
-		       {recon, "2.5.0"},
-		       {observer_cli, "1.5.3"}
+		       {recon, "2.5.1"},
+		       {observer_cli, "1.5.4"}
 		      ]}
 	       ]},
 	     {native,


### PR DESCRIPTION
847e514 switched the Erlang runtime to OTP23. Both *recon* and
*observer_cli* support OTP23 in their latest releases (mostly for "alloc
compat").

This commit bumps both dependencies.