### PR TITLE
Add logic for delete contexts by criteria

### DIFF
--- a/priv/static/specs/http_api_spec.yaml
+++ b/priv/static/specs/http_api_spec.yaml
@@ -55,6 +55,25 @@ paths:
   /contexts:
     delete:
       summary: 'delete all contexts'
+      parameters:
+        - name: version
+          in: query
+          required: false
+          type: string
+          description: 'Version'
+          default: 'v1'
+        - name: imsi
+          in: query
+          required: false
+          type: integer
+          description: 'International Mobile Subscriber Identity'
+          default: '111111111111111'
+        - name: upf-fqdn
+          in: query
+          required: false
+          type: string
+          description: 'The UPF FQDN will be used as regex'
+          default: 'prox01.epc.mnc001.mcc001.3gppnetwork.org'
       responses:
         '200':
           description: return count of contexts


### PR DESCRIPTION
**Extend delete contexts REST API and API for delete contexts contexts by criteria:**   

-  `/api/v1/contexts?version=VERSION&imsi=IMSI&pfcp=PFCP`  

____
**REST API Example:** 

- `/api/v1/contexts?version=v1&imsi=111111111111111&upf-fqdn=prox01.epc.mnc001.mcc001.3gppnetwork.org`  
- `/api/v1/contexts?upf-fqdn=prox01.epc.mnc001.mcc001.3gppnetwork.org`  

____
**API Example:**   
```erlang
ergw_api:delete_contexts(#{
    version => v1,
    'upf-fqdn' => "prox01.epc.mnc001.mcc001.3gppnetwork.org", 
    imsi => <<"111111111111111">>
}).
```
**OR**
```erlang
ergw_api:delete_contexts(#{'upf-fqdn' => "prox01.epc.mnc001.mcc001.3gppnetwork.org"}).
```
____
Query parameters:
| Name   |      Type      |  Description |
|-----------|:---------------:|-----------------:|
| imsi                 | integer | IMSI |
| upf-fqdn          | string | UPF FQDN |
| version            | string | Version |