### PR TITLE
return proper sender TEID when rejecting new sessions

### DIFF
--- a/src/gtp_v1_c.erl
+++ b/src/gtp_v1_c.erl
@@ -277,6 +277,10 @@ load_class(#gtp{type = g_pdu}) ->
 load_class(_) ->
     other.
 
+find_sender_teid(#gtp{
+		    ie = #{{tunnel_endpoint_identifier_control_plane,0} :=
+			       #tunnel_endpoint_identifier_control_plane{tei = TEID}}}) ->
+    TEID;
 find_sender_teid(_) ->
     undefined.
 

--- a/test/ergw_ggsn_test_lib.erl
+++ b/test/ergw_ggsn_test_lib.erl
@@ -469,8 +469,16 @@ validate_response(create_pdp_context_request, overload, Response, GtpC) ->
     validate_seq_no(Response, GtpC),
 
     %% this is debatable, but decoding the request would require even more resources.
-    %% validate_teid(Response, GtpC),
     validate_teid(Response, 0),
+
+    ?match(#gtp{type = create_pdp_context_response,
+		ie = #{{cause,0} := #cause{value = no_resources_available}}},
+	   Response),
+    GtpC;
+
+validate_response(create_pdp_context_request, reject_new, Response, GtpC) ->
+    validate_seq_no(Response, GtpC),
+    validate_teid(Response, GtpC),
 
     ?match(#gtp{type = create_pdp_context_response,
 		ie = #{{cause,0} := #cause{value = no_resources_available}}},

--- a/test/ergw_saegw_test_lib.erl
+++ b/test/ergw_saegw_test_lib.erl
@@ -491,6 +491,15 @@ validate_response(create_session_request, overload, Response, GtpC) ->
 	  Response),
     GtpC;
 
+validate_response(create_session_request, reject_new, Response, GtpC) ->
+    validate_seq_no(Response, GtpC),
+    validate_teid(Response, GtpC),
+
+   ?match(#gtp{type = create_session_response,
+		ie = #{{v2_cause,0} := #v2_cause{v2_cause = no_resources_available}}},
+	  Response),
+    GtpC;
+
 validate_response(create_session_request, invalid_apn, Response, GtpC) ->
     validate_seq_no(Response, GtpC),
     validate_teid(Response, GtpC),

--- a/test/ggsn_SUITE.erl
+++ b/test/ggsn_SUITE.erl
@@ -894,7 +894,7 @@ create_pdp_context_request_accept_new() ->
     [{doc, "Check the accept_new = false can block new contexts"}].
 create_pdp_context_request_accept_new(Config) ->
     ?equal(ergw:system_info(accept_new, false), true),
-    create_pdp_context(overload, Config),
+    create_pdp_context(reject_new, Config),
     ?equal(ergw:system_info(accept_new, true), false),
 
     ?equal([], outstanding_requests()),

--- a/test/ggsn_SUITE.erl
+++ b/test/ggsn_SUITE.erl
@@ -993,7 +993,7 @@ path_failure(Config) ->
     CtxKey = #context_key{socket = 'irx', id = {imsi, ?'IMSI', 5}},
     {GtpC, _, _} = create_pdp_context(Config),
 
-    {_Handler, CtxPid} = gtp_context_reg:lookup(CtxKey),
+    {_, CtxPid} = gtp_context_reg:lookup(CtxKey),
     #{left_tunnel := #tunnel{socket = CSocket}} = gtp_context:info(CtxPid),
 
     ClientIP = proplists:get_value(client_ip, Config),

--- a/test/ggsn_proxy_SUITE.erl
+++ b/test/ggsn_proxy_SUITE.erl
@@ -925,7 +925,7 @@ create_pdp_context_request_accept_new() ->
     [{doc, "Check the accept_new = false can block new connections"}].
 create_pdp_context_request_accept_new(Config) ->
     ?equal(ergw:system_info(accept_new, false), true),
-    create_pdp_context(overload, Config),
+    create_pdp_context(reject_new, Config),
     ?equal(ergw:system_info(accept_new, true), false),
 
     ?equal([], outstanding_requests()),

--- a/test/ggsn_proxy_SUITE.erl
+++ b/test/ggsn_proxy_SUITE.erl
@@ -1016,7 +1016,7 @@ ggsn_broken_recovery(Config) ->
     CtxKey = #context_key{socket = 'irx', id = {imsi, ?'IMSI', 5}},
     {GtpC, _, _} = create_pdp_context(Config),
 
-    {_Handler, CtxPid} = gtp_context_reg:lookup(CtxKey),
+    {_, CtxPid} = gtp_context_reg:lookup(CtxKey),
     #{right_tunnel := #tunnel{socket = CSocket}} = gtp_context:info(CtxPid),
 
     FinalGSN = proplists:get_value(final_gsn, Config),
@@ -1055,7 +1055,7 @@ path_failure_to_ggsn(Config) ->
 
     {GtpC, _, _} = create_pdp_context(Config),
 
-    {_Handler, CtxPid} = gtp_context_reg:lookup(CtxKey),
+    {_, CtxPid} = gtp_context_reg:lookup(CtxKey),
     #{right_tunnel := #tunnel{socket = CSocket}} = gtp_context:info(CtxPid),
 
     FinalGSN = proplists:get_value(final_gsn, Config),
@@ -1112,7 +1112,7 @@ path_failure_to_ggsn_and_restore(Config) ->
 
     {GtpC, _, _} = create_pdp_context(Config),
 
-    {_Handler, CtxPid} = gtp_context_reg:lookup(CtxKey),
+    {_, CtxPid} = gtp_context_reg:lookup(CtxKey),
     #{right_tunnel := #tunnel{socket = CSocket}} = gtp_context:info(CtxPid),
 
     FinalGSN = proplists:get_value(final_gsn, Config),
@@ -1174,7 +1174,7 @@ path_failure_to_sgsn(Config) ->
     CtxKey = #context_key{socket = 'irx', id = {imsi, ?'IMSI', 5}},
     {GtpC, _, _} = create_pdp_context(Config),
 
-    {_Handler, CtxPid} = gtp_context_reg:lookup(CtxKey),
+    {_, CtxPid} = gtp_context_reg:lookup(CtxKey),
     #{left_tunnel := #tunnel{socket = CSocket}} = gtp_context:info(CtxPid),
 
     ClientIP = proplists:get_value(client_ip, Config),
@@ -1504,7 +1504,7 @@ error_indication_ggsn2sgsn(Config) ->
 
     {GtpC, _, _} = create_pdp_context(Config),
 
-    {_Handler, CtxPid} = gtp_context_reg:lookup(CtxKey),
+    {_, CtxPid} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(CtxPid),
     #{bearer := #{right := RightBearer}} = gtp_context:info(CtxPid),
 
@@ -1570,7 +1570,7 @@ update_pdp_context_request_ra_update(Config) ->
     RemoteCtxKey = #context_key{socket = 'remote-irx', id = {imsi, ?'PROXY-IMSI', 5}},
 
     {GtpC1, _, _} = create_pdp_context(Config),
-    {_Handler, CtxPid} = gtp_context_reg:lookup(RemoteCtxKey),
+    {_, CtxPid} = gtp_context_reg:lookup(RemoteCtxKey),
     #{left_tunnel := LeftTunnel1, bearer := #{left := LeftBearer1}} = gtp_context:info(CtxPid),
 
     {GtpC2, _, _} = update_pdp_context(ra_update, GtpC1),
@@ -1599,7 +1599,7 @@ update_pdp_context_request_tei_update(Config) ->
     RemoteCtxKey = #context_key{socket = 'remote-irx', id = {imsi, ?'PROXY-IMSI', 5}},
 
     {GtpC1, _, _} = create_pdp_context(Config),
-    {_Handler, CtxPid} = gtp_context_reg:lookup(RemoteCtxKey),
+    {_, CtxPid} = gtp_context_reg:lookup(RemoteCtxKey),
     #{left_tunnel := LeftTunnel1, bearer := #{left := LeftBearer1}} = gtp_context:info(CtxPid),
 
     {_Handler, ProxyCtxPid} = gtp_context_reg:lookup(CtxKey),
@@ -1667,7 +1667,7 @@ update_pdp_context_request_broken_recovery(Config) ->
 			     meck:passthrough([ReqKey, Request, Response])
 		     end),
     {GtpC1, _, _} = create_pdp_context(Config),
-    {_Handler, CtxPid} = gtp_context_reg:lookup(RemoteCtxKey),
+    {_, CtxPid} = gtp_context_reg:lookup(RemoteCtxKey),
     #{left_tunnel := LeftTunnel1, bearer := #{left := LeftBearer1}} = gtp_context:info(CtxPid),
 
     {GtpC2, _, _} = update_pdp_context(simple, GtpC1),

--- a/test/pgw_SUITE.erl
+++ b/test/pgw_SUITE.erl
@@ -1266,7 +1266,7 @@ path_failure(Config) ->
 
     {GtpC, _, _} = create_session(Config),
 
-    {_Handler, CtxPid} = gtp_context_reg:lookup(CtxKey),
+    {_, CtxPid} = gtp_context_reg:lookup(CtxKey),
     #{left_tunnel := #tunnel{socket = CSocket}} = gtp_context:info(CtxPid),
 
     ClientIP = proplists:get_value(client_ip, Config),

--- a/test/pgw_SUITE.erl
+++ b/test/pgw_SUITE.erl
@@ -588,6 +588,7 @@ common() ->
     [invalid_gtp_pdu,
      invalid_gtp_version,
      apn_lookup,
+     create_session_request_missing_sender_teid,
      create_session_request_missing_ie,
      create_session_request_aaa_reject,
      create_session_request_gx_fail,
@@ -1033,6 +1034,15 @@ invalid_gtp_version(Config) ->
     ok.
 
 %%--------------------------------------------------------------------
+create_session_request_missing_sender_teid() ->
+    [{doc, "Check that Create Session Request IE validation works"}].
+create_session_request_missing_sender_teid(Config) ->
+    create_session(missing_sender_teid, Config),
+
+    meck_validate(Config),
+    ok.
+
+%%--------------------------------------------------------------------
 create_session_request_missing_ie() ->
     [{doc, "Check that Create Session Request IE validation works"}].
 create_session_request_missing_ie(Config) ->
@@ -1170,7 +1180,7 @@ create_session_request_accept_new() ->
     [{doc, "Check the accept_new = false can block new session"}].
 create_session_request_accept_new(Config) ->
     ?equal(ergw:system_info(accept_new, false), true),
-    create_session(overload, Config),
+    create_session(reject_new, Config),
     ?equal(ergw:system_info(accept_new, true), false),
 
     meck_validate(Config),

--- a/test/pgw_proxy_SUITE.erl
+++ b/test/pgw_proxy_SUITE.erl
@@ -1118,7 +1118,7 @@ path_failure_to_pgw(Config) ->
 
     {GtpC, _, _} = create_session(Config),
 
-    {_Handler, CtxPid} = gtp_context_reg:lookup(CtxKey),
+    {_, CtxPid} = gtp_context_reg:lookup(CtxKey),
     #{right_tunnel := #tunnel{socket = CSocket}} = gtp_context:info(CtxPid),
 
     FinalGSN = proplists:get_value(final_gsn, Config),
@@ -1173,7 +1173,7 @@ path_failure_to_pgw_and_restore(Config) ->
 
     {GtpC, _, _} = create_session(Config),
 
-    {_Handler, CtxPid} = gtp_context_reg:lookup(CtxKey),
+    {_, CtxPid} = gtp_context_reg:lookup(CtxKey),
     #{right_tunnel := #tunnel{socket = CSocket}} = gtp_context:info(CtxPid),
 
     FinalGSN = proplists:get_value(final_gsn, Config),
@@ -1237,7 +1237,7 @@ path_failure_to_sgw(Config) ->
 
     {GtpC, _, _} = create_session(Config),
 
-    {_Handler, CtxPid} = gtp_context_reg:lookup(CtxKey),
+    {_, CtxPid} = gtp_context_reg:lookup(CtxKey),
     #{left_tunnel := #tunnel{socket = CSocket}} = gtp_context:info(CtxPid),
 
     ClientIP = proplists:get_value(client_ip, Config),
@@ -1827,7 +1827,7 @@ error_indication_pgw2sgw(Config) ->
 
     {GtpC, _, _} = create_session(Config),
 
-    {_Handler, CtxPid} = gtp_context_reg:lookup(CtxKey),
+    {_, CtxPid} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(CtxPid),
     #{bearer := #{right := RightBearer}} = gtp_context:info(CtxPid),
 
@@ -1894,7 +1894,7 @@ modify_bearer_request_ra_update(Config) ->
 
     {GtpC1, _, _} = create_session(Config),
 
-    {_Handler, CtxPid} = gtp_context_reg:lookup(RemoteCtxKey),
+    {_, CtxPid} = gtp_context_reg:lookup(RemoteCtxKey),
     #{left_tunnel := LeftTunnel1, bearer := #{left := LeftBearer1}} = gtp_context:info(CtxPid),
 
     {GtpC2, _, _} = modify_bearer(ra_update, GtpC1),
@@ -1924,7 +1924,7 @@ modify_bearer_request_tei_update(Config) ->
 
     {GtpC1, _, _} = create_session(Config),
 
-    {_Handler, CtxPid} = gtp_context_reg:lookup(RemoteCtxKey),
+    {_, CtxPid} = gtp_context_reg:lookup(RemoteCtxKey),
     #{left_tunnel := LeftTunnel1, bearer := #{left := LeftBearer1}} = gtp_context:info(CtxPid),
 
     {_Handler, ProxyCtxPid} = gtp_context_reg:lookup(CtxKey),
@@ -2416,7 +2416,7 @@ interop_sgsn_to_sgw(Config) ->
 
     {GtpC1, _, _} = ergw_ggsn_test_lib:create_pdp_context(Config),
 
-    {_Handler, CtxPid} = gtp_context_reg:lookup(RemoteCtxKey),
+    {_, CtxPid} = gtp_context_reg:lookup(RemoteCtxKey),
     #{left_tunnel := LeftTunnel1, bearer := #{left := LeftBearer1}} = gtp_context:info(CtxPid),
 
     check_contexts_metric(v1, 3, 1),
@@ -2468,7 +2468,7 @@ interop_sgw_to_sgsn(Config) ->
 
     {GtpC1, _, _} = create_session(Config),
 
-    {_Handler, CtxPid} = gtp_context_reg:lookup(RemoteCtxKey),
+    {_, CtxPid} = gtp_context_reg:lookup(RemoteCtxKey),
     #{left_tunnel := LeftTunnel1, bearer := #{left := LeftBearer1}} = gtp_context:info(CtxPid),
 
     check_contexts_metric(v1, 0, 0),

--- a/test/pgw_proxy_SUITE.erl
+++ b/test/pgw_proxy_SUITE.erl
@@ -1010,7 +1010,7 @@ create_session_request_accept_new() ->
     [{doc, "Check the accept_new = false can block new session"}].
 create_session_request_accept_new(Config) ->
     ?equal(ergw:system_info(accept_new, false), true),
-    create_session(overload, Config),
+    create_session(reject_new, Config),
     ?equal(ergw:system_info(accept_new, true), false),
 
     ?equal([], outstanding_requests()),

--- a/test/saegw_s11_SUITE.erl
+++ b/test/saegw_s11_SUITE.erl
@@ -733,7 +733,7 @@ create_session_request_accept_new() ->
     [{doc, "Check the accept_new = false can block new session"}].
 create_session_request_accept_new(Config) ->
     ?equal(ergw:system_info(accept_new, false), true),
-    create_session(overload, Config),
+    create_session(reject_new, Config),
     ?equal(ergw:system_info(accept_new, true), false),
 
     meck_validate(Config),


### PR DESCRIPTION
Make sure to return a proper TEID when rejecting new sessions due to an internal block (accept_new == false).

Fixes #322
