### PR TITLE
Extend delete contexts REST API

### DIFF
--- a/priv/static/specs/http_api_spec.yaml
+++ b/priv/static/specs/http_api_spec.yaml
@@ -52,6 +52,28 @@ paths:
       responses:
         '200':
           description: returns the metrics
+  /contexts:
+    delete:
+      summary: 'delete all contexts'
+      responses:
+        '200':
+          description: return count of contexts
+          schema:
+            $ref: '#/definitions/DeleteContexts'
+  /contexts/{count}:
+    delete:
+      summary: 'delete N contexts'
+      parameters:
+        - name: count
+          in: path
+          required: true
+          type: integer
+          description: 'number of contexts for deleting'
+      responses:
+        '200':
+          description: return count of contexts
+          schema:
+            $ref: '#/definitions/DeleteContexts'
 definitions:
   Status:
     type: "object"
@@ -62,6 +84,12 @@ definitions:
       plmnId:
         $ref:
           "#/definitions/PLMN"
+  DeleteContexts:
+    type: "object"
+    properties:
+      contexts:
+        type: "integer"
+        default: 0
   PLMN:
     type: "object"
     properties:

--- a/src/ergw_api.erl
+++ b/src/ergw_api.erl
@@ -41,6 +41,10 @@ contexts(all) ->
     lists:usort([Pid || {{_Socket, {teid, 'gtp-c', _TEID}}, {_, Pid}}
 				       <- gtp_context_reg:all(), is_pid(Pid)]).
 
+delete_contexts(all) ->
+    lists:foreach(fun(Context) ->
+        gtp_context:trigger_delete_context(Context)
+    end, contexts(all));
 delete_contexts(Count) ->
     delete_contexts(contexts(all), Count).
 
@@ -70,6 +74,8 @@ collect_contexts(Context, Tunnels) ->
     [Info#{'Process' => Context} | Tunnels].
 
 delete_contexts(_Contexts, 0) ->
+    ok;
+delete_contexts([], _Count) ->
     ok;
 delete_contexts(Contexts, Count) ->
     Id = rand:uniform(length(Contexts)),

--- a/src/ergw_http_api.erl
+++ b/src/ergw_http_api.erl
@@ -30,7 +30,7 @@ start_http_listener(Opts) ->
 		    {"/api/v1/status", http_api_handler, []},
 		    {"/api/v1/status/accept-new", http_api_handler, []},
 		    {"/api/v1/status/accept-new/:value", http_api_handler, []},
-		    {"/api/v1/contexts/:count", http_api_handler, []},
+		    {"/api/v1/contexts/[:count]", http_api_handler, []},
 		    {"/metrics/[:registry]", prometheus_cowboy2_handler, []},
 		    %% 5G SBI APIs
 		    {"/sbi/nbsf-management/v1/pcfBindings", sbi_nbsf_handler, []},

--- a/src/http_api_handler.erl
+++ b/src/http_api_handler.erl
@@ -94,14 +94,18 @@ handle_request(<<"POST">>, _, json, Req, State) ->
             {true, Req2, State}
     end;
 
+handle_request(<<"DELETE">>, <<"/api/v1/contexts">>, json, Req, State) ->
+    ok = ergw_api:delete_contexts(all),
+    Response = jsx:encode(#{contexts => length(ergw_api:contexts(all))}),
+    Req2 = cowboy_req:set_resp_body(Response, Req),
+    {true, Req2, State};
+
 handle_request(<<"DELETE">>, <<"/api/v1/contexts/", _/binary>>, json, Req, State) ->
     Value = cowboy_req:binding(count, Req),
     case catch binary_to_integer(Value) of
 	Count when is_integer(Count), Count > 0 ->
 	    ok = ergw_api:delete_contexts(Count),
-	    Contexts = ergw_api:contexts(all),
-
-	    Response = jsx:encode(#{contexts => erlang:length(Contexts)}),
+	    Response = jsx:encode(#{contexts => length(ergw_api:contexts(all))}),
 	    Req2 = cowboy_req:set_resp_body(Response, Req),
 	    {true, Req2, State};
 	_ ->
@@ -109,6 +113,7 @@ handle_request(<<"DELETE">>, <<"/api/v1/contexts/", _/binary>>, json, Req, State
 	    Req3 = cowboy_req:set_resp_body(Response, Req),
 	    {true, Req3, State}
     end;
+
 handle_request(_, _, Req, _, State) ->
     {false, Req, State}.
 


### PR DESCRIPTION
- Extend delete contexts REST API for delete all contexts:
  - `/api/v1/contexts/{count}`  - Delete N contexts
  - `/api/v1/contexts` - Delete all contexts
- Fix REST API `/api/v1/contexts/count` 500 error when try delete N contexts when contexts  length is `0`
- Fix CT of `http_api_delete_sessions`