### PR TITLE
Change default value of 'idle_timeout'

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,13 +393,13 @@ Then fill just created **ergw.config** file with content like described below pr
          },
 
          {path_management, [
-           {t3, 10000},
-           {n3,  5},
-           {echo, 60000},
-           {idle_timeout, 1800000},
-           {idle_echo,     600000},
-           {down_timeout, 3600000},
-           {down_echo,     600000},
+           {t3, 10000},             % optional, can be positive integer, by default: 10000
+           {n3,  5},                % optional, can be positive integer, by default: 5
+           {echo, 60000},           % optional, can be positive integer or 'off', by default: 60000
+           {idle_timeout, 1800000}, % optional, can be positive integer or 'infinity', by default: infinity
+           {idle_echo,     600000}, % optional, can be positive integer or 'off', by default: infinity
+           {down_timeout, 3600000}, % optional, can be positive integer or 'infinity', by default: infinity
+           {down_echo,     600000}, % optional, can be positive integer or 'off', by default: infinity
            {icmp_error_handling, immediate} % optional, can be 'ignore' | 'immediate', by default: immediate
          ]}
         ]},

--- a/config/ergw-c-node.config
+++ b/config/ergw-c-node.config
@@ -104,7 +104,7 @@
 	  [{t3, 10000},
 	   {n3,  5},
 	   {echo, 60000},
-	   {idle_timeout, 1800000},
+	   % {idle_timeout, infinity}, % optional, can be positive integer, by default: infinity
 	   {idle_echo,     600000},
 	   {down_timeout, 3600000},
 	   {down_echo,     600000}

--- a/src/gtp_path.erl
+++ b/src/gtp_path.erl
@@ -152,7 +152,7 @@ stop(Path) ->
     {t3, 10 * 1000},                  % echo retry interval
     {n3,  5},                         % echo retry count
     {echo, 60 * 1000},                % echo ping interval
-    {idle_timeout, 1800 * 1000},      % time to keep the path entry when idle
+    {idle_timeout, infinity},         % time to keep the path entry when idle
     {idle_echo,     600 * 1000},      % echo retry interval when idle
     {down_timeout, 3600 * 1000},      % time to keep the path entry when down
     {down_echo,     600 * 1000},      % echo retry interval when down

--- a/test/config_SUITE.erl
+++ b/test/config_SUITE.erl
@@ -203,7 +203,6 @@
 	  [{t3, 10 * 1000},
 	   {n3, 5},
 	   {echo, 60 * 1000},
-	   {idle_timeout, 1800 * 1000},
 	   {idle_echo,     600 * 1000},
 	   {down_timeout, 3600 * 1000},
 	   {down_echo,     600 * 1000}]
@@ -1080,6 +1079,7 @@ config(_Config)  ->
     ?ok_option(set_cfg_value([path_management, idle_timeout], 300 * 1000, ?PGW_PROXY_CONFIG)),
     ?ok_option(set_cfg_value([path_management, down_timeout], 7200 * 1000, ?PGW_PROXY_CONFIG)),
     ?ok_option(set_cfg_value([path_management, idle_timeout], 0, ?PGW_PROXY_CONFIG)),
+	?ok_option(set_cfg_value([path_management, idle_timeout], infinity, ?PGW_PROXY_CONFIG)),
     ?ok_option(set_cfg_value([path_management, down_timeout], 0, ?PGW_PROXY_CONFIG)),
     ?ok_option(set_cfg_value([path_management, icmp_error_handling], ignore, ?PGW_PROXY_CONFIG)),
 

--- a/test/ggsn_proxy_SUITE.erl
+++ b/test/ggsn_proxy_SUITE.erl
@@ -203,7 +203,6 @@
 		 {path_management, [{t3, 10 * 1000},
 				    {n3,  5},
 				    {echo, 60 * 1000},
-				    {idle_timeout, 1800 * 1000},
 				    {idle_echo,     600 * 1000},
 				    {down_timeout, 3600 * 1000},
 				    {down_echo,     600 * 1000}]}
@@ -426,7 +425,6 @@
 		 {path_management, [{t3, 10 * 1000},
 				    {n3,  5},
 				    {echo, 60 * 1000},
-				    {idle_timeout, 1800 * 1000},
 				    {idle_echo,     600 * 1000},
 				    {down_timeout, 3600 * 1000},
 				    {down_echo,     600 * 1000}]}

--- a/test/pgw_proxy_SUITE.erl
+++ b/test/pgw_proxy_SUITE.erl
@@ -218,7 +218,6 @@
 		 {path_management, [{t3, 10 * 1000},
 				    {n3,  5},
 				    {echo, 60 * 1000},
-				    {idle_timeout, 1800 * 1000},
 				    {idle_echo,     600 * 1000},
 				    {down_timeout, 3600 * 1000},
 				    {down_echo,     600 * 1000}]}
@@ -456,7 +455,6 @@
 		 {path_management, [{t3, 10 * 1000},
 				    {n3,  5},
 				    {echo, 60 * 1000},
-				    {idle_timeout, 1800 * 1000},
 				    {idle_echo,     600 * 1000},
 				    {down_timeout, 3600 * 1000},
 				    {down_echo,     600 * 1000}]}


### PR DESCRIPTION
Start use `infinity` value in `idle_timeout`
Motivation:
- by default - this functionality is not needed
- in specific scenarios we should set the value to 12h