### PR TITLE
replace context key tupels with records

### DIFF
--- a/include/ergw.hrl
+++ b/include/ergw.hrl
@@ -172,3 +172,7 @@
 	  ip                        :: {inet:ip4_address(),1..32}|
 				       {inet:ip6_address(),1..128}
 	}).
+
+-record(seid_key, {seid}).
+-record(context_key, {socket, id}).
+-record(socket_teid_key, {name, type, teid}).

--- a/src/ergw.erl
+++ b/src/ergw.erl
@@ -27,6 +27,7 @@
 	 terminate/2, code_change/3]).
 
 -include_lib("kernel/include/logger.hrl").
+-include("include/ergw.hrl").
 
 -define(SERVER, ?MODULE).
 -record(state, {tid :: ets:tid()}).
@@ -208,7 +209,7 @@ i(memory, path) ->
 
 i(memory, context) ->
     MemUsage =
-	lists:foldl(fun({{seid, _}, {_, Pid}}, Mem) ->
+	lists:foldl(fun({#seid_key{}, {_, Pid}}, Mem) ->
 			    {memory, M} = erlang:process_info(Pid, memory),
 			    Mem + M;
 		       (_, Mem) ->

--- a/src/ergw_api.erl
+++ b/src/ergw_api.erl
@@ -14,6 +14,8 @@
 
 -ignore_xref([peer/1, tunnel/1, memory/1]).
 
+-include("include/ergw.hrl").
+
 %%%===================================================================
 %%% API
 %%%===================================================================
@@ -38,8 +40,8 @@ tunnel(Socket) when is_atom(Socket) ->
     lists:foldl(fun collext_path_contexts/2, [], gtp_path_reg:all(Socket)).
 
 contexts(all) ->
-    lists:usort([Pid || {{_Socket, {teid, 'gtp-c', _TEID}}, {_, Pid}}
-				       <- gtp_context_reg:all(), is_pid(Pid)]).
+    lists:usort([Pid || {#socket_teid_key{type = 'gtp-c'}, {_, Pid}}
+			    <- gtp_context_reg:all(), is_pid(Pid)]).
 
 delete_contexts(all) ->
     lists:foreach(fun(Context) ->

--- a/src/ergw_gtp_socket.erl
+++ b/src/ergw_gtp_socket.erl
@@ -166,10 +166,11 @@ make_seq_id(#gtp{version = Version, seq_no = SeqNo})
 make_seq_id(_) ->
     undefined.
 
-make_request(ArrivalTS, Src, IP, Port, Msg = #gtp{version = Version, type = Type}, Socket, Info) ->
+make_request(ArrivalTS, Src, IP, Port, Msg = #gtp{version = Version, type = Type},
+	     #socket{name = SocketName} = Socket, Info) ->
     SeqId = make_seq_id(Msg),
     #request{
-       key = {Socket, IP, Port, Type, SeqId},
+       key = {request, {SocketName, IP, Port, Type, SeqId}},
        socket = Socket,
        info = Info,
        src = Src,

--- a/src/ergw_pfcp.erl
+++ b/src/ergw_pfcp.erl
@@ -158,7 +158,7 @@ outer_header_removal(v6) ->
     #outer_header_removal{header = 'GTP-U/UDP/IPv6'}.
 
 ctx_teid_key(#pfcp_ctx{name = Name}, TEI) ->
-    {Name, {teid, 'gtp-u', TEI}}.
+    #socket_teid_key{name = Name, type = 'gtp-u', teid = TEI}.
 
 up_inactivity_timer(#pfcp_ctx{up_inactivity_timer = Timer})
   when is_integer(Timer) ->

--- a/src/ergw_pfcp_context.erl
+++ b/src/ergw_pfcp_context.erl
@@ -755,7 +755,7 @@ make_pctx_bearer_key(_, _, _, Keys) ->
     Keys.
 
 make_pctx_keys(Bearer, #pfcp_ctx{seid = #seid{cp = SEID}} = PCtx) ->
-    maps:fold(make_pctx_bearer_key(_, _, PCtx, _), [{seid, SEID}], Bearer).
+    maps:fold(make_pctx_bearer_key(_, _, PCtx, _), [#seid_key{seid = SEID}], Bearer).
 
 register_ctx_ids(Handler, Bearer, PCtx) ->
     Keys = make_pctx_keys(Bearer, PCtx),

--- a/src/ergw_sx_node.erl
+++ b/src/ergw_sx_node.erl
@@ -183,7 +183,7 @@ init([Parent, Node, NodeSelect, IP4, IP6, NotifyUp]) ->
 
     RegKeys =
 	[gtp_context:socket_teid_key(Socket, TEI),
-	 {seid, SEID}],
+	 #seid_key{seid = SEID}],
     gtp_context_reg:register(RegKeys, ?MODULE, self()),
 
     Nodes = setup:get_env(ergw, nodes, #{}),

--- a/src/gtp_context_reg.erl
+++ b/src/gtp_context_reg.erl
@@ -15,7 +15,6 @@
 -export([start_link/0]).
 -export([register/3, register_new/3, update/4, unregister/3,
 	 lookup/1, select/1,
-	 match_keys/2,
 	 await_unreg/1]).
 -export([all/0]).
 
@@ -49,19 +48,6 @@ lookup(Key) when is_tuple(Key) ->
 
 select(Key) ->
     ets:select(?SERVER, [{{Key, '$1'},[],['$1']}]).
-
-match_key(#socket{name = Name}, Key) ->
-    select({Name, Key}).
-
-match_keys(_, []) ->
-    throw({error, not_found});
-match_keys(Socket, [H|T]) ->
-    case match_key(Socket, H) of
-	[_|_] = Match ->
-	    Match;
-	_ ->
-	    match_keys(Socket, T)
-    end.
 
 register(Keys, Handler, Pid)
   when is_list(Keys), is_atom(Handler), is_pid(Pid) ->

--- a/src/gtp_v1_c.erl
+++ b/src/gtp_v1_c.erl
@@ -16,7 +16,7 @@
 	 build_echo_request/0,
 	 validate_teid/2,
 	 type/0, port/0,
-	 get_msg_keys/1, update_context_id/2,
+	 get_context_id/1, update_context_id/2,
 	 get_cause/1, get_common_flags/1,
 	 find_sender_teid/1,
 	 load_class/1]).
@@ -233,7 +233,7 @@ get_common_flags(IEs) ->
 get_ext_common_flags(IEs) ->
     get_element(?'Extended Common Flags', IEs, #extended_common_flags.flags, []).
 
-get_context_id(IEs) ->
+get_context_id(#gtp{version = v1, ie = IEs}) ->
     NSAPI = get_element(?'NSAPI', IEs, #nsapi.nsapi, '_'),
     UIMSI = proplists:get_bool('Unauthenticated IMSI', get_ext_common_flags(IEs)),
     %% order of key selection, first match terminates:
@@ -251,16 +251,8 @@ get_context_id(IEs) ->
 	    undefined
     end.
 
-get_msg_keys(#gtp{version = v1, ie = IEs}) ->
-    case get_context_id(IEs) of
-	undefined ->
-	    [];
-	Id ->
-	    [Id]
-    end.
-
-update_context_id(#gtp{version = v1, ie = IEs}, Context) ->
-    case get_context_id(IEs) of
+update_context_id(Msg, Context) ->
+    case get_context_id(Msg) of
 	{_, _, NSAPI} = Id when is_integer(NSAPI) ->
 	    Context#context{context_id = Id};
 	_ ->

--- a/src/gtp_v2_c.erl
+++ b/src/gtp_v2_c.erl
@@ -16,7 +16,7 @@
 	 build_echo_request/0,
 	 validate_teid/2,
 	 type/0, port/0,
-	 get_msg_keys/1, update_context_id/2,
+	 get_context_id/1, update_context_id/2,
 	 get_cause/1, get_indication_flags/1,
 	 find_sender_teid/1,
 	 load_class/1]).
@@ -258,7 +258,7 @@ get_context_ebi(#{?'Bearer Contexts' :=
 get_context_ebi(_) ->
     '_'.
 
-get_context_id(IEs) ->
+get_context_id(#gtp{version = v2, ie = IEs}) ->
     EBI = get_context_ebi(IEs),
     UIMSI = proplists:get_bool('UIMSI', get_indication_flags(IEs)),
     case {UIMSI, IEs} of
@@ -270,16 +270,8 @@ get_context_id(IEs) ->
 	    undefined
     end.
 
-get_msg_keys(#gtp{version = v2, ie = IEs}) ->
-    case get_context_id(IEs) of
-	undefined ->
-	    [];
-	Id ->
-	    [Id]
-    end.
-
-update_context_id(#gtp{version = v2, ie = IEs}, Context) ->
-    case get_context_id(IEs) of
+update_context_id(Msg, Context) ->
+    case get_context_id(Msg) of
 	{_, _, EBI} = Id when is_integer(EBI) ->
 	    Context#context{context_id = Id};
 	_Other ->

--- a/test/ergw_test_lib.erl
+++ b/test/ergw_test_lib.erl
@@ -43,6 +43,7 @@
 -export([init_ets/1]).
 
 -include("ergw_test_lib.hrl").
+-include_lib("stdlib/include/ms_transform.hrl").
 -include_lib("kernel/include/logger.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("gtplib/include/gtp_packet.hrl").
@@ -544,7 +545,8 @@ add_cfg_value([H | T], Value, Config) ->
 %%%===================================================================
 
 outstanding_requests() ->
-    ets:match_object(gtp_context_reg, {{'_', {'_', '_', '_', '_', '_'}}, '_'}).
+    Ms = ets:fun2ms(fun({Key, _} = Obj) when element(1, Key) == 'request' -> Obj end),
+    ets:select(gtp_context_reg, Ms).
 
 wait4tunnels(Cnt) ->
     case [X || X = #{tunnels := T} <- ergw_api:peer(all), T /= 0] of

--- a/test/ergw_test_sx_up.erl
+++ b/test/ergw_test_sx_up.erl
@@ -172,7 +172,8 @@ handle_call({send, Msg}, _From,
 	    #state{gtp = GtpSocket, cp_ip = IP, up_ip = UpIP} = State)
   when is_binary(Msg) ->
     {ok, SxPid} = ergw_sx_node_reg:lookup(ergw_inet:bin2ip(UpIP)),
-    [[SxTEI]] = ets:match(gtp_context_reg, {{'cp-socket',{teid,'gtp-u','$1'}},{'_',SxPid}}),
+    TEIDMatch = #socket_teid_key{name = 'cp-socket', type = 'gtp-u', teid = '$1', _ = '_'},
+    [[SxTEI]] = ets:match(gtp_context_reg, {TEIDMatch, {'_',SxPid}}),
     BinMsg = gtp_packet:encode(#gtp{version = v1, type = g_pdu, tei = SxTEI, ie = Msg}),
     ok = gen_udp:send(GtpSocket, IP, ?GTP1u_PORT, BinMsg),
     {reply, ok, State};

--- a/test/ggsn_SUITE.erl
+++ b/test/ggsn_SUITE.erl
@@ -973,9 +973,10 @@ path_failure() ->
     [{doc, "Check that Create PDP Context works and "
       "that a path failure (Echo timeout) terminates the session"}].
 path_failure(Config) ->
+    CtxKey = #context_key{socket = 'irx', id = {imsi, ?'IMSI', 5}},
     {GtpC, _, _} = create_pdp_context(Config),
 
-    {_Handler, CtxPid} = gtp_context_reg:lookup({'irx', {imsi, ?'IMSI', 5}}),
+    {_Handler, CtxPid} = gtp_context_reg:lookup(CtxKey),
     #{left_tunnel := #tunnel{socket = CSocket}} = gtp_context:info(CtxPid),
 
     ClientIP = proplists:get_value(client_ip, Config),
@@ -1414,10 +1415,11 @@ delete_pdp_context_requested() ->
     [{doc, "Check GGSN initiated Delete PDP Context"}].
 delete_pdp_context_requested(Config) ->
     Cntl = whereis(gtpc_client_server),
+    CtxKey = #context_key{socket = 'irx', id = {imsi, ?'IMSI', 5}},
 
     {GtpC, _, _} = create_pdp_context(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
 
     Self = self(),
@@ -1449,10 +1451,11 @@ delete_pdp_context_requested_resend() ->
     [{doc, "Check resend of GGSN initiated Delete PDP Context"}].
 delete_pdp_context_requested_resend(Config) ->
     Cntl = whereis(gtpc_client_server),
+    CtxKey = #context_key{socket = 'irx', id = {imsi, ?'IMSI', 5}},
 
     {_, _, _} = create_pdp_context(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
 
     Self = self(),
@@ -1717,6 +1720,7 @@ gy_validity_timer(Config) ->
 simple_aaa() ->
     [{doc, "Check simple session with RADIOS/DIAMETER over (S)Gi"}].
 simple_aaa(Config) ->
+    CtxKey = #context_key{socket = 'irx', id = {imsi, ?'IMSI', 5}},
     Interim = rand:uniform(1800) + 1800,
     AAAReply = #{'Acct-Interim-Interval' => Interim},
 
@@ -1733,7 +1737,7 @@ simple_aaa(Config) ->
 
     {GtpC, _, _} = create_pdp_context(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
     {ok, PCtx} = gtp_context:test_cmd(Server, pfcp_ctx),
 
@@ -1826,6 +1830,7 @@ simple_aaa(Config) ->
 simple_ofcs() ->
     [{doc, "Check simple session with DIAMETER Rf"}].
 simple_ofcs(Config) ->
+    CtxKey = #context_key{socket = 'irx', id = {imsi, ?'IMSI', 5}},
     Interim = rand:uniform(1800) + 1800,
     AAAReply = #{'Acct-Interim-Interval' => [Interim]},
 
@@ -1842,7 +1847,7 @@ simple_ofcs(Config) ->
 
     {GtpC, _, _} = create_pdp_context(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
     {ok, PCtx} = gtp_context:test_cmd(Server, pfcp_ctx),
 
@@ -1975,9 +1980,10 @@ simple_ofcs(Config) ->
 simple_ocs() ->
     [{doc, "Test Gy a simple interaction"}].
 simple_ocs(Config) ->
+    CtxKey = #context_key{socket = 'irx', id = {imsi, ?'IMSI', 5}},
     {GtpC, _, _} = create_pdp_context(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
     {ok, PCtx} = gtp_context:test_cmd(Server, pfcp_ctx),
 
@@ -2164,10 +2170,11 @@ gy_ccr_asr_overlap() ->
     [{doc, "Test that ASR is answered when it arrives during CCR-T"}].
 gy_ccr_asr_overlap(Config) ->
     Cntl = whereis(gtpc_client_server),
+    CtxKey = #context_key{socket = 'irx', id = {imsi, ?'IMSI', 5}},
 
     {GtpC, _, _} = create_pdp_context(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
 
     #{'Session' := Session} = gtp_context:info(Server),
@@ -2296,9 +2303,10 @@ volume_threshold(Config) ->
 gx_rar_gy_interaction() ->
     [{doc, "Check that a Gx RAR triggers a Gy request"}].
 gx_rar_gy_interaction(Config) ->
+    CtxKey = #context_key{socket = 'irx', id = {imsi, ?'IMSI', 5}},
     {GtpC, _, _} = create_pdp_context(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
 
     {ok, Session} = gtp_context:test_cmd(Server, session),
@@ -2356,10 +2364,11 @@ gx_asr() ->
     [{doc, "Check that ASR on Gx terminates the session"}].
 gx_asr(Config) ->
     Cntl = whereis(gtpc_client_server),
+    CtxKey = #context_key{socket = 'irx', id = {imsi, ?'IMSI', 5}},
 
     {GtpC, _, _} = create_pdp_context(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
 
     ResponseFun = fun(_, _, _, _) -> ok end,
@@ -2382,9 +2391,10 @@ gx_asr(Config) ->
 gx_rar() ->
     [{doc, "Check that RAR on Gx changes the session"}].
 gx_rar(Config) ->
+    CtxKey = #context_key{socket = 'irx', id = {imsi, ?'IMSI', 5}},
     {GtpC, _, _} = create_pdp_context(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
 
     #{'Session' := Session} = gtp_context:info(Server),
@@ -2491,10 +2501,11 @@ gy_asr() ->
     [{doc, "Check that ASR on Gy terminates the session"}].
 gy_asr(Config) ->
     Cntl = whereis(gtpc_client_server),
+    CtxKey = #context_key{socket = 'irx', id = {imsi, ?'IMSI', 5}},
 
     {GtpC, _, _} = create_pdp_context(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
 
     ResponseFun = fun(_, _, _, _) -> ok end,
@@ -2627,6 +2638,7 @@ gtp_idle_timeout(Config) ->
 up_inactivity_timer() ->
     [{doc, "Test expiry of the User Plane Inactivity Timer"}].
 up_inactivity_timer(Config) ->
+    CtxKey = #context_key{socket = 'irx', id = {imsi, ?'IMSI', 5}},
     Interim = rand:uniform(1800) + 1800,
     AAAReply = #{'Acct-Interim-Interval' => Interim},
 
@@ -2644,7 +2656,8 @@ up_inactivity_timer(Config) ->
 	   end),
 
     create_pdp_context(Config),
-    {_Handler, Server} = gtp_context_reg:lookup({'irx', {imsi, ?'IMSI', 5}}),
+
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
     {ok, PCtx} = gtp_context:test_cmd(Server, pfcp_ctx),
     [SER|_] = lists:filter(

--- a/test/pgw_SUITE.erl
+++ b/test/pgw_SUITE.erl
@@ -1247,9 +1247,11 @@ path_failure() ->
     [{doc, "Check that Create Session Request works and "
       "that a path failure (Echo timeout) terminates the session"}].
 path_failure(Config) ->
+    CtxKey = #context_key{socket = 'irx-socket', id = {imsi, ?'IMSI', 5}},
+
     {GtpC, _, _} = create_session(Config),
 
-    {_Handler, CtxPid} = gtp_context_reg:lookup({'irx-socket', {imsi, ?'IMSI', 5}}),
+    {_Handler, CtxPid} = gtp_context_reg:lookup(CtxKey),
     #{left_tunnel := #tunnel{socket = CSocket}} = gtp_context:info(CtxPid),
 
     ClientIP = proplists:get_value(client_ip, Config),
@@ -2162,10 +2164,11 @@ delete_bearer_request() ->
      {timetrap,{seconds,60}}].
 delete_bearer_request(Config) ->
     Cntl = whereis(gtpc_client_server),
+    CtxKey = #context_key{socket = 'irx-socket', id = {imsi, ?'IMSI', 5}},
 
     {GtpC, _, _} = create_session(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx-socket', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
 
     Self = self(),
@@ -2240,10 +2243,11 @@ delete_bearer_request_resend() ->
      {timetrap,{seconds,60}}].
 delete_bearer_request_resend(Config) ->
     Cntl = whereis(gtpc_client_server),
+    CtxKey = #context_key{socket = 'irx-socket', id = {imsi, ?'IMSI', 5}},
 
     {_, _, _} = create_session(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx-socket', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
 
     Self = self(),
@@ -2824,6 +2828,7 @@ gy_validity_timer(Config) ->
 simple_aaa() ->
     [{doc, "Check simple session with RADIOS/DIAMETER over (S)Gi"}].
 simple_aaa(Config) ->
+    CtxKey = #context_key{socket = 'irx-socket', id = {imsi, ?'IMSI', 5}},
     Interim = rand:uniform(1800) + 1800,
     AAAReply = #{'Acct-Interim-Interval' => Interim},
 
@@ -2840,7 +2845,7 @@ simple_aaa(Config) ->
 
     {GtpC, _, _} = create_session(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx-socket', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
     {ok, PCtx} = gtp_context:test_cmd(Server, pfcp_ctx),
 
@@ -2935,6 +2940,7 @@ simple_aaa(Config) ->
 simple_ofcs() ->
     [{doc, "Check simple session with DIAMETER Rf"}].
 simple_ofcs(Config) ->
+    CtxKey = #context_key{socket = 'irx-socket', id = {imsi, ?'IMSI', 5}},
     Interim = rand:uniform(1800) + 1800,
     AAAReply = #{'Acct-Interim-Interval' => [Interim]},
 
@@ -2951,7 +2957,7 @@ simple_ofcs(Config) ->
 
     {GtpC, _, _} = create_session(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx-socket', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
     {ok, PCtx} = gtp_context:test_cmd(Server, pfcp_ctx),
 
@@ -3086,6 +3092,7 @@ simple_ofcs(Config) ->
 ofcs_no_interim() ->
     [{doc, "Check that OFCS reporting also works without Acct-Interim-Interval"}].
 ofcs_no_interim(Config) ->
+    CtxKey = #context_key{socket = 'irx-socket', id = {imsi, ?'IMSI', 5}},
     AAAReply = #{},
 
     ok = meck:expect(ergw_aaa_session, invoke,
@@ -3101,7 +3108,7 @@ ofcs_no_interim(Config) ->
 
     {GtpC, _, _} = create_session(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx-socket', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
     {ok, _} = gtp_context:test_cmd(Server, pfcp_ctx),
 
@@ -3252,9 +3259,11 @@ secondary_rat_usage_data_report(Config) ->
 simple_ocs() ->
     [{doc, "Test Gy a simple interaction"}].
 simple_ocs(Config) ->
+    CtxKey = #context_key{socket = 'irx-socket', id = {imsi, ?'IMSI', 5}},
+
     {GtpC, _, _} = create_session(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx-socket', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
     {ok, PCtx} = gtp_context:test_cmd(Server, pfcp_ctx),
 
@@ -3439,6 +3448,7 @@ split_charging1() ->
     [{doc, "Used different Rating-Groups for Online and Offline charging, "
       "without catch all PCC rules/RG"}].
 split_charging1(Config) ->
+    CtxKey = #context_key{socket = 'irx-socket', id = {imsi, ?'IMSI', 5}},
     Interim = rand:uniform(1800) + 1800,
     AAAReply = #{'Acct-Interim-Interval' => [Interim]},
 
@@ -3455,7 +3465,7 @@ split_charging1(Config) ->
 
     {GtpC, _, _} = create_session(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx-socket', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
     {ok, PCtx} = gtp_context:test_cmd(Server, pfcp_ctx),
 
@@ -3755,6 +3765,7 @@ split_charging2() ->
     [{doc, "Used different Rating-Groups for Online and Offline charging, "
       "with catch all PCC rules/RG"}].
 split_charging2(Config) ->
+    CtxKey = #context_key{socket = 'irx-socket', id = {imsi, ?'IMSI', 5}},
     Interim = rand:uniform(1800) + 1800,
     AAAReply = #{'Acct-Interim-Interval' => [Interim]},
 
@@ -3771,7 +3782,7 @@ split_charging2(Config) ->
 
     {GtpC, _, _} = create_session(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx-socket', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
     {ok, PCtx} = gtp_context:test_cmd(Server, pfcp_ctx),
 
@@ -4157,6 +4168,7 @@ aa_pool_select_fail(Config) ->
 tariff_time_change() ->
     [{doc, "Check Rf and Gy action on Tariff-Time-Change"}].
 tariff_time_change(Config) ->
+    CtxKey = #context_key{socket = 'irx-socket', id = {imsi, ?'IMSI', 5}},
     Interim = rand:uniform(1800) + 1800,
     AAAReply = #{'Acct-Interim-Interval' => [Interim]},
 
@@ -4179,7 +4191,7 @@ tariff_time_change(Config) ->
 
     {GtpC, _, _} = create_session(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx-socket', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
     {ok, PCtx} = gtp_context:test_cmd(Server, pfcp_ctx),
 
@@ -4401,10 +4413,11 @@ gy_ccr_asr_overlap() ->
     [{doc, "Test that ASR is answered when it arrives during CCR-T"}].
 gy_ccr_asr_overlap(Config) ->
     Cntl = whereis(gtpc_client_server),
+    CtxKey = #context_key{socket = 'irx-socket', id = {imsi, ?'IMSI', 5}},
 
     {GtpC, _, _} = create_session(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx-socket', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
 
     #{'Session' := Session} = gtp_context:info(Server),
@@ -4535,9 +4548,11 @@ volume_threshold(Config) ->
 gx_rar_gy_interaction() ->
     [{doc, "Check that a Gx RAR triggers a Gy request"}].
 gx_rar_gy_interaction(Config) ->
+    CtxKey = #context_key{socket = 'irx-socket', id = {imsi, ?'IMSI', 5}},
+
     {GtpC, _, _} = create_session(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx-socket', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
 
     {ok, Session} = gtp_context:test_cmd(Server, session),
@@ -4730,10 +4745,11 @@ gx_asr() ->
     [{doc, "Check that ASR on Gx terminates the session"}].
 gx_asr(Config) ->
     Cntl = whereis(gtpc_client_server),
+    CtxKey = #context_key{socket = 'irx-socket', id = {imsi, ?'IMSI', 5}},
 
     {GtpC, _, _} = create_session(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx-socket', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
 
     ResponseFun = fun(_, _, _, _) -> ok end,
@@ -4756,9 +4772,11 @@ gx_asr(Config) ->
 gx_rar() ->
     [{doc, "Check that RAR on Gx changes the session"}].
 gx_rar(Config) ->
+    CtxKey = #context_key{socket = 'irx-socket', id = {imsi, ?'IMSI', 5}},
+
     {GtpC, _, _} = create_session(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx-socket', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
 
     #{'Session' := Session} = gtp_context:info(Server),
@@ -4883,10 +4901,11 @@ gy_asr() ->
     [{doc, "Check that ASR on Gy terminates the session"}].
 gy_asr(Config) ->
     Cntl = whereis(gtpc_client_server),
+    CtxKey = #context_key{socket = 'irx-socket', id = {imsi, ?'IMSI', 5}},
 
     {GtpC, _, _} = create_session(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx-socket', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
 
     ResponseFun = fun(_, _, _, _) -> ok end,
@@ -5174,6 +5193,7 @@ gtp_idle_timeout(Config) ->
 up_inactivity_timer() ->
     [{doc, "Test expiry of the User Plane Inactivity Timer"}].
 up_inactivity_timer(Config) ->
+    CtxKey = #context_key{socket = 'irx-socket', id = {imsi, ?'IMSI', 5}},
     Interim = rand:uniform(1800) + 1800,
     AAAReply = #{'Acct-Interim-Interval' => Interim},
 
@@ -5191,7 +5211,8 @@ up_inactivity_timer(Config) ->
 	   end),
 
     create_session(Config),
-    {_Handler, Server} = gtp_context_reg:lookup({'irx-socket', {imsi, ?'IMSI', 5}}),
+
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
     {ok, PCtx} = gtp_context:test_cmd(Server, pfcp_ctx),
     [SER|_] = lists:filter(

--- a/test/saegw_s11_SUITE.erl
+++ b/test/saegw_s11_SUITE.erl
@@ -999,10 +999,11 @@ delete_bearer_request() ->
      {timetrap,{seconds,60}}].
 delete_bearer_request(Config) ->
     Cntl = whereis(gtpc_client_server),
+    CtxKey = #context_key{socket = 'irx', id = {imsi, ?'IMSI', 5}},
 
     {GtpC, _, _} = create_session(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({irx, {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
 
     Self = self(),
@@ -1034,10 +1035,11 @@ delete_bearer_request_resend() ->
      {timetrap,{seconds,60}}].
 delete_bearer_request_resend(Config) ->
     Cntl = whereis(gtpc_client_server),
+    CtxKey = #context_key{socket = 'irx', id = {imsi, ?'IMSI', 5}},
 
     {_, _, _} = create_session(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({irx, {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
 
     Self = self(),
@@ -1238,6 +1240,7 @@ gy_validity_timer(Config) ->
 simple_aaa() ->
     [{doc, "Check simple session with RADIOS/DIAMETER over (S)Gi"}].
 simple_aaa(Config) ->
+    CtxKey = #context_key{socket = 'irx', id = {imsi, ?'IMSI', 5}},
     Interim = rand:uniform(1800) + 1800,
     AAAReply = #{'Acct-Interim-Interval' => Interim},
 
@@ -1255,7 +1258,7 @@ simple_aaa(Config) ->
 
     {GtpC, _, _} = create_session(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
     {ok, PCtx} = gtp_context:test_cmd(Server, pfcp_ctx),
 
@@ -1346,6 +1349,7 @@ simple_aaa(Config) ->
 simple_ofcs() ->
     [{doc, "Check simple session with DIAMETER Rf"}].
 simple_ofcs(Config) ->
+    CtxKey = #context_key{socket = 'irx', id = {imsi, ?'IMSI', 5}},
     Interim = rand:uniform(1800) + 1800,
     AAAReply = #{'Acct-Interim-Interval' => [Interim]},
 
@@ -1362,7 +1366,7 @@ simple_ofcs(Config) ->
 
     {GtpC, _, _} = create_session(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
     {ok, PCtx} = gtp_context:test_cmd(Server, pfcp_ctx),
 
@@ -1494,9 +1498,11 @@ simple_ofcs(Config) ->
 simple_ocs() ->
     [{doc, "Test Gy a simple interaction"}].
 simple_ocs(Config) ->
+    CtxKey = #context_key{socket = 'irx', id = {imsi, ?'IMSI', 5}},
+
     {GtpC, _, _} = create_session(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
     {ok, PCtx} = gtp_context:test_cmd(Server, pfcp_ctx),
 
@@ -1680,10 +1686,11 @@ gy_ccr_asr_overlap() ->
     [{doc, "Test that ASR is answered when it arrives during CCR-T"}].
 gy_ccr_asr_overlap(Config) ->
     Cntl = whereis(gtpc_client_server),
+    CtxKey = #context_key{socket = 'irx', id = {imsi, ?'IMSI', 5}},
 
     {GtpC, _, _} = create_session(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
 
     #{'Session' := Session} = gtp_context:info(Server),
@@ -1810,9 +1817,11 @@ volume_threshold(Config) ->
 gx_rar_gy_interaction() ->
     [{doc, "Check that a Gx RAR triggers a Gy request"}].
 gx_rar_gy_interaction(Config) ->
+    CtxKey = #context_key{socket = 'irx', id = {imsi, ?'IMSI', 5}},
+
     {GtpC, _, _} = create_session(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
 
     {ok, Session} = gtp_context:test_cmd(Server, session),
@@ -1868,10 +1877,11 @@ gx_asr() ->
     [{doc, "Check that ASR on Gx terminates the session"}].
 gx_asr(Config) ->
     Cntl = whereis(gtpc_client_server),
+    CtxKey = #context_key{socket = 'irx', id = {imsi, ?'IMSI', 5}},
 
     {GtpC, _, _} = create_session(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
 
     ResponseFun = fun(_, _, _, _) -> ok end,
@@ -1892,10 +1902,12 @@ gx_asr(Config) ->
 gx_rar() ->
     [{doc, "Check that RAR on Gx changes the session"}].
 gx_rar(Config) ->
+    CtxKey = #context_key{socket = 'irx', id = {imsi, ?'IMSI', 5}},
+
     {GtpC1, _, _} = create_session(Config),
     {GtpC2, _, _} = modify_bearer(enb_u_tei, GtpC1),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
 
     #{'Session' := Session} = gtp_context:info(Server),
@@ -2000,10 +2012,11 @@ gy_asr() ->
     [{doc, "Check that ASR on Gy terminates the session"}].
 gy_asr(Config) ->
     Cntl = whereis(gtpc_client_server),
+    CtxKey = #context_key{socket = 'irx', id = {imsi, ?'IMSI', 5}},
 
     {GtpC, _, _} = create_session(Config),
 
-    {_Handler, Server} = gtp_context_reg:lookup({'irx', {imsi, ?'IMSI', 5}}),
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
 
     ResponseFun = fun(_, _, _, _) -> ok end,
@@ -2126,6 +2139,7 @@ gtp_idle_timeout(Config) ->
 up_inactivity_timer() ->
     [{doc, "Test expiry of the User Plane Inactivity Timer"}].
 up_inactivity_timer(Config) ->
+    CtxKey = #context_key{socket = 'irx', id = {imsi, ?'IMSI', 5}},
     Interim = rand:uniform(1800) + 1800,
     AAAReply = #{'Acct-Interim-Interval' => Interim},
 
@@ -2143,7 +2157,8 @@ up_inactivity_timer(Config) ->
 	   end),
 
     create_session(Config),
-    {_Handler, Server} = gtp_context_reg:lookup({'irx', {imsi, ?'IMSI', 5}}),
+
+    {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
     {ok, PCtx} = gtp_context:test_cmd(Server, pfcp_ctx),
     [SER|_] = lists:filter(

--- a/test/tdf_SUITE.erl
+++ b/test/tdf_SUITE.erl
@@ -1829,15 +1829,16 @@ tdf_app_id(Config) ->
 %%%===================================================================
 
 tdf_node_pid() ->
-    [[Pid]] = ets:match(gtp_context_reg, {{'cp-socket',{teid,'gtp-u','_'}},{ergw_sx_node, '$1'}}),
+    TEIDMatch = #socket_teid_key{name = 'cp-socket', type = 'gtp-u', _ = '_'},
+    [[Pid]] = ets:match(gtp_context_reg, {TEIDMatch, {ergw_sx_node, '$1'}}),
     Pid.
 
 tdf_seid() ->
-    [[SEID]] = ets:match(gtp_context_reg, {{seid, '$1'},{ergw_sx_node, '_'}}),
+    [[SEID]] = ets:match(gtp_context_reg, {#seid_key{seid = '$1'}, {ergw_sx_node, '_'}}),
     SEID.
 
 tdf_session_pid() ->
-    [[SEID]] = ets:match(gtp_context_reg, {{seid, '_'},{tdf, '$1'}}),
+    [[SEID]] = ets:match(gtp_context_reg, {#seid_key{_ = '_'}, {tdf, '$1'}}),
     SEID.
 
 ue_ip_address(Type, Config) ->


### PR DESCRIPTION
Instead of having to count fields in tuples, records allow us to
specify matches with the more readable record syntax.
They also give us `tagged keys`, that means we can deduce the type
of the key from the record tag.

This was originally part of the stateless work, but will also be
helpful for the cluster registry.