### PR TITLE
use random udp source port for GTP-C requests

### DIFF
--- a/include/ergw.hrl
+++ b/include/ergw.hrl
@@ -134,6 +134,7 @@
 	  key		:: term(),
 	  socket	:: #socket{},
 	  info          :: #gtp_socket_info{},
+	  src		:: atom(),
 	  ip		:: inet:ip_address(),
 	  port		:: 0 .. 65535,
 	  version	:: 'v1' | 'v2',

--- a/src/ergw_gtp_c_socket.erl
+++ b/src/ergw_gtp_c_socket.erl
@@ -14,8 +14,8 @@
 
 %% API
 -export([start_link/1,
-	 info/1, send/4, send_response/3,
-	 send_request/6, send_request/7, resend_request/2]).
+	 info/1, send/5, send_response/3,
+	 send_request/7, send_request/8, resend_request/2]).
 -export([get_seq_no/2, get_uniq_id/1]).
 
 %% gen_server callbacks
@@ -23,7 +23,7 @@
 	 terminate/2, code_change/3]).
 
 -ifdef(TEST).
--export([get_request_q/1, get_response_q/1, send_reply/2, make_send_req/7]).
+-export([get_request_q/1, get_response_q/1, send_reply/2, make_send_req/8]).
 
 -define(MAKE_SEND_REQ, ?MODULE:make_send_req).
 -else.
@@ -45,7 +45,8 @@
 	  gtp_socket :: #socket{},
 	  info       :: #gtp_socket_info{},
 
-	  socket     :: socket:socket(),
+	  recv_socket    :: socket:socket(),
+	  send_socket    :: socket:socket(),
 	  burst_size = 1 :: non_neg_integer(),
 
 	  v1_seq_no = 0 :: v1_sequence_number(),
@@ -59,6 +60,7 @@
 
 -record(send_req, {
 	  req_id  :: term(),
+	  src     :: gtp | any,
 	  address :: inet:ip_address(),
 	  port    :: inet:port_number(),
 	  t3      :: non_neg_integer(),
@@ -86,25 +88,25 @@ start_link(SocketOpts) ->
 info(Socket) ->
     call(Socket, info).
 
-send(Socket, IP, Port, Data) ->
-    cast(Socket, {send, IP, Port, Data}).
+send(Socket, Src, IP, Port, Data) ->
+    cast(Socket, {send, Src, IP, Port, Data}).
 
 send_response(#request{socket = Socket} = ReqKey, Msg, DoCache) ->
     message_counter(tx, ReqKey, Msg),
     Data = gtp_packet:encode(Msg),
     cast(Socket, {send_response, ReqKey, Data, DoCache}).
 
-%% send_request/7
-send_request(Socket, DstIP, DstPort, T3, N3, Msg, CbInfo) ->
+%% send_request/8
+send_request(Socket, Src, DstIP, DstPort, T3, N3, Msg, CbInfo) ->
     ?LOG(debug, "~p: gtp_socket send_request to ~s(~p):~w: ~p",
 	 [self(), inet:ntoa(DstIP), DstIP, DstPort, Msg]),
-    cast(Socket, ?MAKE_SEND_REQ(undefined, DstIP, DstPort, T3, N3, Msg, CbInfo)).
+    cast(Socket, ?MAKE_SEND_REQ(undefined, Src, DstIP, DstPort, T3, N3, Msg, CbInfo)).
 
-%% send_request/6
-send_request(Socket, DstIP, DstPort, ReqId, Msg, CbInfo) ->
+%% send_request/7
+send_request(Socket, Src, DstIP, DstPort, ReqId, Msg, CbInfo) ->
     ?LOG(debug, "~p: gtp_socket send_request ~p to ~s:~w: ~p",
 		[self(), ReqId, inet:ntoa(DstIP), DstPort, Msg]),
-    cast(Socket, ?MAKE_SEND_REQ(ReqId, DstIP, DstPort, ?T3 * 2, 0, Msg, CbInfo)).
+    cast(Socket, ?MAKE_SEND_REQ(ReqId, Src, DstIP, DstPort, ?T3 * 2, 0, Msg, CbInfo)).
 
 resend_request(Socket, ReqId) ->
     cast(Socket, {resend_request, ReqId}).
@@ -140,7 +142,8 @@ call(#socket{pid = Handler}, Request) ->
 init(#{name := Name, ip := IP, burst_size := BurstSize} = SocketOpts) ->
     process_flag(trap_exit, true),
 
-    {ok, Socket} = ergw_gtp_socket:make_gtp_socket(IP, ?GTP1c_PORT, SocketOpts),
+    {ok, RecvSocket} = ergw_gtp_socket:make_gtp_socket(IP, ?GTP1c_PORT, SocketOpts),
+    {ok, SendSocket} = ergw_gtp_socket:make_gtp_socket(IP, 0, SocketOpts),
     VRF = case SocketOpts of
 	      #{vrf := VRF0} when is_binary(VRF0) ->
 		  VRF0;
@@ -159,7 +162,8 @@ init(#{name := Name, ip := IP, burst_size := BurstSize} = SocketOpts) ->
 	       gtp_socket = GtpSocket,
 	       info = #gtp_socket_info{vrf = VRF, ip = IP},
 
-	       socket = Socket,
+	       recv_socket = RecvSocket,
+	       send_socket = SendSocket,
 	       burst_size = BurstSize,
 
 	       v1_seq_no = 0,
@@ -170,7 +174,8 @@ init(#{name := Name, ip := IP, burst_size := BurstSize} = SocketOpts) ->
 
 	       unique_id = rand:uniform(16#ffffffff)
 	      },
-    self() ! {'$socket', Socket, select, undefined},
+    self() ! {'$socket', RecvSocket, select, undefined},
+    self() ! {'$socket', SendSocket, select, undefined},
     {ok, State}.
 
 handle_call(info, _From, #state{info = Info} = State) ->
@@ -197,9 +202,9 @@ handle_call(Request, _From, State) ->
     ?LOG(error, "handle_call: unknown ~p", [Request]),
     {reply, ok, State}.
 
-handle_cast({send, IP, Port, Data}, State)
+handle_cast({send, Src, IP, Port, Data}, State)
   when is_binary(Data) ->
-    sendto(IP, Port, Data, State),
+    sendto(Src, IP, Port, Data, State),
     {noreply, State};
 
 handle_cast({send_response, ReqKey, Data, DoCache}, State0)
@@ -255,19 +260,26 @@ handle_info({timeout, TRef, requests}, #state{requests = Requests} = State) ->
 handle_info({timeout, TRef, responses}, #state{responses = Responses} = State) ->
     {noreply, State#state{responses = ergw_cache:expire(TRef, Responses)}};
 
-handle_info({'$socket', Socket, select, Info}, #state{socket = Socket} = State) ->
-    handle_input(Socket, Info, State);
+handle_info({'$socket', Socket, select, Info}, #state{recv_socket = Socket} = State) ->
+    handle_input(Socket, gtp, Info, State);
 
-handle_info({'$socket', Socket, abort, Info}, #state{socket = Socket} = State) ->
-    handle_input(Socket, Info, State);
+handle_info({'$socket', Socket, abort, Info}, #state{recv_socket = Socket} = State) ->
+    handle_input(Socket, gtp, Info, State);
+
+handle_info({'$socket', Socket, select, Info}, #state{send_socket = Socket} = State) ->
+    handle_input(Socket, any, Info, State);
+
+handle_info({'$socket', Socket, abort, Info}, #state{send_socket = Socket} = State) ->
+    handle_input(Socket, any, Info, State);
 
 handle_info(Info, State) ->
     ?LOG(error, "~s:handle_info: unknown ~p, ~p",
 		[?MODULE, Info, State]),
     {noreply, State}.
 
-terminate(_Reason, #state{socket = Socket} = _State) ->
-    socket:close(Socket),
+terminate(_Reason, #state{recv_socket = RecvSocket, send_socket = SendSocket} = _State) ->
+    socket:close(RecvSocket),
+    socket:close(SendSocket),
     ok.
 
 code_change(_OldVsn, State, _Extra) ->
@@ -315,9 +327,10 @@ new_sequence_number(#gtp{version = v2, type = Type} = Msg,
 family({_,_,_,_}) -> inet;
 family({_,_,_,_,_,_,_,_}) -> inet6.
 
-make_send_req(ReqId, Address, Port, T3, N3, Msg, CbInfo) ->
+make_send_req(ReqId, Src, Address, Port, T3, N3, Msg, CbInfo) ->
     #send_req{
        req_id = ReqId,
+       src = Src,
        address = Address,
        port = Port,
        t3 = T3,
@@ -327,33 +340,33 @@ make_send_req(ReqId, Address, Port, T3, N3, Msg, CbInfo) ->
        send_ts = erlang:monotonic_time()
       }.
 
-make_request(ArrivalTS, IP, Port, Msg, #state{gtp_socket = Socket, info = Info}) ->
-    ergw_gtp_socket:make_request(ArrivalTS, IP, Port, Msg, Socket, Info).
+make_request(ArrivalTS, Src, IP, Port, Msg, #state{gtp_socket = Socket, info = Info}) ->
+    ergw_gtp_socket:make_request(ArrivalTS, Src, IP, Port, Msg, Socket, Info).
 
-handle_input(Socket, Info, #state{burst_size = BurstSize} = State) ->
-    handle_input(Socket, Info, 0, BurstSize, State).
+handle_input(Socket, Src, Info, #state{burst_size = BurstSize} = State) ->
+    handle_input(Socket, Src, Info, 0, BurstSize, State).
 
-handle_input(Socket, _Info, Cnt, Max, State0)
+handle_input(Socket, _Src, _Info, Cnt, Max, State0)
   when Cnt >= Max ->
     %% break the loop and restart
     self() ! {'$socket', Socket, select, undefined},
     {noreply, State0};
 
-handle_input(Socket, Info, Cnt, Max, State0) ->
+handle_input(Socket, Src, Info, Cnt, Max, State0) ->
     case socket:recvfrom(Socket, 0, [], nowait) of
 	{error, _} ->
 	    State = handle_err_input(Socket, State0),
-	    handle_input(Socket, Info, Cnt + 1, Max, State);
+	    handle_input(Socket, Src, Info, Cnt + 1, Max, State);
 
 	{ok, {#{addr := IP, port := Port}, Data}} ->
 	    ArrivalTS = erlang:monotonic_time(),
-	    State = handle_message(ArrivalTS, IP, Port, Data, State0),
-	    handle_input(Socket, Info, Cnt + 1, Max, State);
+	    State = handle_message(ArrivalTS, Src, IP, Port, Data, State0),
+	    handle_input(Socket, Src, Info, Cnt + 1, Max, State);
 
 	{select, _SelectInfo} when Cnt == 0 ->
 	    %% there must be something in the error queue
 	    State = handle_err_input(Socket, State0),
-	    handle_input(Socket, Info, Cnt + 1, Max, State);
+	    handle_input(Socket, Src, Info, Cnt + 1, Max, State);
 
 	{select, _SelectInfo} ->
 	    {noreply, State0}
@@ -427,16 +440,16 @@ handle_err_input(Socket, State) ->
     end,
     State.
 
-handle_message(ArrivalTS, IP, Port, Data, #state{gtp_socket = Socket} = State0) ->
+handle_message(ArrivalTS, Src, IP, Port, Data, #state{gtp_socket = Socket} = State0) ->
     try gtp_packet:decode(Data, #{ies => binary}) of
 	Msg = #gtp{} ->
 	    %% TODO: handle decode failures
 
-	    ?LOG(debug, "handle message: ~p", [{IP, Port,
+	    ?LOG(debug, "handle message: ~p", [{Src, IP, Port,
 						State0#state.gtp_socket,
 						Msg}]),
 	    ergw_prometheus:gtp(rx, Socket, IP, Msg),
-	    handle_message_1(ArrivalTS, IP, Port, Msg, State0)
+	    handle_message_1(ArrivalTS, Src, IP, Port, Msg, State0)
     catch
 	Class:Error ->
 	    ergw_prometheus:gtp_error(rx, Socket, 'malformed-requests'),
@@ -444,17 +457,17 @@ handle_message(ArrivalTS, IP, Port, Data, #state{gtp_socket = Socket} = State0) 
 	    State0
     end.
 
-handle_message_1(_, _, _, #gtp{version = Version}, #state{gtp_socket = Socket} = State)
+handle_message_1(_, _, _, _, #gtp{version = Version}, #state{gtp_socket = Socket} = State)
   when Version /= v1 andalso Version /= v2 ->
     ergw_prometheus:gtp_error(rx, Socket, 'version-not-supported'),
     State;
 
-handle_message_1(ArrivalTS, IP, Port, #gtp{type = echo_request} = Msg, State) ->
-    ReqKey = make_request(ArrivalTS, IP, Port, Msg, State),
+handle_message_1(ArrivalTS, Src, IP, Port, #gtp{type = echo_request} = Msg, State) ->
+    ReqKey = make_request(ArrivalTS, Src, IP, Port, Msg, State),
     gtp_path:handle_request(ReqKey, Msg),
     State;
 
-handle_message_1(ArrivalTS, IP, Port, #gtp{version = Version, type = MsgType} = Msg, State) ->
+handle_message_1(ArrivalTS, Src, IP, Port, #gtp{version = Version, type = MsgType} = Msg, State) ->
     Handler =
 	case Version of
 	    v1 -> gtp_v1_c;
@@ -462,15 +475,15 @@ handle_message_1(ArrivalTS, IP, Port, #gtp{version = Version, type = MsgType} = 
 	end,
     case Handler:gtp_msg_type(MsgType) of
 	response ->
-	    handle_response(ArrivalTS, IP, Port, Msg, State);
+	    handle_response(ArrivalTS, Src, IP, Port, Msg, State);
 	request ->
-	    ReqKey = make_request(ArrivalTS, IP, Port, Msg, State),
+	    ReqKey = make_request(ArrivalTS, Src, IP, Port, Msg, State),
 	    handle_request(ReqKey, Msg, State);
 	_ ->
 	    State
     end.
 
-handle_response(ArrivalTS, IP, _Port, Msg, #state{gtp_socket = Socket} = State0) ->
+handle_response(ArrivalTS, _Src, IP, _Port, Msg, #state{gtp_socket = Socket} = State0) ->
     SeqId = ergw_gtp_socket:make_seq_id(Msg),
     {Req, State} = take_request(SeqId, State0),
     case Req of
@@ -486,12 +499,12 @@ handle_response(ArrivalTS, IP, _Port, Msg, #state{gtp_socket = Socket} = State0)
 	    State
     end.
 
-handle_request(#request{ip = IP, port = Port} = ReqKey, Msg,
+handle_request(#request{src = Src, ip = IP, port = Port} = ReqKey, Msg,
 	       #state{gtp_socket = Socket, responses = Responses} = State) ->
     case ergw_cache:get(cache_key(ReqKey), Responses) of
 	{value, Data} ->
 	    ergw_prometheus:gtp(rx, Socket, IP, Msg, duplicate),
-	    sendto(IP, Port, Data, State);
+	    sendto(Src, IP, Port, Data, State);
 
 	_Other ->
 	    ?LOG(debug, "HandleRequest: ~p", [_Other]),
@@ -520,10 +533,16 @@ take_request(SeqId, #state{pending = PendingIn} = State) ->
 	    {Req, State#state{pending = PendingOut}}
     end.
 
-sendto(RemoteIP, Port, Data, #state{socket = Socket}) ->
+socket(gtp, #state{recv_socket = Socket}) ->
+    Socket;
+socket(any, #state{send_socket = Socket}) ->
+    Socket.
+
+sendto(Src, RemoteIP, Port, Data, State) ->
     Dest = #{family => family(RemoteIP),
 	     addr => RemoteIP,
 	     port => Port},
+    Socket = socket(Src, State),
     case socket:sendto(Socket, Data, Dest, nowait) of
 	ok -> ok;
 	Other  ->
@@ -537,8 +556,8 @@ send_reply({M, F, A}, Reply) ->
 send_request_reply(#send_req{cb_info = CbInfo}, Reply) ->
     send_reply(CbInfo, Reply).
 
-send_request(#send_req{address = DstIP, port = DstPort, data = Data} = SendReq, State0) ->
-    sendto(DstIP, DstPort, Data, State0),
+send_request(#send_req{src = Src, address = DstIP, port = DstPort, data = Data} = SendReq, State0) ->
+    sendto(Src, DstIP, DstPort, Data, State0),
     State = start_request(SendReq, State0),
     request_q_in(SendReq, State).
 
@@ -557,8 +576,8 @@ enqueue_response(ReqKey, Data, DoCache,
 enqueue_response(_ReqKey, _Data, _DoCache, State) ->
     State.
 
-do_send_response(#request{ip = IP, port = Port} = ReqKey, Data, DoCache, State) ->
-    sendto(IP, Port, Data, State),
+do_send_response(#request{src = Src, ip = IP, port = Port} = ReqKey, Data, DoCache, State) ->
+    sendto(Src, IP, Port, Data, State),
     measure_response(ReqKey),
     enqueue_response(ReqKey, Data, DoCache, State).
 

--- a/src/ergw_gtp_socket.erl
+++ b/src/ergw_gtp_socket.erl
@@ -47,7 +47,7 @@ send(Socket, Src, IP, Port, Data) ->
 %%% Options Validation
 %%%===================================================================
 
--define(SocketDefaults, [{ip, invalid}, {burst_size, 10}]).
+-define(SocketDefaults, [{ip, invalid}, {burst_size, 10}, {split_sockets, true}]).
 
 validate_options(Name, Values) ->
     ergw_config:validate_options(fun validate_option/2, Values,
@@ -76,6 +76,8 @@ validate_option(vrf, Value) ->
 validate_option(freebind, Value) when is_boolean(Value) ->
     Value;
 validate_option(reuseaddr, Value) when is_boolean(Value) ->
+    Value;
+validate_option(split_sockets, Value) when is_boolean(Value) ->
     Value;
 validate_option(rcvbuf, Value)
   when is_integer(Value) andalso Value > 0 ->

--- a/src/ergw_gtp_socket.erl
+++ b/src/ergw_gtp_socket.erl
@@ -10,11 +10,11 @@
 -compile({parse_transform, cut}).
 
 %% API
--export([validate_options/2, info/1, send/4]).
--export([make_seq_id/1, make_request/6]).
+-export([validate_options/2, info/1, send/5]).
+-export([make_seq_id/1, make_request/7]).
 -export([make_gtp_socket/3]).
 
--ignore_xref([info/1, send/4]).
+-ignore_xref([info/1, send/5]).
 
 -if(?OTP_RELEASE =< 23).
 -ignore_xref([behaviour_info/1]).
@@ -30,7 +30,7 @@
 %%====================================================================
 
 -callback info(Socket :: #socket{}) -> Info :: term().
--callback send(Socket :: #socket{}, IP :: inet:ip_address(),
+-callback send(Socket :: #socket{}, Src :: atom(), IP :: inet:ip_address(),
 	       Port :: inet:port_number(), Data :: binary()) -> Result :: term().
 
 %%====================================================================
@@ -40,8 +40,8 @@
 info(Socket) ->
     invoke_handler(Socket, info, []).
 
-send(Socket, IP, Port, Data) ->
-    invoke_handler(Socket, send, [IP, Port, Data]).
+send(Socket, Src, IP, Port, Data) ->
+    invoke_handler(Socket, send, [Src, IP, Port, Data]).
 
 %%%===================================================================
 %%% Options Validation
@@ -158,12 +158,13 @@ make_seq_id(#gtp{version = Version, seq_no = SeqNo})
 make_seq_id(_) ->
     undefined.
 
-make_request(ArrivalTS, IP, Port, Msg = #gtp{version = Version, type = Type}, Socket, Info) ->
+make_request(ArrivalTS, Src, IP, Port, Msg = #gtp{version = Version, type = Type}, Socket, Info) ->
     SeqId = make_seq_id(Msg),
     #request{
        key = {Socket, IP, Port, Type, SeqId},
        socket = Socket,
        info = Info,
+       src = Src,
        ip = IP,
        port = Port,
        version = Version,

--- a/src/ergw_gtp_u_socket.erl
+++ b/src/ergw_gtp_u_socket.erl
@@ -13,7 +13,7 @@
 -compile({parse_transform, cut}).
 
 %% API
--export([start_link/1, info/1, send/4]).
+-export([start_link/1, info/1, send/5]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -50,9 +50,9 @@ start_link(SocketOpts) ->
 info(Socket) ->
     call(Socket, info).
 
-send(#socket{type = 'gtp-u'} = Socket, IP, Port, #gtp{} = Msg) ->
+send(#socket{type = 'gtp-u'} = Socket, _Src, IP, Port, #gtp{} = Msg) ->
     cast(Socket, make_send_req(IP, Port, Msg));
-send(#socket{type = 'gtp-u'} = Socket, IP, Port, Data) ->
+send(#socket{type = 'gtp-u'} = Socket, _Src, IP, Port, Data) ->
     cast(Socket, {send, IP, Port, Data}).
 
 %%%===================================================================
@@ -152,7 +152,7 @@ make_send_req(Address, Port, Msg) ->
       }.
 
 make_request(IP, Port, Msg, #state{gtp_socket = Socket, info = Info}) ->
-    ergw_gtp_socket:make_request(0, IP, Port, Msg, Socket, Info).
+    ergw_gtp_socket:make_request(0, gtp, IP, Port, Msg, Socket, Info).
 
 handle_input(Socket, Info, #state{burst_size = BurstSize} = State) ->
     handle_input(Socket, Info, BurstSize, State).

--- a/src/ergw_proxy_lib.erl
+++ b/src/ergw_proxy_lib.erl
@@ -11,7 +11,7 @@
 	  {parse_transform, cut}]).
 
 -export([validate_options/3, validate_option/2,
-	 forward_request/3, forward_request/7, forward_request/9,
+	 forward_request/3, forward_request/8, forward_request/10,
 	 get_seq_no/3,
 	 select_gw/5,
 	 select_gtp_proxy_sockets/2,
@@ -28,17 +28,17 @@
 %%% API
 %%%===================================================================
 
-%% forward_request/9
-forward_request(Direction, #tunnel{socket = Socket}, DstIP, DstPort,
+%% forward_request/10
+forward_request(Direction, #tunnel{socket = Socket}, Src, DstIP, DstPort,
 		Request, ReqKey, SeqNo, NewPeer, OldState) ->
     {ReqId, ReqInfo} = make_proxy_request(Direction, ReqKey, SeqNo, NewPeer, OldState),
     ?LOG(debug, "Invoking Context Send Request: ~p", [Request]),
-    gtp_context:send_request(Socket, DstIP, DstPort, ReqId, Request, ReqInfo).
+    gtp_context:send_request(Socket, Src, DstIP, DstPort, ReqId, Request, ReqInfo).
 
-%% forward_request/7
+%% forward_request/8
 forward_request(Direction, #tunnel{remote = #fq_teid{ip = IP}} = Tunnel,
-		Request, ReqKey, SeqNo, NewPeer, OldState) ->
-    forward_request(Direction, Tunnel, IP, ?GTP1c_PORT,
+		Src, Request, ReqKey, SeqNo, NewPeer, OldState) ->
+    forward_request(Direction, Tunnel, Src, IP, ?GTP1c_PORT,
 		    Request, ReqKey, SeqNo, NewPeer, OldState).
 
 %% forward_request/3

--- a/src/ergw_sx_node.erl
+++ b/src/ergw_sx_node.erl
@@ -291,7 +291,7 @@ handle_event(cast, {send, 'Access', _VRF, Data}, {connected, _},
 
     Msg = #gtp{version = v1, type = g_pdu, tei = TEI, ie = Data},
     Bin = gtp_packet:encode(Msg),
-    ergw_gtp_u_socket:send(Socket, IP, ?GTP1u_PORT, Bin),
+    ergw_gtp_u_socket:send(Socket, gtp, IP, ?GTP1u_PORT, Bin),
 
     keep_state_and_data;
 
@@ -486,7 +486,7 @@ pfcp_reply_actions({call, From}, Reply) ->
     [{reply, From, Reply}].
 
 make_request(IP, Port, Msg, #data{cp_socket = Socket, cp_info = Info}) ->
-    ergw_gtp_socket:make_request(0, IP, Port, Msg, Socket, Info).
+    ergw_gtp_socket:make_request(0, sx, IP, Port, Msg, Socket, Info).
 
 %% IPv4, non fragmented, UDP packet
 handle_ip_pdu(<<Version:4, IHL:4, _TOS:8, TotLen:16, _Id:16, _:2, 0:1, 0:13,

--- a/src/ggsn_gn.erl
+++ b/src/ggsn_gn.erl
@@ -769,7 +769,7 @@ msg(#tunnel{remote = #fq_teid{teid = RemoteCntlTEI}}, Type, RequestIEs) ->
     #gtp{version = v1, type = Type, tei = RemoteCntlTEI, ie = RequestIEs}.
 
 send_request(Tunnel, DstIP, DstPort, T3, N3, Msg, ReqInfo) ->
-    gtp_context:send_request(Tunnel, DstIP, DstPort, T3, N3, Msg, ReqInfo).
+    gtp_context:send_request(Tunnel, any, DstIP, DstPort, T3, N3, Msg, ReqInfo).
 
 send_request(#tunnel{remote = #fq_teid{ip = RemoteCntlIP}} = Tunnel, T3, N3, Msg, ReqInfo) ->
     send_request(Tunnel, RemoteCntlIP, ?GTP1c_PORT, T3, N3, Msg, ReqInfo).

--- a/src/ggsn_gn_proxy.erl
+++ b/src/ggsn_gn_proxy.erl
@@ -640,7 +640,7 @@ msg(#tunnel{remote = #fq_teid{teid = RemoteCntlTEI}}, Type, RequestIEs) ->
     #gtp{version = v1, type = Type, tei = RemoteCntlTEI, ie = RequestIEs}.
 
 send_request(Tunnel, DstIP, DstPort, T3, N3, Msg, ReqInfo) ->
-    gtp_context:send_request(Tunnel, DstIP, DstPort, T3, N3, Msg, ReqInfo).
+    gtp_context:send_request(Tunnel, any, DstIP, DstPort, T3, N3, Msg, ReqInfo).
 
 send_request(#tunnel{remote = #fq_teid{ip = RemoteCntlIP}} = Tunnel, T3, N3, Msg, ReqInfo) ->
     send_request(Tunnel, RemoteCntlIP, ?GTP2c_PORT, T3, N3, Msg, ReqInfo).
@@ -696,7 +696,7 @@ bind_forward_path(ggsn2sgsn, Request,
 forward_request(Direction, ReqKey, #gtp{seq_no = ReqSeqNo, ie = ReqIEs} = Request,
 		Tunnel, Bearer, Context, Data) ->
     FwdReq = build_context_request(Tunnel, Bearer, Context, false, undefined, Request),
-    ergw_proxy_lib:forward_request(Direction, Tunnel, FwdReq, ReqKey,
+    ergw_proxy_lib:forward_request(Direction, Tunnel, any, FwdReq, ReqKey,
 				   ReqSeqNo, is_map_key(?'Recovery', ReqIEs), Data).
 
 forward_response(#proxy_request{request = ReqKey, seq_no = SeqNo, new_peer = NewPeer},

--- a/src/gtp_context.erl
+++ b/src/gtp_context.erl
@@ -15,9 +15,9 @@
 
 -export([handle_response/4,
 	 start_link/6,
-	 send_request/7,
+	 send_request/8,
 	 send_response/2, send_response/3,
-	 send_request/6, resend_request/2,
+	 send_request/7, resend_request/2,
 	 request_finished/1,
 	 path_restart/2,
 	 terminate_colliding_context/2, terminate_context/1,
@@ -69,17 +69,18 @@
 handle_response(Context, ReqInfo, Request, Response) ->
     gen_statem:cast(Context, {handle_response, ReqInfo, Request, Response}).
 
-%% send_request/7
-send_request(#tunnel{socket = Socket}, DstIP, DstPort, T3, N3, Msg, ReqInfo) ->
+%% send_request/8
+send_request(#tunnel{socket = Socket}, Src, DstIP, DstPort, T3, N3, Msg, ReqInfo) ->
     CbInfo = {?MODULE, handle_response, [self(), ReqInfo, Msg]},
-    ergw_gtp_c_socket:send_request(Socket, DstIP, DstPort, T3, N3, Msg, CbInfo).
+    ergw_gtp_c_socket:send_request(Socket, Src, DstIP, DstPort, T3, N3, Msg, CbInfo).
 
-%% send_request/6
-send_request(Socket, DstIP, DstPort, ReqId, Msg, ReqInfo) when is_record(Socket, socket) ->
+%% send_request/7
+send_request(Socket, Src, DstIP, DstPort, ReqId, Msg, ReqInfo)
+  when is_record(Socket, socket) ->
     CbInfo = {?MODULE, handle_response, [self(), ReqInfo, Msg]},
-    ergw_gtp_c_socket:send_request(Socket, DstIP, DstPort, ReqId, Msg, CbInfo);
-send_request(#tunnel{socket = Socket}, DstIP, DstPort, ReqId, Msg, ReqInfo) ->
-    send_request(Socket, DstIP, DstPort, ReqId, Msg, ReqInfo).
+    ergw_gtp_c_socket:send_request(Socket, Src, DstIP, DstPort, ReqId, Msg, CbInfo);
+send_request(#tunnel{socket = Socket}, Src, DstIP, DstPort, ReqId, Msg, ReqInfo) ->
+    send_request(Socket, Src, DstIP, DstPort, ReqId, Msg, ReqInfo).
 
 resend_request(#tunnel{socket = Socket}, ReqId) ->
     ergw_gtp_c_socket:resend_request(Socket, ReqId).

--- a/src/gtp_path.erl
+++ b/src/gtp_path.erl
@@ -552,7 +552,7 @@ send_echo_request(State, #{socket := Socket, handler := Handler, ip := DstIP,
     Msg = Handler:build_echo_request(),
     Ref = erlang:make_ref(),
     CbInfo = {?MODULE, handle_response, [self(), echo_request, Ref]},
-    ergw_gtp_c_socket:send_request(Socket, DstIP, ?GTP1c_PORT, T3, N3, Msg, CbInfo),
+    ergw_gtp_c_socket:send_request(Socket, any, DstIP, ?GTP1c_PORT, T3, N3, Msg, CbInfo),
     State#state{echo = Ref}.
 
 path_restart(RestartCounter, State, #{contexts := CtxS} = Data, Actions) ->

--- a/src/saegw_s11.erl
+++ b/src/saegw_s11.erl
@@ -252,7 +252,7 @@ handle_request(ReqKey,
     Actions = context_idle_action([], Context),
     {keep_state, DataNew, Actions};
 
-handle_request(#request{ip = SrcIP, port = SrcPort} = ReqKey,
+handle_request(#request{src = Src, ip = IP, port = Port} = ReqKey,
 	       #gtp{type = modify_bearer_command,
 		    seq_no = SeqNo,
 		    ie = #{?'APN-AMBR' := AMBR,
@@ -273,7 +273,7 @@ handle_request(#request{ip = SrcIP, port = SrcPort} = ReqKey,
 		      group = copy_ies_to_response(Bearer, [EBI], [?'Bearer Level QoS'])}],
     RequestIEs = gtp_v2_c:build_recovery(Type, LeftTunnel, false, RequestIEs0),
     Msg = msg(LeftTunnel, Type, RequestIEs),
-    send_request(LeftTunnel, SrcIP, SrcPort, ?T3, ?N3, Msg#gtp{seq_no = SeqNo}, undefined),
+    send_request(LeftTunnel, Src, IP, Port, ?T3, ?N3, Msg#gtp{seq_no = SeqNo}, undefined),
 
     Actions = context_idle_action([], Context),
     {keep_state_and_data, Actions};
@@ -709,14 +709,17 @@ copy_ies_to_response(RequestIEs, ResponseIEs0, [H|T]) ->
 msg(#tunnel{remote = #fq_teid{teid = RemoteCntlTEI}}, Type, RequestIEs) ->
     #gtp{version = v2, type = Type, tei = RemoteCntlTEI, ie = RequestIEs}.
 
-send_request(Tunnel, DstIP, DstPort, T3, N3, Msg, ReqInfo) ->
-    gtp_context:send_request(Tunnel, DstIP, DstPort, T3, N3, Msg, ReqInfo).
-
+%% send_request/5
 send_request(#tunnel{remote = #fq_teid{ip = RemoteCntlIP}} = Tunnel, T3, N3, Msg, ReqInfo) ->
-    send_request(Tunnel, RemoteCntlIP, ?GTP2c_PORT, T3, N3, Msg, ReqInfo).
+    send_request(Tunnel, any, RemoteCntlIP, ?GTP2c_PORT, T3, N3, Msg, ReqInfo).
 
+%% send_request/6
 send_request(Tunnel, T3, N3, Type, RequestIEs, ReqInfo) ->
     send_request(Tunnel, T3, N3, msg(Tunnel, Type, RequestIEs), ReqInfo).
+
+%% send_request/8
+send_request(Tunnel, Src, DstIP, DstPort, T3, N3, Msg, ReqInfo) ->
+    gtp_context:send_request(Tunnel, Src, DstIP, DstPort, T3, N3, Msg, ReqInfo).
 
 delete_context(From, TermCause, connected, #{left_tunnel := Tunnel} = Data) ->
     Type = delete_bearer_request,

--- a/test/ergw_ggsn_test_lib.erl
+++ b/test/ergw_ggsn_test_lib.erl
@@ -719,9 +719,9 @@ ggsn_update_context(From, Tunnel) ->
     NSAPI = 5,
     RequestIEs0 = [#nsapi{nsapi = NSAPI}],
     RequestIEs = gtp_v1_c:build_recovery(Type, Tunnel, false, RequestIEs0),
-    ggsn_send_request(Tunnel, ?T3, ?N3, Type, RequestIEs, From).
+    ggsn_send_request(Tunnel, any, ?T3, ?N3, Type, RequestIEs, From).
 
 ggsn_send_request(#tunnel{remote = #fq_teid{ip = RemoteCntlIP, teid = RemoteCntlTEI}} = Tunnel,
-		  T3, N3, Type, RequestIEs, From) ->
+		  Src, T3, N3, Type, RequestIEs, From) ->
     Msg = #gtp{version = v1, type = Type, tei = RemoteCntlTEI, ie = RequestIEs},
-    gtp_context:send_request(Tunnel, RemoteCntlIP, ?GTP1c_PORT, T3, N3, Msg, From).
+    gtp_context:send_request(Tunnel, Src, RemoteCntlIP, ?GTP1c_PORT, T3, N3, Msg, From).

--- a/test/ergw_pgw_test_lib.erl
+++ b/test/ergw_pgw_test_lib.erl
@@ -1201,9 +1201,9 @@ pgw_update_context(From, Tunnel) ->
 		    ]},
 	 #v2_aggregate_maximum_bit_rate{uplink = 48128, downlink = 1704125}],
     RequestIEs = gtp_v2_c:build_recovery(Type, Tunnel, false, RequestIEs0),
-    pgw_send_request(Tunnel, ?T3, ?N3, Type, RequestIEs, From).
+    pgw_send_request(Tunnel, any, ?T3, ?N3, Type, RequestIEs, From).
 
 pgw_send_request(#tunnel{remote = #fq_teid{ip = RemoteCntlIP, teid = RemoteCntlTEI}} = Tunnel,
-		 T3, N3, Type, RequestIEs, From) ->
+		 Src, T3, N3, Type, RequestIEs, From) ->
     Msg = #gtp{version = v2, type = Type, tei = RemoteCntlTEI, ie = RequestIEs},
-    gtp_context:send_request(Tunnel, RemoteCntlIP, ?GTP2c_PORT, T3, N3, Msg, From).
+    gtp_context:send_request(Tunnel, Src, RemoteCntlIP, ?GTP2c_PORT, T3, N3, Msg, From).

--- a/test/ggsn_SUITE.erl
+++ b/test/ggsn_SUITE.erl
@@ -533,13 +533,13 @@ init_per_testcase(TestCase, Config)
   when TestCase == delete_pdp_context_requested_resend ->
     setup_per_testcase(Config),
     ok = meck:expect(ergw_gtp_c_socket, send_request,
-		     fun(Socket, DstIP, DstPort, _T3, _N3,
+		     fun(Socket, Src, DstIP, DstPort, _T3, _N3,
 			 #gtp{type = delete_pdp_context_request} = Msg, CbInfo) ->
 			     %% reduce timeout to 1 second and 2 resends
 			     %% to speed up the test
-			     meck:passthrough([Socket, DstIP, DstPort, 1000, 2, Msg, CbInfo]);
-			(Socket, DstIP, DstPort, T3, N3, Msg, CbInfo) ->
-			     meck:passthrough([Socket, DstIP, DstPort, T3, N3, Msg, CbInfo])
+			     meck:passthrough([Socket, Src, DstIP, DstPort, 1000, 2, Msg, CbInfo]);
+			(Socket, Src, DstIP, DstPort, T3, N3, Msg, CbInfo) ->
+			     meck:passthrough([Socket, Src, DstIP, DstPort, T3, N3, Msg, CbInfo])
 		     end),
     Config;
 init_per_testcase(request_fast_resend, Config) ->
@@ -649,7 +649,7 @@ end_per_testcase(path_restart, Config) ->
     Config;
 end_per_testcase(TestCase, Config)
   when TestCase == delete_pdp_context_requested_resend ->
-    ok = meck:delete(ergw_gtp_c_socket, send_request, 7),
+    ok = meck:delete(ergw_gtp_c_socket, send_request, 8),
     end_per_testcase(Config),
     Config;
 end_per_testcase(request_fast_resend, Config) ->
@@ -943,12 +943,12 @@ path_failure(Config) ->
 
     ClientIP = proplists:get_value(client_ip, Config),
     ok = meck:expect(ergw_gtp_c_socket, send_request,
-		     fun (_, IP, _, _, _, #gtp{type = echo_request}, CbInfo)
+		     fun (_, _, IP, _, _, _, #gtp{type = echo_request}, CbInfo)
 			   when IP =:= ClientIP ->
 			     %% simulate a Echo timeout
 			     ergw_gtp_c_socket:send_reply(CbInfo, timeout);
-			 (Socket, IP, Port, T3, N3, Msg, CbInfo) ->
-			     meck:passthrough([Socket, IP, Port, T3, N3, Msg, CbInfo])
+			 (Socket, Src, IP, Port, T3, N3, Msg, CbInfo) ->
+			     meck:passthrough([Socket, Src, IP, Port, T3, N3, Msg, CbInfo])
 		     end),
 
     gtp_path:ping(CSocket, v1, ClientIP),
@@ -963,7 +963,7 @@ path_failure(Config) ->
     wait4tunnels(?TIMEOUT),
     meck_validate(Config),
 
-    ok = meck:delete(ergw_gtp_c_socket, send_request, 7),
+    ok = meck:delete(ergw_gtp_c_socket, send_request, 8),
     ok.
 
 %%--------------------------------------------------------------------

--- a/test/saegw_s11_SUITE.erl
+++ b/test/saegw_s11_SUITE.erl
@@ -498,15 +498,15 @@ init_per_testcase(TestCase, Config)
        TestCase == modify_bearer_command_timeout ->
     setup_per_testcase(Config),
     ok = meck:expect(ergw_gtp_c_socket, send_request,
-		     fun(Socket, DstIP, DstPort, _T3, _N3,
+		     fun(Socket, Src, DstIP, DstPort, _T3, _N3,
 			 #gtp{type = Type} = Msg, CbInfo)
 			   when Type == delete_bearer_request;
 				Type == update_bearer_request ->
 			     %% reduce timeout to 1 second and 2 resends
 			     %% to speed up the test
-			     meck:passthrough([Socket, DstIP, DstPort, 1000, 2, Msg, CbInfo]);
-			(Socket, DstIP, DstPort, T3, N3, Msg, CbInfo) ->
-			     meck:passthrough([Socket, DstIP, DstPort, T3, N3, Msg, CbInfo])
+			     meck:passthrough([Socket, Src, DstIP, DstPort, 1000, 2, Msg, CbInfo]);
+			(Socket, Src, DstIP, DstPort, T3, N3, Msg, CbInfo) ->
+			     meck:passthrough([Socket, Src, DstIP, DstPort, T3, N3, Msg, CbInfo])
 		     end),
     Config;
 init_per_testcase(create_session_overload, Config) ->
@@ -590,7 +590,7 @@ end_per_testcase(create_session_request_accept_new, Config) ->
 end_per_testcase(TestCase, Config)
   when TestCase == delete_bearer_request_resend;
        TestCase == modify_bearer_command_timeout ->
-    ok = meck:delete(ergw_gtp_c_socket, send_request, 7),
+    ok = meck:delete(ergw_gtp_c_socket, send_request, 8),
     end_per_testcase(Config),
     Config;
 end_per_testcase(create_session_overload, Config) ->


### PR DESCRIPTION
Both GTP v1 and v2 have similar definitions for UDP source port
of GTP requests:

> The UDP Source Port is a locally allocated port number at the sending GSN/RNC.

Doing so has advantages when the receiver is using RSSI, NAT gateways
need to map those requests and are helpful for outgoing proxies.