### PR TITLE
Add logic for get TEIDs of contexts by IMSI

### DIFF
--- a/priv/static/specs/http_api_spec.yaml
+++ b/priv/static/specs/http_api_spec.yaml
@@ -53,6 +53,20 @@ paths:
         '200':
           description: returns the metrics
   /contexts:
+    get:
+      summary: 'get TEIDs of contexts by IMSI'
+      parameters:
+        - name: imsi
+          in: query
+          required: true
+          type: integer
+          default: 111111111111111
+          description: 'list of related TEIDs'
+      responses:
+        '200':
+          description: return list of TEIDs
+          schema:
+            $ref: '#/definitions/GetContextsTeids'
     delete:
       summary: 'delete all contexts'
       responses:
@@ -93,6 +107,14 @@ definitions:
       contexts:
         type: "integer"
         default: 0
+  GetContextsTeids:
+    type: "object"
+    properties:
+      teids:
+        type: "array"
+        items:
+          type: integer
+          default: 3416802480
   PLMN:
     type: "object"
     properties:

--- a/src/http_api_handler.erl
+++ b/src/http_api_handler.erl
@@ -91,6 +91,12 @@ handle_request(<<"POST">>, _, json, Req, State) ->
             {true, Req2, State}
     end;
 
+handle_request(<<"GET">>, <<"/api/v1/contexts">>, json, Req, State) ->
+    Qs = cowboy_req:parse_qs(Req),
+    TEIDs = ergw_api:get_teids(#{imsi => proplists:get_value(<<"imsi">>, Qs, <<>>)}),
+    Response = jsx:encode(#{teids => TEIDs}),
+    {Response, Req, State};
+
 handle_request(<<"DELETE">>, <<"/api/v1/contexts">>, json, Req, State) ->
     ok = ergw_api:delete_contexts(all),
     Response = jsx:encode(#{contexts => length(ergw_api:contexts(all))}),


### PR DESCRIPTION
**Added GET method for contexts REST API and add new API for get TEIDs of contexts by IMSI:**   

-  `/api/v1/contexts?imsi=IMSI`
  
____
**REST API Request Example:** 

- `/api/v1/contexts?imsi=111111111111111`  

____
**REST API Response Example:** 

```json
{
  "teids": [3416802480, 1708401240]
}
```

____
**API Example:**   
```erlang
ergw_api:get_teids(#{
    imsi => <<"111111111111111">>
}).
```
____
Query parameters:
| Name   |      Type      |  Description |
|-----------|:---------------:|-----------------:|
| imsi                 | integer | IMSI |