### PR TITLE
lowercase APN before further processing it

### DIFF
--- a/apps/ergw_core/src/ergw_node_selection.erl
+++ b/apps/ergw_core/src/ergw_node_selection.erl
@@ -87,6 +87,9 @@ candidates(Name, Services, NodeSelection) ->
 	    L
     end.
 
+lowercase_apn([H|_] = APN) when is_binary(H) ->
+    [string:lowercase(X) || X <- APN].
+
 expand_apn_plmn(IMSI) when is_binary(IMSI) ->
     {MCC, MNC, _} = itu_e212:split_imsi(IMSI),
     {MCC, MNC};
@@ -113,12 +116,12 @@ split_apn([H|_] = APN)
 
 apn_to_fqdn([H|_] = APN, IMSI)
   when is_binary(H) ->
-    apn_to_fqdn(expand_apn(APN, IMSI)).
+    apn_to_fqdn(expand_apn(lowercase_apn(APN), IMSI)).
 
 apn_to_fqdn([H|_] = APN)
   when is_binary(H) ->
     FQDN =
-	case lists:reverse(APN) of
+	case lists:reverse(lowercase_apn(APN)) of
 	    [<<"gprs">>, MCC, MNC | APN_NI] ->
 		lists:reverse([<<"org">>, <<"3gppnetwork">>, MCC, MNC, <<"epc">>, <<"apn">> | APN_NI]);
 	    [<<"org">>, <<"3gppnetwork">> | _] ->
@@ -375,9 +378,9 @@ lookup(Name, ServiceSet, Selection) when is_binary(Name) ->
 normalize_name({fqdn, FQDN}) ->
     FQDN;
 normalize_name([H|_] = Name) when is_binary(H) ->
-    normalize_name_fqdn(lists:reverse(Name));
+    normalize_name_fqdn(lists:reverse(lowercase_apn(Name)));
 normalize_name(Name) when is_binary(Name) ->
-    normalize_name_fqdn(lists:reverse(binary:split(Name, <<$.>>, [global]))).
+    normalize_name_fqdn(lists:reverse(binary:split(string:lowercase(Name), <<$.>>, [global]))).
 
 normalize_name_fqdn([<<"org">>, <<"3gppnetwork">> | _] = Name) ->
     lists:reverse(Name);

--- a/apps/ergw_core/test/node_selection_SUITE.erl
+++ b/apps/ergw_core/test/node_selection_SUITE.erl
@@ -272,7 +272,7 @@ a_lookup_no_final_a(_Config) ->
 default_lookup() ->
     [{doc, "lookup from config"}].
 default_lookup(_Config) ->
-    R = ergw_node_selection:candidates(<<"example.apn.epc">>, [{'x-3gpp-upf','x-sxa'}], [default]),
+    R = ergw_node_selection:candidates(<<"example.apn.EPC">>, [{'x-3gpp-upf','x-sxa'}], [default]),
     ?match([{<<"topon.sx.prox01.node.epc.mnc001.mcc001.3gppnetwork.org">>, _, _, [_|_], _}], R),
     [{_, _, _, IP4, _}] = R,
     ?equal(lists:sort([?UP1]), lists:sort(IP4)),


### PR DESCRIPTION
The 3GPP specification do not spell it out but seem to assume that
APN names are used in all places as case insensitive.
Lowercase all APN names from GTP before using it further.