### PR TITLE
implement UP based TEID assignment

### DIFF
--- a/include/ergw.hrl
+++ b/include/ergw.hrl
@@ -74,6 +74,7 @@
 -record(pfcp_ctx, {
 	  name			:: term(),
 	  node			:: pid(),
+	  features,
 	  seid			:: #seid{},
 
 	  cp_bearer		:: #bearer{},
@@ -82,6 +83,7 @@
 	  idmap = #{}		:: map(),
 	  urr_by_id = #{}	:: map(),
 	  urr_by_grp = #{}	:: map(),
+	  chid_by_pdr = #{}	:: map(),
 	  sx_rules = #{}	:: map(),
 	  timers = #{}		:: map(),
 	  timer_by_tref = #{}	:: map(),

--- a/rebar.config
+++ b/rebar.config
@@ -23,6 +23,7 @@
 	    {test, [
 		    {erl_opts, [nowarn_export_all]},
 		    {deps, [{gun, {git, "https://github.com/ninenines/gun.git", {tag, "2.0.0-pre.1"}}},
+			    {parse_trans, "3.3.0"},
 			    {meck, "0.8.13"},
 			    {proper, "1.3.0"}
 			   ]},

--- a/rebar.lock
+++ b/rebar.lock
@@ -30,7 +30,7 @@
   0},
  {<<"pfcplib">>,
   {git,"https://github.com/travelping/pfcplib.git",
-       {ref,"4129bd08343eafc7f2125becfd23ae84ea707de7"}},
+       {ref,"304e876adff9b44a9d7add0e83bcb4d2ab437476"}},
   0},
  {<<"pmod_transform">>,
   {git,"git://github.com/erlang/pmod_transform.git",

--- a/src/ergw_gtp_gsn_lib.erl
+++ b/src/ergw_gtp_gsn_lib.erl
@@ -130,7 +130,7 @@ create_session_fun(APN, PAA, DAF, {Candidates, SxConnectId}, Session,
     PCC3 = ergw_pcc_context:session_events_to_pcc_ctx(AuthSEvs, PCC2),
     PCC4 = ergw_pcc_context:session_events_to_pcc_ctx(RfSEvs, PCC3),
 
-    PCtx = case ergw_pfcp_context:create_pfcp_session(PendingPCtx, PCC4, Bearer, Context) of
+    PCtx = case ergw_pfcp_context:create_session(gtp_context, PCC4, PCtx0, Bearer, Context) of
 	       {ok, Result10} -> Result10;
 	       {error, Err10} -> throw(Err10#ctx_err{context = Context, tunnel = LeftTunnel})
 	   end,
@@ -197,7 +197,7 @@ apply_bearer_change(Bearer, URRActions, SendEM, PCtx0, PCC) ->
 	if SendEM -> #{send_end_marker => true};
 	   true   -> #{}
 	end,
-    case ergw_pfcp_context:modify_pfcp_session(PCC, URRActions, ModifyOpts, Bearer, PCtx0) of
+    case ergw_pfcp_context:modify_session(PCC, URRActions, ModifyOpts, Bearer, PCtx0) of
 	{ok, {PCtx, UsageReport}} ->
 	    gtp_context:usage_report(self(), URRActions, UsageReport),
 	    {ok, PCtx};
@@ -224,7 +224,7 @@ usage_report(URRActions, UsageReport, #{pfcp := PCtx, 'Session' := Session}) ->
     ergw_gtp_gsn_session:usage_report(URRActions, UsageReport, PCtx, Session).
 
 close_context(Reason, #{pfcp := PCtx, 'Session' := Session}) ->
-    UsageReport = ergw_pfcp_context:delete_pfcp_session(Reason, PCtx),
+    UsageReport = ergw_pfcp_context:delete_session(Reason, PCtx),
     ergw_gtp_gsn_session:close_context(Reason, UsageReport, PCtx, Session),
     ergw_prometheus:termination_cause(?FUNCTION_NAME, Reason),
     ok.

--- a/src/ergw_inet.erl
+++ b/src/ergw_inet.erl
@@ -7,7 +7,7 @@
 
 -module(ergw_inet).
 
--export([ip2bin/1, bin2ip/1,
+-export([to_ip/1, ip2bin/1, bin2ip/1,
 	 ipv6_interface_id/2,
 	 ipv6_prefix/1, ipv6_prefix/2]).
 -export([ip_csum/1, make_udp/5]).
@@ -18,6 +18,13 @@
 %%====================================================================
 %% IP Address helpers
 %%====================================================================
+
+to_ip({_,_,_,_} = IP) ->
+    IP;
+to_ip({_,_,_,_,_,_,_,_} = IP) ->
+    IP;
+to_ip(IP) when is_binary(IP) ->
+    bin2ip(IP).
 
 ip2bin(V) when is_atom(V) ->
     V;

--- a/src/ggsn_gn_proxy.erl
+++ b/src/ggsn_gn_proxy.erl
@@ -286,7 +286,7 @@ handle_request(ReqKey,
 
     PCC = ergw_proxy_lib:proxy_pcc(),
     PCtx =
-	case ergw_pfcp_context:create_pfcp_session(PCtx0, PCC, Bearer, Context) of
+	case ergw_pfcp_context:create_session(gtp_context, PCC, PCtx0, Bearer, Context) of
 	    {ok, Result7} -> Result7;
 	    {error, Err7} -> throw(Err7#ctx_err{tunnel = LeftTunnel})
 	end,
@@ -418,7 +418,7 @@ handle_response(#proxy_request{direction = sgsn2ggsn} = ProxyRequest,
 	if ?CAUSE_OK(Cause) ->
 		PCC = ergw_proxy_lib:proxy_pcc(),
 		{PCtx, _} =
-		    case ergw_pfcp_context:modify_pfcp_session(PCC, [], #{}, Bearer, PCtx0) of
+		    case ergw_pfcp_context:modify_session(PCC, [], #{}, Bearer, PCtx0) of
 			{ok, Result2} -> Result2;
 			{error, Err2} -> throw(Err2#ctx_err{tunnel = LeftTunnel})
 		    end,
@@ -457,7 +457,7 @@ handle_response(#proxy_request{direction = sgsn2ggsn} = ProxyRequest,
 
     PCC = ergw_proxy_lib:proxy_pcc(),
     {PCtx, _} =
-	case ergw_pfcp_context:modify_pfcp_session(PCC, [], #{}, Bearer, PCtxOld) of
+	case ergw_pfcp_context:modify_session(PCC, [], #{}, Bearer, PCtxOld) of
 	    {ok, Result2} -> Result2;
 	    {error, Err2} -> throw(Err2#ctx_err{tunnel = LeftTunnel})
 	end,
@@ -545,7 +545,7 @@ handle_proxy_info(Session, Tunnel, Bearer, Context, #{proxy_ds := ProxyDS}) ->
     end.
 
 delete_forward_session(Reason, #{pfcp := PCtx, 'Session' := Session}) ->
-    URRs = ergw_pfcp_context:delete_pfcp_session(Reason, PCtx),
+    URRs = ergw_pfcp_context:delete_session(Reason, PCtx),
     SessionOpts = to_session(gtp_context:usage_report_to_accounting(URRs)),
     ?LOG(debug, "Accounting Opts: ~p", [SessionOpts]),
     ergw_aaa_session:invoke(Session, SessionOpts, stop, #{async => true}).

--- a/src/ggsn_gn_proxy.erl
+++ b/src/ggsn_gn_proxy.erl
@@ -222,7 +222,7 @@ handle_request(ReqKey,
 		    ie = IEs} = Request, _Resent, _State,
 	       #{context := Context0, aaa_opts := AAAopts, node_selection := NodeSelect,
 		 left_tunnel := LeftTunnel0,
-		 bearer := #{left := LeftBearer0, right := RightBearer0} = Bearer0,
+		 bearer := #{left := LeftBearer0} = Bearer0,
 		 'Session' := Session} = Data) ->
     Context = ggsn_gn:update_context_from_gtp_req(Request, Context0),
 
@@ -231,7 +231,7 @@ handle_request(ReqKey,
 	    {ok, Result1} -> Result1;
 	    {error, Err1} -> throw(Err1#ctx_err{tunnel = LeftTunnel0})
 	end,
-
+    Bearer1 = Bearer0#{left => LeftBearer1},
     LeftTunnel = gtp_path:bind(Request, LeftTunnel1),
 
     gtp_context:terminate_colliding_context(LeftTunnel, Context),
@@ -272,21 +272,20 @@ handle_request(ReqKey,
 	    {error, Err4} -> throw(Err4#ctx_err{context = ProxyContext, tunnel = LeftTunnel})   %% TBD: proxy context ???
 	end,
 
-    LeftBearer =
-	case ergw_gsn_lib:assign_local_data_teid(PCtx0, NodeCaps, LeftTunnel, LeftBearer1) of
+    Bearer2 =
+	case ergw_gsn_lib:assign_local_data_teid(left, PCtx0, NodeCaps, LeftTunnel, Bearer1) of
 	    {ok, Result5} -> Result5;
 	    {error, Err5} -> throw(Err5#ctx_err{tunnel = LeftTunnel})
 	end,
-    RightBearer =
-	case ergw_gsn_lib:assign_local_data_teid(PCtx0, NodeCaps, RightTunnel, RightBearer0) of
+    Bearer3 =
+	case ergw_gsn_lib:assign_local_data_teid(right, PCtx0, NodeCaps, RightTunnel, Bearer2) of
 	    {ok, Result6} -> Result6;
 	    {error, Err6} -> throw(Err6#ctx_err{tunnel = LeftTunnel})
 	end,
-    Bearer = Bearer0#{left => LeftBearer, right => RightBearer},
 
     PCC = ergw_proxy_lib:proxy_pcc(),
-    PCtx =
-	case ergw_pfcp_context:create_session(gtp_context, PCC, PCtx0, Bearer, Context) of
+    {PCtx, Bearer} =
+	case ergw_pfcp_context:create_session(gtp_context, PCC, PCtx0, Bearer3, Context) of
 	    {ok, Result7} -> Result7;
 	    {error, Err7} -> throw(Err7#ctx_err{tunnel = LeftTunnel})
 	end,
@@ -300,7 +299,8 @@ handle_request(ReqKey,
 	Data#{context => Context, proxy_context => ProxyContext, pfcp => PCtx,
 	      left_tunnel => LeftTunnel, right_tunnel => RightTunnel, bearer => Bearer},
 
-    forward_request(sgsn2ggsn, ReqKey, Request, RightTunnel, RightBearer, ProxyContext, Data),
+    forward_request(sgsn2ggsn, ReqKey, Request, RightTunnel,
+		    maps:get(right, Bearer), ProxyContext, Data),
 
     {keep_state, DataNew};
 

--- a/src/ggsn_gn_proxy.erl
+++ b/src/ggsn_gn_proxy.erl
@@ -465,7 +465,7 @@ handle_response(#proxy_request{direction = sgsn2ggsn} = ProxyRequest,
     forward_response(ProxyRequest, Response, LeftTunnel, LeftBearer, Context),
 
     DataNew =
-	Data#{proxy_context => ProxyContext, pfcp := PCtx,
+	Data#{proxy_context => ProxyContext, pfcp => PCtx,
 	      right_tunnel => RightTunnel, bearer => Bearer},
     {keep_state, DataNew};
 

--- a/src/gtp_context.erl
+++ b/src/gtp_context.erl
@@ -481,7 +481,7 @@ handle_event(info, #aaa_request{procedure = {gx, 'RAR'},
 %%% step 2
 %%% step 3:
     {PCtx1, UsageReport} =
-	case ergw_pfcp_context:modify_pfcp_session(PCC1, [], #{}, Bearer, PCtx0) of
+	case ergw_pfcp_context:modify_session(PCC1, [], #{}, Bearer, PCtx0) of
 	    {ok, Result1} -> Result1;
 	    {error, Err1} -> throw(Err1#ctx_err{context = Context, tunnel = LeftTunnel})
 	end,
@@ -502,7 +502,7 @@ handle_event(info, #aaa_request{procedure = {gx, 'RAR'},
 
 %%% step 6:
     {PCtx, _} =
-	case ergw_pfcp_context:modify_pfcp_session(PCC4, [], #{}, Bearer, PCtx1) of
+	case ergw_pfcp_context:modify_session(PCC4, [], #{}, Bearer, PCtx1) of
 	    {ok, Result2} -> Result2;
 	    {error, Err2} -> throw(Err2#ctx_err{context = Context, tunnel = LeftTunnel})
 	end,
@@ -548,7 +548,7 @@ handle_event(internal, {session, {update_credits, _} = CreditEv, _}, _State,
 
     {PCC, _PCCErrors} = ergw_pcc_context:gy_events_to_pcc_ctx(Now, [CreditEv], PCC0),
     {PCtx, _} =
-	case ergw_pfcp_context:modify_pfcp_session(PCC, [], #{}, Bearer, PCtx0) of
+	case ergw_pfcp_context:modify_session(PCC, [], #{}, Bearer, PCtx0) of
 	    {ok, Result1} -> Result1;
 	    {error, Err1} -> throw(Err1#ctx_err{context = Context, tunnel = LeftTunnel})
 	end,

--- a/src/pgw_s5s8.erl
+++ b/src/pgw_s5s8.erl
@@ -279,7 +279,7 @@ handle_request(ReqKey,
     Response = response(modify_bearer_response, LeftTunnel, ResponseIEs, Request),
     gtp_context:send_response(ReqKey, Request, Response),
 
-    DataNew = Data#{pfcp := PCtx, left_tunnel => LeftTunnel, bearer => Bearer},
+    DataNew = Data#{pfcp => PCtx, left_tunnel => LeftTunnel, bearer => Bearer},
     Actions = context_idle_action([], Context),
     {keep_state, DataNew, Actions};
 
@@ -307,7 +307,7 @@ handle_request(ReqKey,
     Response = response(modify_bearer_response, LeftTunnel, ResponseIEs, Request),
     gtp_context:send_response(ReqKey, Request, Response),
 
-    DataNew = Data#{pfcp := PCtx, left_tunnel => LeftTunnel},
+    DataNew = Data#{pfcp => PCtx, left_tunnel => LeftTunnel},
     Actions = context_idle_action([], Context),
     {keep_state, DataNew, Actions};
 

--- a/src/pgw_s5s8_proxy.erl
+++ b/src/pgw_s5s8_proxy.erl
@@ -529,7 +529,7 @@ handle_response(#proxy_request{direction = sgw2pgw,
     forward_response(ProxyRequest, Response, LeftTunnel, LeftBearer, Context),
 
     DataNew =
-	Data#{proxy_context => ProxyContext, pfcp := PCtx,
+	Data#{proxy_context => ProxyContext, pfcp => PCtx,
 	      right_tunnel => RightTunnel, bearer => Bearer},
 
     {keep_state, DataNew};

--- a/src/pgw_s5s8_proxy.erl
+++ b/src/pgw_s5s8_proxy.erl
@@ -294,7 +294,7 @@ handle_request(ReqKey,
 
     PCC = ergw_proxy_lib:proxy_pcc(),
     PCtx =
-	case ergw_pfcp_context:create_pfcp_session(PCtx0, PCC, Bearer, Context) of
+	case ergw_pfcp_context:create_session(gtp_context, PCC, PCtx0, Bearer, Context) of
 	    {ok, Result7} -> Result7;
 	    {error, Err7} -> throw(Err7#ctx_err{tunnel = LeftTunnel})
 	end,
@@ -476,7 +476,7 @@ handle_response(#proxy_request{direction = sgw2pgw} = ProxyRequest,
 	if ?CAUSE_OK(Cause) ->
 		PCC = ergw_proxy_lib:proxy_pcc(),
 		{PCtx, _} =
-		    case ergw_pfcp_context:modify_pfcp_session(PCC, [], #{}, Bearer, PCtx0) of
+		    case ergw_pfcp_context:modify_session(PCC, [], #{}, Bearer, PCtx0) of
 			{ok, Result2} -> Result2;
 			{error, Err2} -> throw(Err2#ctx_err{tunnel = LeftTunnel})
 		    end,
@@ -521,7 +521,7 @@ handle_response(#proxy_request{direction = sgw2pgw,
 	end,
     PCC = ergw_proxy_lib:proxy_pcc(),
     {PCtx, _} =
-	case ergw_pfcp_context:modify_pfcp_session(PCC, [], ModifyOpts, Bearer, PCtxOld) of
+	case ergw_pfcp_context:modify_session(PCC, [], ModifyOpts, Bearer, PCtxOld) of
 	    {ok, Result2} -> Result2;
 	    {error, Err2} -> throw(Err2#ctx_err{tunnel = LeftTunnel})
 	end,
@@ -643,7 +643,7 @@ handle_proxy_info(Session, Tunnel, Bearer, Context, #{proxy_ds := ProxyDS}) ->
     end.
 
 delete_forward_session(Reason, #{pfcp := PCtx, 'Session' := Session}) ->
-    URRs = ergw_pfcp_context:delete_pfcp_session(Reason, PCtx),
+    URRs = ergw_pfcp_context:delete_session(Reason, PCtx),
     SessionOpts = to_session(gtp_context:usage_report_to_accounting(URRs)),
     ?LOG(debug, "Accounting Opts: ~p", [SessionOpts]),
     ergw_aaa_session:invoke(Session, SessionOpts, stop, #{async => true}).

--- a/src/saegw_s11.erl
+++ b/src/saegw_s11.erl
@@ -297,7 +297,7 @@ handle_request(ReqKey,
     Response = response(release_access_bearers_response, LeftTunnel, ResponseIEs, Request),
     gtp_context:send_response(ReqKey, Request, Response),
 
-    DataNew = Data#{context => Context, pfcp := PCtx, bearer => Bearer},
+    DataNew = Data#{context => Context, pfcp => PCtx, bearer => Bearer},
     Actions = context_idle_action([], Context),
     {keep_state, DataNew, Actions};
 

--- a/src/sbi_nbsf_handler.erl
+++ b/src/sbi_nbsf_handler.erl
@@ -105,7 +105,7 @@ to_json(Req0, ObjList) when length(ObjList) /= 1 ->
     {stop, Req, done};
 
 to_json(Req, [{gtp_context, Pid}]) ->
-    #{right_bearer := RightBearer, context := Context} = gtp_context:info(Pid),
+    #{bearer := #{right := RightBearer}, context := Context} = gtp_context:info(Pid),
     Keys = [apn, imsi, msisdn, vrf, ms_v4, ms_v6],
     Obj = lists:foldl(fun(K, B) -> context2binding(K, RightBearer, Context, B) end, #{}, Keys),
     Response = jsx:encode(Obj),

--- a/src/tdf.erl
+++ b/src/tdf.erl
@@ -274,7 +274,7 @@ handle_event(info, #aaa_request{procedure = {gx, 'RAR'},
 %%% step 2
 %%% step 3:
     {PCtx1, UsageReport} =
-	case ergw_pfcp_context:modify_pfcp_session(PCC1, [], #{}, Bearer, PCtx0) of
+	case ergw_pfcp_context:modify_session(PCC1, [], #{}, Bearer, PCtx0) of
 	    {ok, Result1} -> Result1;
 	    {error, Err1} -> throw(Err1#ctx_err{context = Context})
 	end,
@@ -295,7 +295,7 @@ handle_event(info, #aaa_request{procedure = {gx, 'RAR'},
 
 %%% step 6:
     {PCtx, _} =
-	case ergw_pfcp_context:modify_pfcp_session(PCC4, [], #{}, Bearer, PCtx1) of
+	case ergw_pfcp_context:modify_session(PCC4, [], #{}, Bearer, PCtx1) of
 	    {ok, Result2} -> Result2;
 	    {error, Err2} -> throw(Err2#ctx_err{context = Context})
 	end,
@@ -334,7 +334,7 @@ handle_event(internal, {session, {update_credits, _} = CreditEv, _}, _State,
 
     {PCC, _PCCErrors} = ergw_pcc_context:gy_events_to_pcc_ctx(Now, [CreditEv], PCC0),
     {PCtx, _} =
-	case ergw_pfcp_context:modify_pfcp_session(PCC, [], #{}, Bearer, PCtx0) of
+	case ergw_pfcp_context:modify_session(PCC, [], #{}, Bearer, PCtx0) of
 	    {ok, Result1} -> Result1;
 	    {error, Err1} -> throw(Err1#ctx_err{context = Context})
 	end,
@@ -439,7 +439,7 @@ start_session(#data{apn = APN, context = Context, dp_node = Node,
     PCC4 = ergw_pcc_context:session_events_to_pcc_ctx(RfSEvs, PCC3),
 
     PCtx =
-	case ergw_pfcp_context:create_tdf_session(PendingPCtx, PCC4, Bearer, Context) of
+	case ergw_pfcp_context:create_session(tdf, PCC4, PendingPCtx, Bearer, Context) of
 	    {ok, Result5} -> Result5;
 	    {error, Err5} -> throw({fail, Err5})
 	end,
@@ -506,7 +506,7 @@ ccr_initial(Session, API, SessionOpts, ReqOpts) ->
     end.
 
 close_pdn_context(Reason, run, #data{pfcp = PCtx, session = Session}) ->
-    URRs = ergw_pfcp_context:delete_pfcp_session(Reason, PCtx),
+    URRs = ergw_pfcp_context:delete_session(Reason, PCtx),
 
     %% TODO: Monitors, AAA over SGi
 

--- a/test/ergw_test_sx_up.erl
+++ b/test/ergw_test_sx_up.erl
@@ -443,7 +443,7 @@ choose_up_ip(choose, _, #state{up_ip = IP})
     {ergw_inet:ip2bin(?LOCALHOST_IPv4), undefined};
 choose_up_ip(_, choose, #state{up_ip = IP})
   when size(IP) == 16 ->
-    {ergw_inet:ip2bin(?LOCALHOST_IPv6), IP}.
+    {undefined, ergw_inet:ip2bin(?LOCALHOST_IPv6)}.
 
 process_f_teid(Id, #{f_teid := #f_teid{teid = choose, choose_id = ChId}},
 	       {RespIEs, #state{teids = TEIDs} = State})

--- a/test/ergw_test_sx_up.erl
+++ b/test/ergw_test_sx_up.erl
@@ -535,7 +535,7 @@ process_request_ies(IEs, RESTI, Acc) ->
 
 %% process_request/3
 process_request(ReqIEs, RespIEs, State0) ->
-    ct:pal("Process Req: ~p", [ReqIEs]),
+    %% ct:pal("Process Req: ~p", [ReqIEs]),
     State = State0#state{teids = #{}},
     #pfcpsereq_flags{resti = RESTI} =
 	maps:get(pfcpsereq_flags, ReqIEs, #pfcpsereq_flags{resti = 0}),

--- a/test/ggsn_proxy_SUITE.erl
+++ b/test/ggsn_proxy_SUITE.erl
@@ -1421,7 +1421,7 @@ error_indication_ggsn2sgsn(Config) ->
 
     {_Handler, CtxPid} = gtp_context_reg:lookup({'irx', {imsi, ?'IMSI', 5}}),
     true = is_pid(CtxPid),
-    #{right_bearer := RightBearer} = gtp_context:info(CtxPid),
+    #{bearer := #{right := RightBearer}} = gtp_context:info(CtxPid),
 
     ergw_test_sx_up:send('sgw-u', make_error_indication_report(RightBearer)),
 
@@ -1484,10 +1484,10 @@ update_pdp_context_request_ra_update() ->
 update_pdp_context_request_ra_update(Config) ->
     {GtpC1, _, _} = create_pdp_context(Config),
     {_Handler, CtxPid} = gtp_context_reg:lookup({'remote-irx', {imsi, ?'PROXY-IMSI', 5}}),
-    #{left_tunnel := LeftTunnel1, left_bearer := LeftBearer1} = gtp_context:info(CtxPid),
+    #{left_tunnel := LeftTunnel1, bearer := #{left := LeftBearer1}} = gtp_context:info(CtxPid),
 
     {GtpC2, _, _} = update_pdp_context(ra_update, GtpC1),
-    #{left_tunnel := LeftTunnel2, left_bearer := LeftBearer2} = gtp_context:info(CtxPid),
+    #{left_tunnel := LeftTunnel2, bearer := #{left := LeftBearer2}} = gtp_context:info(CtxPid),
 
     ?equal([], outstanding_requests()),
     delete_pdp_context(GtpC2),
@@ -1510,7 +1510,7 @@ update_pdp_context_request_tei_update() ->
 update_pdp_context_request_tei_update(Config) ->
     {GtpC1, _, _} = create_pdp_context(Config),
     {_Handler, CtxPid} = gtp_context_reg:lookup({'remote-irx', {imsi, ?'PROXY-IMSI', 5}}),
-    #{left_tunnel := LeftTunnel1, left_bearer := LeftBearer1} = gtp_context:info(CtxPid),
+    #{left_tunnel := LeftTunnel1, bearer := #{left := LeftBearer1}} = gtp_context:info(CtxPid),
 
     {_Handler, ProxyCtxPid} = gtp_context_reg:lookup({'irx', {imsi, ?'IMSI', 5}}),
     #{right_tunnel := RightTunnel1} = gtp_context:info(ProxyCtxPid),
@@ -1518,7 +1518,7 @@ update_pdp_context_request_tei_update(Config) ->
     ?match({gtp_context, ProxyCtxPid}, gtp_context_reg:lookup(ProxyRegKey1)),
 
     {GtpC2, _, _} = update_pdp_context(tei_update, GtpC1),
-    #{left_tunnel := LeftTunnel2, left_bearer := LeftBearer2} = gtp_context:info(CtxPid),
+    #{left_tunnel := LeftTunnel2, bearer := #{left := LeftBearer2}} = gtp_context:info(CtxPid),
 
     #{right_tunnel := RightTunnel2} = gtp_context:info(ProxyCtxPid),
     ProxyRegKey2 = gtp_context:tunnel_key(local, RightTunnel2),
@@ -1576,10 +1576,10 @@ update_pdp_context_request_broken_recovery(Config) ->
 		     end),
     {GtpC1, _, _} = create_pdp_context(Config),
     {_Handler, CtxPid} = gtp_context_reg:lookup({'remote-irx', {imsi, ?'PROXY-IMSI', 5}}),
-    #{left_tunnel := LeftTunnel1, left_bearer := LeftBearer1} = gtp_context:info(CtxPid),
+    #{left_tunnel := LeftTunnel1, bearer := #{left := LeftBearer1}} = gtp_context:info(CtxPid),
 
     {GtpC2, _, _} = update_pdp_context(simple, GtpC1),
-    #{left_tunnel := LeftTunnel2, left_bearer := LeftBearer2} = gtp_context:info(CtxPid),
+    #{left_tunnel := LeftTunnel2, bearer := #{left := LeftBearer2}} = gtp_context:info(CtxPid),
 
     ?equal([], outstanding_requests()),
     delete_pdp_context(GtpC2),

--- a/test/pgw_SUITE.erl
+++ b/test/pgw_SUITE.erl
@@ -1351,8 +1351,7 @@ simple_session_request(Config) ->
 		 pdi :=
 		     #pdi{
 			group =
-			    #{f_teid :=
-				  #f_teid{choose_id = 5, teid = choose},
+			    #{f_teid := #f_teid{teid = choose},
 			      network_instance :=
 				  #network_instance{instance = <<3, "irx">>},
 			      sdf_filter :=

--- a/test/pgw_proxy_SUITE.erl
+++ b/test/pgw_proxy_SUITE.erl
@@ -1658,7 +1658,7 @@ error_indication_pgw2sgw(Config) ->
 
     {_Handler, CtxPid} = gtp_context_reg:lookup({'irx', {imsi, ?'IMSI', 5}}),
     true = is_pid(CtxPid),
-    #{right_bearer := RightBearer} = gtp_context:info(CtxPid),
+    #{bearer := #{right := RightBearer}} = gtp_context:info(CtxPid),
 
     ergw_test_sx_up:send('sgw-u', make_error_indication_report(RightBearer)),
 
@@ -1721,10 +1721,10 @@ modify_bearer_request_ra_update() ->
 modify_bearer_request_ra_update(Config) ->
     {GtpC1, _, _} = create_session(Config),
     {_Handler, CtxPid} = gtp_context_reg:lookup({'remote-irx', {imsi, ?'PROXY-IMSI', 5}}),
-    #{left_tunnel := LeftTunnel1, left_bearer := LeftBearer1} = gtp_context:info(CtxPid),
+    #{left_tunnel := LeftTunnel1, bearer := #{left := LeftBearer1}} = gtp_context:info(CtxPid),
 
     {GtpC2, _, _} = modify_bearer(ra_update, GtpC1),
-    #{left_tunnel := LeftTunnel2, left_bearer := LeftBearer2} = gtp_context:info(CtxPid),
+    #{left_tunnel := LeftTunnel2, bearer := #{left := LeftBearer2}} = gtp_context:info(CtxPid),
 
     ?equal([], outstanding_requests()),
     delete_session(GtpC2),
@@ -1747,7 +1747,7 @@ modify_bearer_request_tei_update() ->
 modify_bearer_request_tei_update(Config) ->
     {GtpC1, _, _} = create_session(Config),
     {_Handler, CtxPid} = gtp_context_reg:lookup({'remote-irx', {imsi, ?'PROXY-IMSI', 5}}),
-    #{left_tunnel := LeftTunnel1, left_bearer := LeftBearer1} = gtp_context:info(CtxPid),
+    #{left_tunnel := LeftTunnel1, bearer := #{left := LeftBearer1}} = gtp_context:info(CtxPid),
 
     {_Handler, ProxyCtxPid} = gtp_context_reg:lookup({'irx', {imsi, ?'IMSI', 5}}),
     #{right_tunnel := RightTunnel1} = gtp_context:info(ProxyCtxPid),
@@ -1755,7 +1755,7 @@ modify_bearer_request_tei_update(Config) ->
     ?match({gtp_context, ProxyCtxPid}, gtp_context_reg:lookup(ProxyRegKey1)),
 
     {GtpC2, _, _} = modify_bearer(tei_update, GtpC1),
-    #{left_tunnel := LeftTunnel2, left_bearer := LeftBearer2} = gtp_context:info(CtxPid),
+    #{left_tunnel := LeftTunnel2, bearer := #{left := LeftBearer2}} = gtp_context:info(CtxPid),
 
     #{right_tunnel := RightTunnel2} = gtp_context:info(ProxyCtxPid),
     ProxyRegKey2 = gtp_context:tunnel_key(local, RightTunnel2),
@@ -2232,13 +2232,13 @@ interop_sgsn_to_sgw() ->
 interop_sgsn_to_sgw(Config) ->
     {GtpC1, _, _} = ergw_ggsn_test_lib:create_pdp_context(Config),
     {_Handler, CtxPid} = gtp_context_reg:lookup({'remote-irx', {imsi, ?'PROXY-IMSI', 5}}),
-    #{left_tunnel := LeftTunnel1, left_bearer := LeftBearer1} = gtp_context:info(CtxPid),
+    #{left_tunnel := LeftTunnel1, bearer := #{left := LeftBearer1}} = gtp_context:info(CtxPid),
 
     check_contexts_metric(v1, 3, 1),
     check_contexts_metric(v2, 0, 0),
 
     {GtpC2, _, _} = modify_bearer(tei_update, GtpC1),
-    #{left_tunnel := LeftTunnel2, left_bearer := LeftBearer2} = gtp_context:info(CtxPid),
+    #{left_tunnel := LeftTunnel2, bearer := #{left := LeftBearer2}} = gtp_context:info(CtxPid),
 
     ?equal([], outstanding_requests()),
     check_contexts_metric(v1, 3, 0),
@@ -2281,12 +2281,12 @@ interop_sgw_to_sgsn() ->
 interop_sgw_to_sgsn(Config) ->
     {GtpC1, _, _} = create_session(Config),
     {_Handler, CtxPid} = gtp_context_reg:lookup({'remote-irx', {imsi, ?'PROXY-IMSI', 5}}),
-    #{left_tunnel := LeftTunnel1, left_bearer := LeftBearer1} = gtp_context:info(CtxPid),
+    #{left_tunnel := LeftTunnel1, bearer := #{left := LeftBearer1}} = gtp_context:info(CtxPid),
 
     check_contexts_metric(v1, 0, 0),
     check_contexts_metric(v2, 3, 1),
     {GtpC2, _, _} = ergw_ggsn_test_lib:update_pdp_context(tei_update, GtpC1),
-    #{left_tunnel := LeftTunnel2, left_bearer := LeftBearer2} = gtp_context:info(CtxPid),
+    #{left_tunnel := LeftTunnel2, bearer := #{left := LeftBearer2}} = gtp_context:info(CtxPid),
 
     check_contexts_metric(v1, 3, 1),
     check_contexts_metric(v2, 3, 0),


### PR DESCRIPTION
3GPP Rel. 16 removed the option to assign UP TEIDs in the CP instance. TEID assignment in the UPF is mandatory now.

This implements the CP part of that change.