### PR TITLE
fix statem data corruption in S5/S8 proxy

### DIFF
--- a/src/pgw_s5s8_proxy.erl
+++ b/src/pgw_s5s8_proxy.erl
@@ -886,8 +886,8 @@ close_context(Side, TermCause, State, Data)
 	    initiate_session_teardown(pgw2sgw, undefined, State, Data)
     end,
     delete_forward_session(TermCause, Data);
-close_context(_, _, _, _) ->
-    ok.
+close_context(_, _, _, Data) ->
+    Data.
 
 delete_context(From, TermCause, State, Data0)
   when State == connected; State == connecting ->


### PR DESCRIPTION
The corruption of the statem data only happens when trying to close
the context. This was the cause for many of the CI failures in
pgw_proxy_SUITE.dns_node_selection.

While this might ocure in running instance as well, there should be
not operational impact as it only abort a context that is already
terminating.