### PR TITLE
change socket config split_sockets to send_port

### DIFF
--- a/src/ergw_gtp_c_socket.erl
+++ b/src/ergw_gtp_c_socket.erl
@@ -140,14 +140,14 @@ call(#socket{pid = Handler}, Request) ->
 %%%===================================================================
 
 init(#{name := Name, ip := IP, burst_size := BurstSize,
-       split_sockets := SplitSockets} = SocketOpts) ->
+       send_port := SendPort} = SocketOpts) ->
     process_flag(trap_exit, true),
 
     {ok, RecvSocket} = ergw_gtp_socket:make_gtp_socket(IP, ?GTP1c_PORT, SocketOpts),
     SendSocket =
-	case SplitSockets of
-	    true ->
-		{ok, SndSocket} = ergw_gtp_socket:make_gtp_socket(IP, 0, SocketOpts),
+	case SendPort of
+	    _ when is_integer(SendPort) ->
+		{ok, SndSocket} = ergw_gtp_socket:make_gtp_socket(IP, SendPort, SocketOpts),
 		self() ! {'$socket', SndSocket, select, undefined},
 		SndSocket;
 	    false ->

--- a/src/ergw_gtp_socket.erl
+++ b/src/ergw_gtp_socket.erl
@@ -47,7 +47,7 @@ send(Socket, Src, IP, Port, Data) ->
 %%% Options Validation
 %%%===================================================================
 
--define(SocketDefaults, [{ip, invalid}, {burst_size, 10}, {split_sockets, true}]).
+-define(SocketDefaults, [{ip, invalid}, {burst_size, 10}, {send_port, true}]).
 
 validate_options(Name, Values) ->
     ergw_config:validate_options(fun validate_option/2, Values,
@@ -77,8 +77,14 @@ validate_option(freebind, Value) when is_boolean(Value) ->
     Value;
 validate_option(reuseaddr, Value) when is_boolean(Value) ->
     Value;
-validate_option(split_sockets, Value) when is_boolean(Value) ->
-    Value;
+validate_option(send_port, Port)
+  when is_integer(Port) andalso
+       (Port =:= 0 orelse (Port >= 1024 andalso Port < 65536)) ->
+    Port;
+validate_option(send_port, true) ->
+    0;
+validate_option(send_port, false) ->
+    false;
 validate_option(rcvbuf, Value)
   when is_integer(Value) andalso Value > 0 ->
     Value;

--- a/test/config_SUITE.erl
+++ b/test/config_SUITE.erl
@@ -614,6 +614,13 @@ config(_Config)  ->
     ?error_option(set_cfg_value([sockets, irx, invalid], true, ?GGSN_CONFIG)),
     ?error_option(set_cfg_value([sockets, irx], invalid, ?GGSN_CONFIG)),
     ?error_option(add_cfg_value([sockets, irx], [], ?GGSN_CONFIG)),
+    ?ok_option(set_cfg_value([sockets, irx, send_port], true, ?GGSN_CONFIG)),
+    ?ok_option(set_cfg_value([sockets, irx, send_port], false, ?GGSN_CONFIG)),
+    ?ok_option(set_cfg_value([sockets, irx, send_port], 0, ?GGSN_CONFIG)),
+    ?ok_option(set_cfg_value([sockets, irx, send_port], 12345, ?GGSN_CONFIG)),
+    ?error_option(set_cfg_value([sockets, irx, send_port], -1, ?GGSN_CONFIG)),
+    ?error_option(set_cfg_value([sockets, irx, send_port], 22, ?GGSN_CONFIG)),
+    ?error_option(set_cfg_value([sockets, irx, send_port], invalid, ?GGSN_CONFIG)),
 
     ?ok_option(add_cfg_value([sockets, irx, vrf], 'irx', ?GGSN_CONFIG)),
     ?ok_option(add_cfg_value([sockets, irx, vrf], "irx", ?GGSN_CONFIG)),

--- a/test/pgw_SUITE.erl
+++ b/test/pgw_SUITE.erl
@@ -563,7 +563,7 @@ init_per_group(sx_fail, Config) ->
     lib_init_per_suite([{upf, false} | Config]);
 init_per_group(single_socket, Config0) ->
     AppCfg0 = proplists:get_value(app_cfg, Config0),
-    AppCfg = set_cfg_value([ergw, sockets, 'irx-socket', split_sockets], false, AppCfg0),
+    AppCfg = set_cfg_value([ergw, sockets, 'irx-socket', send_port], false, AppCfg0),
     Config = lists:keystore(app_cfg, 1, Config0, {app_cfg, AppCfg}),
     lib_init_per_suite(Config);
 init_per_group(ipv6, Config) ->


### PR DESCRIPTION
The option can now be used to either select a random port (true or 0),
not seperate port (false) or a specific port (1024-65535) for sending