### PR TITLE
Update alpine to 3.13 for Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,7 @@ RUN     rebar3 as prod release
 
 # -- runtime image --
 
-FROM alpine:3.12
+FROM alpine:3.13
 
 WORKDIR /
 RUN     apk update && \


### PR DESCRIPTION
The https://github.com/erlang/docker-erlang-otp/blob/master/23/alpine/Dockerfile#L1 has base image what based upon `alpine:3.13`.
**Notes:**
`alpine:3.13` is based on `musl 1.2.x`. https://musl.libc.org/releases.html:
> musl-1.2.1.tar.gz (sig) - August 4, 2020
This release features the new "mallocng" malloc implementation, replacing musl's original dlmalloc-like allocator that suffered from fundamental design problems. Its major user-facing new properties are the ability to return freed memory on a much finer granularity and avoidance of many catastrophic fragmentation patterns. In addition it provides strong hardening against memory usage errors by the caller, including detection of overflows, double-free, and use-after-free, and does not admit corruption of allocator state via these errors.