### PR TITLE
lowercase APN before further processing it

### DIFF
--- a/src/ergw_node_selection.erl
+++ b/src/ergw_node_selection.erl
@@ -103,6 +103,9 @@ candidates(Name, Services, NodeSelection) ->
 	    L
     end.
 
+lowercase_apn([H|_] = APN) when is_binary(H); is_list(H) ->
+    [string:lowercase(X) || X <- APN].
+
 expand_apn_plmn(IMSI) when is_binary(IMSI) ->
     {MCC, MNC, _} = itu_e212:split_imsi(IMSI),
     {MCC, MNC};
@@ -129,7 +132,7 @@ split_apn([H|_] = APN)
 
 apn_to_fqdn([H|_] = APN, IMSI)
   when is_binary(H) ->
-    apn_to_fqdn(expand_apn(APN, IMSI)).
+    apn_to_fqdn(expand_apn(lowercase_apn(APN), IMSI)).
 
 apn_to_fqdn([H|_] = APN)
   when is_binary(H) ->
@@ -137,7 +140,7 @@ apn_to_fqdn([H|_] = APN)
 apn_to_fqdn(APN)
   when is_list(APN) ->
     FQDN =
-	case lists:reverse(APN) of
+	case lists:reverse(lowercase_apn(APN)) of
 	    ["gprs", MCC, MNC | APN_NI] ->
 		lists:reverse(["org", "3gppnetwork", MCC, MNC, "epc", "apn" | APN_NI]);
 	    ["org", "3gppnetwork" | _] ->
@@ -316,9 +319,9 @@ lookup(Name, ServiceSet, Selection) ->
 normalize_name({fqdn, FQDN}) ->
     FQDN;
 normalize_name([H|_] = Name) when is_list(H) ->
-    normalize_name_fqdn(lists:reverse(Name));
+    normalize_name_fqdn(lists:reverse(lowercase_apn(Name)));
 normalize_name(Name) when is_list(Name) ->
-    normalize_name_fqdn(lists:reverse(string:tokens(Name, ".")));
+    normalize_name_fqdn(lists:reverse(string:tokens(string:lowercase(Name), ".")));
 normalize_name(Name) when is_binary(Name) ->
     normalize_name(binary_to_list(Name)).
 

--- a/test/node_selection_SUITE.erl
+++ b/test/node_selection_SUITE.erl
@@ -264,7 +264,7 @@ static_lookup() ->
 static_lookup(_Config) ->
     application:set_env(ergw, node_selection, ?ERGW_NODE_SELECTION),
 
-    R = ergw_node_selection:candidates("example.apn.epc", [{"x-3gpp-upf","x-sxa"}], [default]),
+    R = ergw_node_selection:candidates("example.apn.EPC", [{"x-3gpp-upf","x-sxa"}], [default]),
     ?match([{"topon.sx.prox01.epc.mnc001.mcc001.3gppnetwork.org", _, _, [_|_], []}], R),
     [{_, _, _, IP4, _}] = R,
     ?equal(lists:sort([?UP1]), lists:sort(IP4)),


### PR DESCRIPTION
Origin PR: https://github.com/travelping/ergw/pull/394
The 3GPP specification do not spell it out but seem to assume that
APN names are used in all places as case insensitive.
Lowercase all APN names from GTP before using it further.