### PR TITLE
Remove sx_socket option

### DIFF
--- a/priv/dev-sx.config
+++ b/priv/dev-sx.config
@@ -29,15 +29,21 @@
 		 ]},
 	   {grx, [{type, 'gtp-u'},
 		  {node, {172,21,16,1}},
-		  {ip, {172,20,16,55}}]}
-	  ]},
-
-	 {sx_socket,
-	  [{node, 'ergw'},
-	   {name, 'ergw'},
-	   {ip, {0,0,0,0}
-	   %%{ip, {127,0,0,1}
-	   }
+		  {ip, {172,20,16,55}}]},
+	   {cp, [
+	      {type, 'gtp-u'},
+	      {vrf, cp},
+	      {ip,  {127,0,0,1}},
+	      freebind,
+	      {reuseaddr, true}
+	   ]},
+	   {sx, [
+	      {node, 'ergw'},
+	      {name, 'ergw'},
+	      {type, 'pfcp'},
+	      {socket, cp},
+	      {ip,  {0,0,0,0}}
+	   ]}
 	  ]},
 
 	 {vrfs,

--- a/priv/dev.config
+++ b/priv/dev.config
@@ -37,15 +37,15 @@
 	   {irx, [{type, 'gtp-c'},
 		  {ip, {127,0,0,1}},
 		  {reuseaddr, true}
-		 ]}
-	  ]},
-
-	 {sx_socket,
-	  [{node, 'ergw'},
-	   {name, 'ergw'},
-	   {socket, cp},
-	   {ip, {0,0,0,0}},
-	   {reuseaddr, true}
+		 ]},
+	   {sx, [
+	      {node, 'ergw'},
+	      {name, 'ergw'},
+	      {type, 'pfcp'},
+	      {socket, cp},
+	      {ip,  {0,0,0,0}},
+	      {reuseaddr, true}
+	   ]}
 	  ]},
 
 	 {handlers,

--- a/simulator/ergw_sim.erl
+++ b/simulator/ergw_sim.erl
@@ -29,11 +29,25 @@
 
 	 {ergw, [{'$setup_vars',
 		  [{"ORIGIN", {value, "epc.mnc001.mcc001.3gppnetwork.org"}}]},
-		 {sockets, []},
+		 {sockets, [
+		    {cp, [
+		       {type, 'gtp-u'},
+		       {vrf, cp},
+		       {ip,  {127,0,0,1}},
+		       freebind,
+		       {reuseaddr, true}
+		    ]},
+		    {sx, [
+		       {node, 'ergw'},
+		       {name, 'ergw'},
+		       {type, 'pfcp'},
+		       {socket, cp},
+		       {ip,  {127,127,127,127}}
+		    ]}
+		 ]},
 		 {vrfs, []},
 		 {handlers, []},
 		 {node_selection, []},
-		 {sx_socket, #{node => 'ergw', name => 'ergw', ip => {127,127,127,127}}},
 		 {apns, []}
 		]},
 	 {ergw_aaa, [{ergw_aaa_provider, {ergw_aaa_mock, [{shared_secret, <<"MySecret">>}]}}]}


### PR DESCRIPTION
Remove `sx_socket` option because `sx` socket is now handled in the sockets section of `ergw`