### PR TITLE
add experimental location dependent calculation to Tariff-Time-Change

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
            apk --no-cache upgrade
            apk --no-cache add docker gcc git libc-dev libc-utils libgcc linux-headers make bash \
                               musl-dev musl-utils ncurses-dev pcre2 pkgconf scanelf wget zlib \
-                              yaml-dev
+                              yaml-dev tzdata
     - uses: actions/checkout@v2
     - name: Build
       run: rebar3 compile

--- a/apps/ergw/src/ergw_config.erl
+++ b/apps/ergw/src/ergw_config.erl
@@ -1001,7 +1001,9 @@ to_aaa_procedures(List) when is_list(List) ->
 to_aaa_avp('Tariff-Time-Change', V) when is_binary(V) ->
     Time = calendar:rfc3339_to_system_time(binary_to_list(V)),
     calendar:system_time_to_universal_time(Time, second);
-to_aaa_avp('Tariff-Time', V) when is_binary(V) ->
+to_aaa_avp(K, V)
+  when is_binary(V) andalso
+       (K =:= 'Tariff-Time' orelse K =:= 'Local-Tariff-Time') ->
     {ok, [Hour, Minute], _} = io_lib:fread("~d:~d", binary_to_list(V)),
     {Hour, Minute};
 to_aaa_avp(K, V) when is_list(V) ->
@@ -1229,7 +1231,9 @@ from_aaa_avp(_K, {{Year, Month, Day}, {Hour, Minute, Second}}) ->
     iolist_to_binary(
       io_lib:format("~w-~2..0w-~2..0wT~2..0w:~2..0w:~2..0wZ",
 		    [Year, Month, Day, Hour, Minute, Second]));
-from_aaa_avp('Tariff-Time', Time) ->
+from_aaa_avp(K, Time)
+  when K =:= 'Tariff-Time';
+       K =:= 'Local-Tariff-Time' ->
     from_time(Time);
 from_aaa_avp(_K, Value) when is_list(Value) ->
     iolist_to_binary(Value);

--- a/apps/ergw_core/src/ergw_core.app.src
+++ b/apps/ergw_core/src/ergw_core.app.src
@@ -8,7 +8,8 @@
 		    prometheus, cowboy, prometheus_cowboy,
 		    prometheus_diameter_collector,
 		    compiler, os_mon, jobs, ra,
-		    riak_core, riak_core_lite_util, ergw_sbi_client]},
+		    riak_core, riak_core_lite_util, ergw_sbi_client,
+		    zoneinfo]},
     {mod, {ergw_core_app, []}},
     {registered, []}
 ]}.

--- a/apps/ergw_core/src/ergw_gsn_lib.erl
+++ b/apps/ergw_core/src/ergw_gsn_lib.erl
@@ -40,6 +40,10 @@
 	 assign_local_data_teid/5
 	]).
 
+-ifdef(TEST).
+-export([sntp_time_to_datetime/1]).
+-endif.
+
 -include_lib("kernel/include/logger.hrl").
 -include_lib("parse_trans/include/exprecs.hrl").
 -include_lib("gtplib/include/gtp_packet.hrl").

--- a/apps/ergw_core/test/pfcp_context_SUITE.erl
+++ b/apps/ergw_core/test/pfcp_context_SUITE.erl
@@ -1,0 +1,137 @@
+%% Copyright 2021, Travelping GmbH <info@travelping.com>
+
+%% This program is free software; you can redistribute it and/or
+%% modify it under the terms of the GNU General Public License
+%% as published by the Free Software Foundation; either version
+%% 2 of the License, or (at your option) any later version.
+
+-module(pfcp_context_SUITE).
+
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("pfcplib/include/pfcp_packet.hrl").
+-include("ergw_test_lib.hrl").
+
+%%%===================================================================
+%%% Common Test callbacks
+%%%===================================================================
+
+all() ->
+    [localtime_BDST_before_BDST_midnight,
+     localtime_BDST_before_UTC_midnight,
+     localtime_BDST_after_midnight,
+     localtime_BST_before_BST_midnight,
+     localtime_BST_before_UTC_midnight,
+     localtime_BST_after_midnight].
+
+suite() ->
+    [{timetrap, {seconds, 30}}].
+
+init_per_suite(Config) ->
+    application:ensure_all_started(zoneinfo),
+    Config.
+
+end_per_suite(_Config) ->
+    application:stop(zoneinfo),
+    ok.
+
+%%%===================================================================
+%%% Test cases
+%%%===================================================================
+
+localtime_BDST_before_BDST_midnight() ->
+    [{doc, "Check that local time to UTC conversion in Tariff Time calculation works"}].
+localtime_BDST_before_BDST_midnight(_Config) ->
+    %% 2021-10-30T22:58:17Z is 2021-10-30 23:58:17 BDST
+    Now = {{2021, 10, 30}, {22, 58, 17}},
+    Location = "Europe/London",
+
+    URR = ergw_pfcp_context:apply_charging_tariff_time(
+	    #{'Local-Tariff-Time' => {0, 0}, 'Location' => Location}, Now, #{}),
+    ?match(#{monitoring_time := #monitoring_time{}}, URR),
+    ct:pal("Time: ~p", [monitoring_time(URR)]),
+    ?match({{2021, 10, 30}, {23, 0, 0}}, monitoring_time(URR)),
+    ok.
+
+localtime_BDST_before_UTC_midnight() ->
+    [{doc, "Check that local time to UTC conversion in Tariff Time calculation works"}].
+localtime_BDST_before_UTC_midnight(_Config) ->
+    %% 2021-10-30T23:58:17Z is 2021-10-30 00:58:17 BDST,
+    %% next tariff time is midnight next day in BST
+    Now = {{2021, 10, 30}, {23, 58, 17}},
+    Location = "Europe/London",
+
+    URR = ergw_pfcp_context:apply_charging_tariff_time(
+	    #{'Local-Tariff-Time' => {0, 0}, 'Location' => Location}, Now, #{}),
+    ?match(#{monitoring_time := #monitoring_time{}}, URR),
+    ct:pal("Time: ~p", [monitoring_time(URR)]),
+    ?match({{2021, 11, 1}, {0, 0, 0}}, monitoring_time(URR)),
+    ok.
+
+localtime_BDST_after_midnight() ->
+    [{doc, "Check that local time to UTC conversion in Tariff Time calculation works"}].
+localtime_BDST_after_midnight(_Config) ->
+    %% 2021-10-31T00:58:17Z is 2021-10-31 01:58:17 BDST
+    %% next tariff time is midnight next day in BST
+    Now = {{2021, 10, 31}, {0, 58, 17}},
+    Location = "Europe/London",
+
+    URR = ergw_pfcp_context:apply_charging_tariff_time(
+	    #{'Local-Tariff-Time' => {0, 0}, 'Location' => Location}, Now, #{}),
+    ?match(#{monitoring_time := #monitoring_time{}}, URR),
+    ct:pal("Time: ~p", [monitoring_time(URR)]),
+    ?match({{2021, 11, 01}, {0, 0, 0}}, monitoring_time(URR)),
+    ok.
+
+localtime_BST_before_BST_midnight() ->
+    [{doc, "Check that local time to UTC conversion in Tariff Time calculation works"}].
+localtime_BST_before_BST_midnight(_Config) ->
+    %% 2021-03-27T22:58:17Z is 2021-03-27 22:58:17 BST
+    Now = {{2021, 03, 27}, {22, 58, 17}},
+    Location = "Europe/London",
+
+    URR = ergw_pfcp_context:apply_charging_tariff_time(
+	    #{'Local-Tariff-Time' => {0, 0}, 'Location' => Location}, Now, #{}),
+    ?match(#{monitoring_time := #monitoring_time{}}, URR),
+    ct:pal("Time: ~p", [monitoring_time(URR)]),
+    ?match({{2021, 03, 28}, {0, 0, 0}}, monitoring_time(URR)),
+    ok.
+
+localtime_BST_before_UTC_midnight() ->
+    [{doc, "Check that local time to UTC conversion in Tariff Time calculation works"}].
+localtime_BST_before_UTC_midnight(_Config) ->
+    %% 2021-03-27T23:58:17Z is 2021-03-27 23:58:17 BST
+    Now = {{2021, 03, 27}, {23, 58, 17}},
+    Location = "Europe/London",
+
+    URR = ergw_pfcp_context:apply_charging_tariff_time(
+	    #{'Local-Tariff-Time' => {0, 0}, 'Location' => Location}, Now, #{}),
+    ?match(#{monitoring_time := #monitoring_time{}}, URR),
+    ct:pal("Time: ~p", [monitoring_time(URR)]),
+    ?match({{2021, 03, 28}, {0, 0, 0}}, monitoring_time(URR)),
+    ok.
+
+localtime_BST_after_midnight() ->
+    [{doc, "Check that local time to UTC conversion in Tariff Time calculation works"}].
+localtime_BST_after_midnight(_Config) ->
+    %% 2021-03-28T00:58:17Z is 2021-03-28 00:58:17 BST
+    %% next tariff time is midnight next day in BDST
+    Now = {{2021, 03, 28}, {00, 58, 17}},
+    Location = "Europe/London",
+
+    URR = ergw_pfcp_context:apply_charging_tariff_time(
+	    #{'Local-Tariff-Time' => {0, 0}, 'Location' => Location}, Now, #{}),
+    ?match(#{monitoring_time := #monitoring_time{}}, URR),
+    ct:pal("Time: ~p", [monitoring_time(URR)]),
+    ?match({{2021, 03, 28}, {23, 0, 0}}, monitoring_time(URR)),
+    ok.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+monitoring_time(#{monitoring_time := #monitoring_time{time = SNTP}}) ->
+    ergw_gsn_lib:sntp_time_to_datetime(SNTP);
+monitoring_time(_) ->
+    0.

--- a/apps/ergw_core/test/pgw_SUITE.erl
+++ b/apps/ergw_core/test/pgw_SUITE.erl
@@ -4554,7 +4554,10 @@ tariff_time_change(Config) ->
 
     ok = meck:expect(ergw_aaa_session, start_link,
 		     fun (Owner, SOpts0) ->
-			     OPC = #{'Default' => #{'Tariff-Time' => [{15, 4}]}},
+			     OPC = #{'Default' =>
+					 #{'Tariff-Time' =>
+					       [#{'Local-Tariff-Time' => {15, 4},
+						  'Location' => <<"Etc/UTC">>}]}},
 			     SOpts = SOpts0#{'Offline-Charging-Profile' => OPC},
 			     meck:passthrough([Owner, SOpts])
 		     end),

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,8 @@ RUN     apk update && apk --no-cache upgrade && \
 			pkgconf \
 			scanelf \
 			zlib \
-			yaml-dev
+			yaml-dev \
+			tzdata
 
 ADD     . /build
 RUN     rebar3 as prod release
@@ -30,7 +31,7 @@ FROM alpine:3.14
 WORKDIR /
 RUN     apk update && \
 		apk --no-cache upgrade && \
-		apk --no-cache add libgcc libstdc++ zlib ncurses-libs libcrypto1.1 lksctp-tools tini yaml
+		apk --no-cache add libgcc libstdc++ zlib ncurses-libs libcrypto1.1 lksctp-tools tini tzdata yaml
 COPY    docker/docker-entrypoint.sh /
 COPY    config/ergw-c-node.config /etc/ergw-c-node/
 

--- a/rebar.config
+++ b/rebar.config
@@ -21,7 +21,8 @@
 	{netdata, {git, "https://github.com/RoadRunnr/erl_netdata.git", {ref, "cbd6eaf"}}},
 	{gtplib, "3.0.0"},
 	{pfcplib, "2.1.1"},
-	{ergw_aaa, {git, "https://github.com/travelping/ergw_aaa.git", {tag, "4.1.3"}}}
+	{ergw_aaa, {git, "https://github.com/travelping/ergw_aaa.git", {tag, "4.1.3"}}},
+	{zoneinfo, {git, "https://github.com/RoadRunnr/zoneinfo.git", {branch, "master"}}}
 ]}.
 
 {minimum_otp_vsn, "23.0"}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -57,6 +57,10 @@
  {<<"xxhash">>,
   {git,"https://github.com/pierreis/erlang-xxhash.git",
        {ref,"5d222dcb54c9dd8247d4429174126ebda52b0e2d"}},
+  0},
+ {<<"zoneinfo">>,
+  {git,"https://github.com/RoadRunnr/zoneinfo.git",
+       {ref,"53de9dfa58df592be744e62b872f2688986d79a9"}},
   0}]}.
 [
 {pkg_hash,[


### PR DESCRIPTION
This feature should be treated as experimental even when merged.

The preconfigure Tariff-Time in charging profile now has a location
attribute. That location attribute is use to interpret the time a
local time and translate it to UTC for use as a Monitoring Time
in PFCP.

As location name all names from the olsen timezone database are
valid. To specify a UTC time use "Etc/UTC" as location.

This requires also a change to "Tariff-Time" declaration in the config. In the JSON config, it now needs to be something like:

```
"Tariff-Time" : {
    "Local-Tariff-Time": "00:00",
    "Location": "Europe/Berlin"
}
```
