### PR TITLE
Fix issue #245: provided correct config example of sockets section

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,8 +297,7 @@ Then fill just created **ergw.config** file with content like described below pr
           ]},
 
          {sockets,
-          [{'cp-socket',
-            [{type, 'gtp-u'},
+          [{cp, [{type, 'gtp-u'},
              {vrf, cp},
              {ip,  {127,0,0,1}},
              freebind,
@@ -308,7 +307,13 @@ Then fill just created **ergw.config** file with content like described below pr
                   {vrf, epc},
                   {ip,  {127,0,0,1}},
                   {reuseaddr, true}
-                 ]}
+                 ]},
+           {sx, [{node, 'ergw'},
+                 {name, 'ergw'},
+                 {type, 'pfcp'},
+                 {socket, cp},
+                 {ip,  {172,21,16,2}}
+           ]}
           ]},
 
          {vrfs,
@@ -321,14 +326,6 @@ Then fill just created **ergw.config** file with content like described below pr
                   {'MS-Primary-NBNS-Server', {127,0,0,1}},
                   {'MS-Secondary-NBNS-Server', {127,0,0,1}}
                  ]}
-          ]},
-
-         {sx_socket,
-          [{node, 'ergw'},
-           {name, 'ergw'},
-           {socket, 'cp-socket'},
-           {ip,  {127,0,0,1}},
-           freebind
           ]},
 
          {handlers,

--- a/doc/walkthrough-saegw.config
+++ b/doc/walkthrough-saegw.config
@@ -24,10 +24,22 @@
 	  ]},
 
 	 {sockets,
-	  [{epc, [{type, 'gtp-c'},
+	   [{cp, [{type, 'gtp-u'},
+	      {vrf, cp},
+	      {ip,  {127,0,0,1}},
+	     freebind,
+	     {reuseaddr, true}
+	   ]},
+	   {epc, [{type, 'gtp-c'},
 		  {ip,  {172,20,16,1}},
 		  {netdev, "vrf-irx"}
-		 ]}
+		 ]},
+	   {sx, [{node, 'ergw'},
+	      {name, 'ergw'},
+	      {type, 'pfcp'},
+	      {socket, cp},
+	      {ip,  {172,21,16,2}}
+	   ]}
 	  ]},
 
 	 {vrfs,
@@ -37,13 +49,6 @@
 		  {'MS-Primary-NBNS-Server', {127,0,0,1}},
 		  {'MS-Secondary-NBNS-Server', {127,0,0,1}}
 		 ]}
-	  ]},
-
-	 {sx_socket,
-	  [{node, 'ergw'},
-	   {name, 'ergw'},
-	   {ip, {0,0,0,0}
-	   }
 	  ]},
 
 	 {handlers,

--- a/doc/walkthrough-saegw.md
+++ b/doc/walkthrough-saegw.md
@@ -126,9 +126,21 @@ erGW Installation
                  ]},
 
                 {sockets,
-                 [{epc, [{type, 'gtp-c'},
+                 [{cp, [{type, 'gtp-u'},
+                    {vrf, cp},
+                    {ip,  {127,0,0,1}},
+                    freebind,
+                    {reuseaddr, true}
+                  ]},
+                 {epc, [{type, 'gtp-c'},
                          {ip,  {172,20,16,1}},
                          {netdev, "vrf-irx"}
+                        ]},
+                        {sx, [{node, 'ergw'},
+                           {name, 'ergw'},
+                           {type, 'pfcp'},
+                           {socket, cp},
+                           {ip,  {172,21,16,2}}
                         ]}
                  ]},
 
@@ -139,13 +151,6 @@ erGW Installation
                          {'MS-Primary-NBNS-Server', {127,0,0,1}},
                          {'MS-Secondary-NBNS-Server', {127,0,0,1}}
                         ]}
-                 ]},
-
-                {sx_socket,
-                 [{node, 'ergw'},
-                  {name, 'ergw'},
-                  {ip, {0,0,0,0}
-                  }
                  ]},
 
                 {handlers,


### PR DESCRIPTION
Issue https://github.com/travelping/ergw/issues/245.
Providing correct config example for `walkthrough-saegw.config` and for `configuration format`.