### PR TITLE
Start use image 'quay.io/travelping/alpine-erlang:23.3.4'

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: [22.3.4.14, 23.0.4, 23.1.5.0, 23.2.1.0, 23.2.7.0]
+        otp: [22.3, 23.3.4]
     container:
-      image: erlang:${{ matrix.otp }}-alpine
+      image: quay.io/travelping/alpine-erlang:${{ matrix.otp }}
       options: --privileged
     steps:
     - name: Prepare

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,7 +54,11 @@ check:otp-23.1:
   
 check:otp-23.2:
   <<: *check_otp
-  image: quay.io/travelping/alpine-erlang:23.3.3
+  image: erlang:23.2.7.0-alpine
+  
+check:otp-23.3:
+  <<: *check_otp
+  image: quay.io/travelping/alpine-erlang:23.3.4
 
 docker:
   image: jdrouet/docker-with-buildx:stable

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # -- build-environment --
 # see https://docs.docker.com/engine/userguide/eng-image/multistage-build/
 
-FROM quay.io/travelping/alpine-erlang:23.3.3 AS build-env
+FROM quay.io/travelping/alpine-erlang:23.3.4 AS build-env
 
 WORKDIR /build
 RUN     apk update && apk --no-cache upgrade && \


### PR DESCRIPTION
The `SCTP` fix was included into `OTP 23.3.4` release:
https://github.com/erlang/otp/pull/4775 -> https://github.com/erlang/otp/commit/1cf647698614382f14d896a96a626910ca56ffed -> https://github.com/erlang/docker-erlang-otp/pull/342 -> https://github.com/docker-library/official-images/pull/10145 -> https://github.com/travelping/docker-erlang-otp/commit/95c923684138533579ff8c9978140213c08e8ccb. Based on `alpine:3.13` -> `linux-headers=5.4.5-r1`