### PR TITLE
handle timeouts create session/pdp_context requests

### DIFF
--- a/src/ergw_gtp_c_socket.erl
+++ b/src/ergw_gtp_c_socket.erl
@@ -23,7 +23,11 @@
 	 terminate/2, code_change/3]).
 
 -ifdef(TEST).
--export([get_request_q/1, get_response_q/1, send_reply/2]).
+-export([get_request_q/1, get_response_q/1, send_reply/2, make_send_req/7]).
+
+-define(MAKE_SEND_REQ, ?MODULE:make_send_req).
+-else.
+-define(MAKE_SEND_REQ, make_send_req).
 -endif.
 
 -include_lib("kernel/include/logger.hrl").
@@ -94,13 +98,13 @@ send_response(#request{socket = Socket} = ReqKey, Msg, DoCache) ->
 send_request(Socket, DstIP, DstPort, T3, N3, Msg, CbInfo) ->
     ?LOG(debug, "~p: gtp_socket send_request to ~s(~p):~w: ~p",
 	 [self(), inet:ntoa(DstIP), DstIP, DstPort, Msg]),
-    cast(Socket, make_send_req(undefined, DstIP, DstPort, T3, N3, Msg, CbInfo)).
+    cast(Socket, ?MAKE_SEND_REQ(undefined, DstIP, DstPort, T3, N3, Msg, CbInfo)).
 
 %% send_request/6
 send_request(Socket, DstIP, DstPort, ReqId, Msg, CbInfo) ->
     ?LOG(debug, "~p: gtp_socket send_request ~p to ~s:~w: ~p",
 		[self(), ReqId, inet:ntoa(DstIP), DstPort, Msg]),
-    cast(Socket, make_send_req(ReqId, DstIP, DstPort, ?T3 * 2, 0, Msg, CbInfo)).
+    cast(Socket, ?MAKE_SEND_REQ(ReqId, DstIP, DstPort, ?T3 * 2, 0, Msg, CbInfo)).
 
 resend_request(Socket, ReqId) ->
     cast(Socket, {resend_request, ReqId}).

--- a/src/gtp_api.erl
+++ b/src/gtp_api.erl
@@ -59,8 +59,10 @@
 	      {noreply, NewData :: map(), 'hibernate'} |
 	      {stop, Reason :: term(), NewData :: map()}.
 
--callback close_context(Side :: atom(), Reason :: atom(), Data :: map()) -> term().
--callback delete_context(From :: term(), TermCause :: atom(), Data :: map()) -> term().
+-callback close_context(Side :: atom(), Reason :: atom(),
+			State :: term(), Data :: map()) -> term().
+-callback delete_context(From :: term(), TermCause :: atom(),
+			 State :: term(), Data :: map()) -> term().
 
 %% Clean up before the server terminates.
 -callback terminate(

--- a/src/saegw_s11.erl
+++ b/src/saegw_s11.erl
@@ -17,7 +17,7 @@
 	 handle_request/5, handle_response/5,
 	 handle_event/4, terminate/3]).
 
--export([delete_context/3, close_context/3]).
+-export([delete_context/4, close_context/4]).
 
 %% PFCP context API's
 %%-export([defered_usage_report/3]).
@@ -178,7 +178,7 @@ handle_request(ReqKey,
 	      left_tunnel => LeftTunnel, bearer => Bearer},
 
     Actions = context_idle_action([], Context),
-    {keep_state, FinalData, Actions};
+    {next_state, connected, FinalData, Actions};
 
 handle_request(ReqKey,
 	       #gtp{type = modify_bearer_request,
@@ -330,7 +330,7 @@ handle_response(_,
 				#v2_bearer_context{
 				   group = #{?'Cause' := #v2_cause{v2_cause = BearerCause}}
 				  }} = IEs} = Response,
-		_Request, run,
+		_Request, connected = State,
 		#{pfcp := PCtx, left_tunnel := LeftTunnel0, 'Session' := Session} = Data) ->
     LeftTunnel = gtp_path:bind(Response, LeftTunnel0),
 
@@ -343,12 +343,12 @@ handle_response(_,
        true ->
 	    ?LOG(error, "Update Bearer Request failed with ~p/~p",
 			[Cause, BearerCause]),
-	    delete_context(undefined, link_broken, DataNew)
+	    delete_context(undefined, link_broken, State, DataNew)
     end;
 
-handle_response(_, timeout, #gtp{type = update_bearer_request}, run, Data) ->
+handle_response(_, timeout, #gtp{type = update_bearer_request}, connected = State, Data) ->
     ?LOG(error, "Update Bearer Request failed with timeout"),
-    delete_context(undefined, link_broken, Data);
+    delete_context(undefined, link_broken, State, Data);
 
 handle_response({From, TermCause}, timeout, #gtp{type = delete_bearer_request},
 		_State, Data) ->
@@ -373,7 +373,7 @@ handle_response({From, TermCause},
     {next_state, shutdown, DataNew};
 
 handle_response(_CommandReqKey, _Response, _Request, State, _Data)
-  when State =/= run ->
+  when State =/= connected ->
     keep_state_and_data.
 
 terminate(_Reason, _State, #{context := Context}) ->
@@ -443,7 +443,7 @@ encode_paa(IPv4, IPv6) when IPv4 /= undefined, IPv6 /= undefined ->
 encode_paa(Type, IPv4, IPv6) ->
     #v2_pdn_address_allocation{type = Type, address = <<IPv6/binary, IPv4/binary>>}.
 
-close_context(_Side, Reason, Data) ->
+close_context(_Side, Reason, _State, Data) ->
     ergw_gtp_gsn_lib:close_context(Reason, Data).
 
 copy_ppp_to_session({pap, 'PAP-Authentication-Request', _Id, Username, Password}, Session0) ->
@@ -718,14 +718,18 @@ send_request(#tunnel{remote = #fq_teid{ip = RemoteCntlIP}} = Tunnel, T3, N3, Msg
 send_request(Tunnel, T3, N3, Type, RequestIEs, ReqInfo) ->
     send_request(Tunnel, T3, N3, msg(Tunnel, Type, RequestIEs), ReqInfo).
 
-delete_context(From, TermCause, #{left_tunnel := Tunnel} = Data) ->
+delete_context(From, TermCause, connected, #{left_tunnel := Tunnel} = Data) ->
     Type = delete_bearer_request,
     EBI = 5,
     RequestIEs0 = [#v2_cause{v2_cause = reactivation_requested},
 		   #v2_eps_bearer_id{eps_bearer_id = EBI}],
     RequestIEs = gtp_v2_c:build_recovery(Type, Tunnel, false, RequestIEs0),
     send_request(Tunnel, ?T3, ?N3, Type, RequestIEs, {From, TermCause}),
-    {next_state, shutdown_initiated, Data}.
+    {next_state, shutdown_initiated, Data};
+delete_context(undefined, _, _, _) ->
+    keep_state_and_data;
+delete_context(From, _, _, _) ->
+    {keep_state_and_data, [{reply, From, ok}]}.
 
 ppp_ipcp_conf_resp(Verdict, Opt, IPCP) ->
     maps:update_with(Verdict, fun(O) -> [Opt|O] end, [Opt], IPCP).

--- a/test/ergw_test_lib.hrl
+++ b/test/ergw_test_lib.hrl
@@ -12,6 +12,7 @@
 			  update_app_config/3,
 			  load_config/1]).
 -import('ergw_test_lib', [meck_init/1,
+			  meck_init_hut_handle_request/1,
 			  meck_reset/1,
 			  meck_unload/1,
 			  meck_validate/1]).

--- a/test/pgw_proxy_SUITE.erl
+++ b/test/pgw_proxy_SUITE.erl
@@ -621,6 +621,7 @@ common() ->
      create_session_overload_response,
      create_session_request_resend,
      create_session_proxy_request_resend,
+     create_session_request_timeout,
      create_lb_multi_session,
      one_lb_node_down,
      delete_session_request_resend,
@@ -707,6 +708,37 @@ init_per_testcase(create_session_proxy_request_resend, Config) ->
 			     keep_state_and_data;
 			(ReqKey, Msg, Resent, State, Data) ->
 			     meck:passthrough([ReqKey, Msg, Resent, State, Data])
+		     end),
+    Config;
+init_per_testcase(create_session_request_timeout, Config) ->
+    setup_per_testcase(Config),
+    ok = meck:new(pgw_s5s8, [passthrough, no_link]),
+    %% block session in the PGW
+    ok = meck:expect(pgw_s5s8, handle_request,
+		     fun(ReqKey, #gtp{type = create_session_request}, _, _, _) ->
+			     gtp_context:request_finished(ReqKey),
+			     keep_state_and_data;
+			(ReqKey, Msg, Resent, State, Data) ->
+			     meck:passthrough([ReqKey, Msg, Resent, State, Data])
+		     end),
+    ok = meck:expect(ergw_gtp_c_socket, make_send_req,
+		     fun(ReqId, Address, Port, _T3, N3, #gtp{type = Type} = Msg, CbInfo)
+			   when Type == create_session_request ->
+			     %% reduce timeout to 500 ms speed up the test
+			     meck:passthrough([ReqId, Address, Port, 500, N3, Msg, CbInfo]);
+			(ReqId, Address, Port, T3, N3, Msg, CbInfo) ->
+			     meck:passthrough([ReqId, Address, Port, T3, N3, Msg, CbInfo])
+		     end),
+    ok = meck:expect(?HUT, handle_request,
+		     fun(ReqKey, Request, Resent, State, Data) ->
+			     case meck:passthrough([ReqKey, Request, Resent, State, Data]) of
+				 {next_state, connecting, DataNew, _} ->
+				     %% 1 second timeout for the test
+				     Action = [{state_timeout, 1000, connecting}],
+				     {next_state, connecting, DataNew, Action};
+				 Other ->
+				     Other
+			     end
 		     end),
     Config;
 init_per_testcase(delete_session_request_timeout, Config) ->
@@ -843,6 +875,13 @@ end_per_testcase(_Config) ->
 
 end_per_testcase(create_session_proxy_request_resend, Config) ->
     ok = meck:unload(pgw_s5s8),
+    end_per_testcase(Config),
+    Config;
+end_per_testcase(create_session_request_timeout, Config) ->
+    ok = meck:unload(pgw_s5s8),
+    ok = meck:delete(ergw_gtp_c_socket, make_send_req, 7),
+    ok = meck:delete(?HUT, handle_request, 5),
+    ok = meck_init_hut_handle_request(?HUT),
     end_per_testcase(Config),
     Config;
 end_per_testcase(delete_session_request_resend, Config) ->
@@ -987,10 +1026,12 @@ create_session_overload_response(Config) ->
     %% proxy will set the TEID, so use no_resources_available instead of overload
     create_session(no_resources_available, Config),
 
+    ct:sleep(10),
+    ?equal(undefined, gtp_context_reg:lookup({'irx', {imsi, ?'IMSI', 5}})),
+
     ?equal([], outstanding_requests()),
     meck_validate(Config),
     ok.
-
 
 %%--------------------------------------------------------------------
 path_maint() ->
@@ -1692,6 +1733,23 @@ create_session_proxy_request_resend(Config) ->
 
     ?match(1, meck:num_calls(pgw_s5s8, handle_request,
 			     ['_', #gtp{type = create_session_request, _ = '_'}, '_', '_', '_'])),
+    meck_validate(Config),
+    ok.
+
+%%--------------------------------------------------------------------
+create_session_request_timeout() ->
+    [{doc, "Check that the proxy does shutdown the context on timeout"}].
+create_session_request_timeout(Config) ->
+    GtpC = gtp_context(Config),
+    Request = make_request(create_session_request, simple, GtpC),
+
+    ?equal({error,timeout}, send_recv_pdu(GtpC, Request, 2 * 1000, error)),
+
+    ?equal(undefined, gtp_context_reg:lookup({'irx', {imsi, ?'IMSI', 5}})),
+    ?match(1, meck:num_calls(pgw_s5s8, handle_request, '_')),
+
+    wait4tunnels(?TIMEOUT),
+    ?equal([], outstanding_requests()),
     meck_validate(Config),
     ok.
 


### PR DESCRIPTION
A unresponsive GGSN/PGW would leave the session context in proxy
mode dangling. More over, the proxy TEID would be zero and follow
up context teardown would send out a delete request with TEID = 0.

Handle the timeout and use an state timeout to handle the case where
the first request timed out, but a resent was successful.

Add a CT case.