### PR TITLE
Shuffle the config loading to make it available earlier

### DIFF
--- a/src/ergw_app.erl
+++ b/src/ergw_app.erl
@@ -21,11 +21,11 @@
 
 start(_StartType, _StartArgs) ->
     do([error_m ||
-	   gtp_config:init(),
+	   Config <- ergw_config:load(),
 	   ergw_prometheus:declare(),
 	   ensure_jobs_queues(),
-	   Pid <- ergw_sup:start_link(),
-	   ergw_config:load_config(setup:get_all_env(ergw)),
+	   Pid <- ergw_sup:start_link(Config),
+	   ergw_config:apply(Config),
 	   return(Pid)
        ]).
 

--- a/src/ergw_sup.erl
+++ b/src/ergw_sup.erl
@@ -10,7 +10,7 @@
 -behaviour(supervisor).
 
 %% API
--export([start_link/0]).
+-export([start_link/1]).
 
 %% Supervisor callbacks
 -export([init/1]).
@@ -22,14 +22,14 @@
 %% API functions
 %% ===================================================================
 
-start_link() ->
-    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+start_link(Config) ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, [Config]).
 
 %% ===================================================================
 %% Supervisor callbacks
 %% ===================================================================
 
-init([]) ->
+init([Config]) ->
     ok = ergw_node_selection_cache:init(),
     {ok, {{one_for_one, 5, 10}, [?CHILD(gtp_path_reg, worker, []),
 				 ?CHILD(ergw_tei_mngr, worker, []),
@@ -44,5 +44,5 @@ init([]) ->
 				 ?CHILD(ergw_sx_node_mngr, worker, []),
 				 ?CHILD(gtp_proxy_ds, worker, []),
 				 ?CHILD(ergw_ip_pool_sup, supervisor, []),
-				 ?CHILD(ergw, worker, [])
+				 ?CHILD(ergw, worker, [Config])
 				]} }.

--- a/test/gtp_proxy_ds_SUITE.erl
+++ b/test/gtp_proxy_ds_SUITE.erl
@@ -25,9 +25,16 @@ init_per_suite(Config) ->
 	       {[<<"apn2">>], [<<"example2">>, <<"com">>]}
 	      ]}
     ],
-    {ok, Pid} = gen_server:start(ergw, [], []),
-    ergw:load_config([{plmn_id, {<<"001">>, <<"01">>}},
-		      {proxy_map, ProxyMap}]),
+    Cfg = [{plmn_id, {<<"001">>, <<"01">>}},
+        {proxy_map, ProxyMap},
+        {sockets, []},
+        {handlers, []},
+        {ip_pools, #{}},
+        {nodes, #{}}
+    ],
+    application:load(ergw),
+    [application:set_env(ergw, K, V) || {K, V} <- Cfg],
+    {ok, Pid} = gen_server:start(ergw, [Cfg], []),
     gen_server:start({local, gtp_proxy_ds_test}, gtp_proxy_ds, [], []),
     [{ergw, Pid}|Config].
 


### PR DESCRIPTION
Our configuration loading and checking always had problems
with when to load and apply what. This reshuffle the part
to separate configuration validation and the actual application
of the handler and socket config.