### PR TITLE
align VRF name config format IpAddress

### DIFF
--- a/apps/ergw/priv/schemas/ergw_config.yaml
+++ b/apps/ergw/priv/schemas/ergw_config.yaml
@@ -68,14 +68,18 @@ components:
 
     VrfName:
       type: object
+      oneOf:
+        - required:
+          - apn
+        - required:
+          - dnn
       properties:
-        name:
+        apn:
           format: hostname
           type: string
-        type:
-          enum:
-            - apn
-            - dnn
+        dnn:
+          format: hostname
+          type: string
 
     VRF:
       type: object

--- a/apps/ergw/src/ergw_config.erl
+++ b/apps/ergw/src/ergw_config.erl
@@ -926,17 +926,11 @@ to_timeout(#{timeout := Timeout}) ->
 to_timeout(#{<<"timeout">> := _} = Timeout) ->
     to_timeout(maps:fold(fun(K, V, M) -> maps:put(to_atom(K), V, M) end, #{}, Timeout)).
 
-to_vrf({apn, APN}) ->
+to_vrf(#{<<"apn">> := APN}) ->
     << <<(size(L)):8, L/binary>> ||
 	L <- binary:split(to_binary(APN), <<".">>, [global, trim_all]) >>;
-to_vrf({dnn, DNN}) ->
-    to_binary(DNN);
-to_vrf(#{type := Type, name := Name}) when not is_atom(Type) ->
-    to_vrf({to_atom(Type), Name});
-to_vrf(#{name := Name}) ->
-    to_vrf({apn, Name});
-to_vrf(#{<<"name">> := _} = VRF) ->
-    to_vrf(maps:fold(fun(K, V, M) -> maps:put(to_atom(K), V, M) end, #{}, VRF)).
+to_vrf(#{<<"dnn">> :=  DNN}) ->
+    to_binary(DNN).
 
 to_term(V) ->
     String = to_string(V) ++ ".",
@@ -1114,9 +1108,9 @@ from_timeout(Timeout, [{Unit, _}|_]) ->
 
 from_vrf(<<X:8, _/binary>> = APN) when X < 64 ->
     L = [ Part || <<Len:8, Part:Len/bytes>> <= APN ],
-    #{type => apn, name => iolist_to_binary(lists:join($., L))};
+    #{apn => iolist_to_binary(lists:join($., L))};
 from_vrf(DNN) ->
-    #{type => dnn, name => DNN}.
+    #{dnn => DNN}.
 
 from_string(V) ->
     unicode:characters_to_binary(V).

--- a/apps/ergw/test/ergw_http_api_SUITE_data/ggsn.json
+++ b/apps/ergw/test/ergw_http_api_SUITE_data/ggsn.json
@@ -22,8 +22,7 @@
             "prefered_bearer_type": "IPv6",
             "vrfs": [
                 {
-                    "name": "sgi",
-                    "type": "apn"
+                    "apn": "sgi"
                 }
             ]
         }
@@ -255,8 +254,7 @@
             "ue_ip_pools": [
                 {"ip_pools": ["pool-A"],
                  "vrf": {
-                     "name": "sgi",
-                     "type": "apn"
+                     "apn": "sgi"
                  },
                  "ip_versions": ["v4", "v6"]
                 }
@@ -275,8 +273,7 @@
                         "SGi-LAN"
                     ],
                     "name": {
-                        "name": "sgi",
-                        "type": "apn"
+                        "apn": "sgi"
                     }
                 },
                 {
@@ -284,8 +281,7 @@
                         "Access"
                     ],
                     "name": {
-                        "name": "irx",
-                        "type": "apn"
+                        "apn": "irx"
                     }
                 },
                 {
@@ -293,8 +289,7 @@
                         "CP-Function"
                     ],
                     "name": {
-                        "name": "cp",
-                        "type": "apn"
+                        "apn": "cp"
                     }
                 }
             ]
@@ -350,8 +345,7 @@
             "send_port": 0,
             "type": "gtp-c",
             "vrf": {
-                "name": "irx",
-                "type": "apn"
+                "apn": "irx"
             }
         },
         {
@@ -365,8 +359,7 @@
             "send_port": 0,
             "type": "gtp-u",
             "vrf": {
-                "name": "cp",
-                "type": "apn"
+                "apn": "cp"
             }
         }
     ],

--- a/apps/ergw/test/sbi_nbsf_SUITE_data/ipv4.json
+++ b/apps/ergw/test/sbi_nbsf_SUITE_data/ipv4.json
@@ -159,8 +159,7 @@
             "prefered_bearer_type":"IPv6",
             "vrfs":[
                 {
-                    "name":"sgi",
-                    "type":"apn"
+                    "apn":"sgi"
                 }
             ]
         },
@@ -178,8 +177,7 @@
             "prefered_bearer_type":"IPv6",
             "vrfs":[
                 {
-                    "name":"sgi",
-                    "type":"apn"
+                    "apn":"sgi"
                 }
             ]
         },
@@ -197,8 +195,7 @@
             "prefered_bearer_type":"IPv6",
             "vrfs":[
                 {
-                    "name":"sgi",
-                    "type":"apn"
+                    "apn":"sgi"
                 }
             ]
         },
@@ -216,8 +213,7 @@
             "prefered_bearer_type":"IPv6",
             "vrfs":[
                 {
-                    "name":"sgi",
-                    "type":"apn"
+                    "apn":"sgi"
                 }
             ]
         },
@@ -235,8 +231,7 @@
             "prefered_bearer_type":"IPv6",
             "vrfs":[
                 {
-                    "name":"sgi",
-                    "type":"apn"
+                    "apn":"sgi"
                 }
             ]
         }
@@ -707,8 +702,7 @@
             "send_port":0,
             "type":"gtp-c",
             "vrf":{
-                "name":"irx",
-                "type":"apn"
+                "apn":"irx"
             }
         },
         {
@@ -721,8 +715,7 @@
             "send_port":0,
             "type":"gtp-u",
             "vrf":{
-                "name":"cp",
-                "type":"apn"
+                "apn":"cp"
             }
         }
     ],
@@ -746,8 +739,7 @@
             "ue_ip_pools": [
                 {"ip_pools": ["pool-A"],
                  "vrf": {
-                     "name": "sgi",
-                     "type": "apn"
+                     "apn": "sgi"
                  },
                  "ip_versions": ["v4", "v6"]
                 }
@@ -766,8 +758,7 @@
                         "SGi-LAN"
                     ],
                     "name":{
-                        "name":"sgi",
-                        "type":"apn"
+                        "apn":"sgi"
                     }
                 },
                 {
@@ -775,8 +766,7 @@
                         "Access"
                     ],
                     "name":{
-                        "name":"irx",
-                        "type":"apn"
+                        "apn":"irx"
                     }
                 },
                 {
@@ -784,8 +774,7 @@
                         "CP-Function"
                     ],
                     "name":{
-                        "name":"cp",
-                        "type":"apn"
+                        "apn":"cp"
                     }
                 }
             ]
@@ -807,8 +796,7 @@
 		"ue_ip_pools": [
                     {"ip_pools": ["pool-B", "pool-C"],
                      "vrf": {
-			 "name": "sgi",
-			 "type": "apn"
+			 "apn": "sgi"
                      },
                      "ip_versions": ["v4", "v6"]
                     }
@@ -828,8 +816,7 @@
                             "SGi-LAN"
                         ],
                         "name":{
-                            "name":"sgi",
-                            "type":"apn"
+                            "apn":"sgi"
                         }
                     },
                     {
@@ -837,8 +824,7 @@
                             "Access"
                         ],
                         "name":{
-                            "name":"irx",
-                            "type":"apn"
+                            "apn":"irx"
                         }
                     },
                     {
@@ -846,8 +832,7 @@
                             "CP-Function"
                         ],
                         "name":{
-                            "name":"cp",
-                            "type":"apn"
+                            "apn":"cp"
                         }
                     }
                 ]
@@ -868,8 +853,7 @@
 		"ue_ip_pools": [
                     {"ip_pools": ["pool-A"],
                      "vrf": {
-			 "name": "sgi",
-			 "type": "apn"
+			 "apn": "sgi"
                      },
                      "ip_versions": ["v4", "v6"]
                     }
@@ -889,8 +873,7 @@
                             "SGi-LAN"
                         ],
                         "name":{
-                            "name":"sgi",
-                            "type":"apn"
+                            "apn":"sgi"
                         }
                     },
                     {
@@ -898,8 +881,7 @@
                             "Access"
                         ],
                         "name":{
-                            "name":"irx",
-                            "type":"apn"
+                            "apn":"irx"
                         }
                     },
                     {
@@ -907,8 +889,7 @@
                             "CP-Function"
                         ],
                         "name":{
-                            "name":"cp",
-                            "type":"apn"
+                            "apn":"cp"
                         }
                     }
                 ]

--- a/apps/ergw/test/sbi_nbsf_SUITE_data/ipv6.json
+++ b/apps/ergw/test/sbi_nbsf_SUITE_data/ipv6.json
@@ -159,8 +159,7 @@
             "prefered_bearer_type":"IPv6",
             "vrfs":[
                 {
-                    "name":"sgi",
-                    "type":"apn"
+                    "apn":"sgi"
                 }
             ]
         },
@@ -178,8 +177,7 @@
             "prefered_bearer_type":"IPv6",
             "vrfs":[
                 {
-                    "name":"sgi",
-                    "type":"apn"
+                    "apn":"sgi"
                 }
             ]
         },
@@ -197,8 +195,7 @@
             "prefered_bearer_type":"IPv6",
             "vrfs":[
                 {
-                    "name":"sgi",
-                    "type":"apn"
+                    "apn":"sgi"
                 }
             ]
         },
@@ -216,8 +213,7 @@
             "prefered_bearer_type":"IPv6",
             "vrfs":[
                 {
-                    "name":"sgi",
-                    "type":"apn"
+                    "apn":"sgi"
                 }
             ]
         },
@@ -235,8 +231,7 @@
             "prefered_bearer_type":"IPv6",
             "vrfs":[
                 {
-                    "name":"sgi",
-                    "type":"apn"
+                    "apn":"sgi"
                 }
             ]
         }
@@ -707,8 +702,7 @@
             "send_port":0,
             "type":"gtp-c",
             "vrf":{
-                "name":"irx",
-                "type":"apn"
+                "apn":"irx"
             }
         },
         {
@@ -721,8 +715,7 @@
             "send_port":0,
             "type":"gtp-u",
             "vrf":{
-                "name":"cp",
-                "type":"apn"
+                "apn":"cp"
             }
         }
     ],
@@ -746,8 +739,7 @@
             "ue_ip_pools": [
                 {"ip_pools": ["pool-A"],
                  "vrf": {
-                     "name": "sgi",
-                     "type": "apn"
+                     "apn": "sgi"
                  },
                  "ip_versions": ["v4", "v6"]
                 }
@@ -766,8 +758,7 @@
                         "SGi-LAN"
                     ],
                     "name":{
-                        "name":"sgi",
-                        "type":"apn"
+                        "apn":"sgi"
                     }
                 },
                 {
@@ -775,8 +766,7 @@
                         "Access"
                     ],
                     "name":{
-                        "name":"irx",
-                        "type":"apn"
+                        "apn":"irx"
                     }
                 },
                 {
@@ -784,8 +774,7 @@
                         "CP-Function"
                     ],
                     "name":{
-                        "name":"cp",
-                        "type":"apn"
+                        "apn":"cp"
                     }
                 }
             ]
@@ -807,8 +796,7 @@
 		"ue_ip_pools": [
                     {"ip_pools": ["pool-B", "pool-C"],
                      "vrf": {
-			 "name": "sgi",
-			 "type": "apn"
+			 "apn": "sgi"
                      },
                      "ip_versions": ["v4", "v6"]
                     }
@@ -828,8 +816,7 @@
                             "SGi-LAN"
                         ],
                         "name":{
-                            "name":"sgi",
-                            "type":"apn"
+                            "apn":"sgi"
                         }
                     },
                     {
@@ -837,8 +824,7 @@
                             "Access"
                         ],
                         "name":{
-                            "name":"irx",
-                            "type":"apn"
+                            "apn":"irx"
                         }
                     },
                     {
@@ -846,8 +832,7 @@
                             "CP-Function"
                         ],
                         "name":{
-                            "name":"cp",
-                            "type":"apn"
+                            "apn":"cp"
                         }
                     }
                 ]
@@ -868,8 +853,7 @@
 		"ue_ip_pools": [
                     {"ip_pools": ["pool-A"],
                      "vrf": {
-			 "name": "sgi",
-			 "type": "apn"
+			 "apn": "sgi"
                      },
                      "ip_versions": ["v4", "v6"]
                     }
@@ -889,8 +873,7 @@
                             "SGi-LAN"
                         ],
                         "name":{
-                            "name":"sgi",
-                            "type":"apn"
+                            "apn":"sgi"
                         }
                     },
                     {
@@ -898,8 +881,7 @@
                             "Access"
                         ],
                         "name":{
-                            "name":"irx",
-                            "type":"apn"
+                            "apn":"irx"
                         }
                     },
                     {
@@ -907,8 +889,7 @@
                             "CP-Function"
                         ],
                         "name":{
-                            "name":"cp",
-                            "type":"apn"
+                            "apn":"cp"
                         }
                     }
                 ]

--- a/apps/ergw/test/smc_SUITE_data/ggsn.json
+++ b/apps/ergw/test/smc_SUITE_data/ggsn.json
@@ -23,8 +23,7 @@
             "prefered_bearer_type": "IPv6",
             "vrfs": [
                 {
-                    "name": "upstream",
-                    "type": "apn"
+                    "apn": "upstream"
                 }
             ]
         },
@@ -43,8 +42,7 @@
             "prefered_bearer_type": "IPv6",
             "vrfs": [
                 {
-                    "name": "upstream",
-                    "type": "apn"
+                    "apn": "upstream"
                 }
             ]
         }
@@ -230,8 +228,7 @@
             "ue_ip_pools": [
                 {"ip_pools": ["pool-A"],
                  "vrf": {
-                     "name": "sgi",
-                     "type": "apn"
+                     "apn": "sgi"
                  },
                  "ip_versions": ["v4", "v6"]
                 }
@@ -250,8 +247,7 @@
                         "SGi-LAN"
                     ],
                     "name": {
-                        "name": "sgi",
-                        "type": "apn"
+                        "apn": "sgi"
                     }
                 },
                 {
@@ -259,8 +255,7 @@
                         "Access"
                     ],
                     "name": {
-                        "name": "irx",
-                        "type": "apn"
+                        "apn": "irx"
                     }
                 },
                 {
@@ -268,8 +263,7 @@
                         "CP-Function"
                     ],
                     "name": {
-                        "name": "cp",
-                        "type": "apn"
+                        "apn": "cp"
                     }
                 }
             ]
@@ -291,8 +285,7 @@
 		"ue_ip_pools": [
                     {"ip_pools": ["pool-A"],
                      "vrf": {
-			 "name": "sgi",
-			 "type": "apn"
+			 "apn": "sgi"
                      },
                      "ip_versions": ["v4", "v6"]
                     }
@@ -312,8 +305,7 @@
                             "SGi-LAN"
                         ],
                         "name": {
-                            "name": "sgi",
-                            "type": "apn"
+                            "apn": "sgi"
                         }
                     },
                     {
@@ -321,8 +313,7 @@
                             "Access"
                         ],
                         "name": {
-                            "name": "irx",
-                            "type": "apn"
+                            "apn": "irx"
                         }
                     },
                     {
@@ -330,8 +321,7 @@
                             "CP-Function"
                         ],
                         "name": {
-                            "name": "cp",
-                            "type": "apn"
+                            "apn": "cp"
                         }
                     }
                 ]
@@ -388,8 +378,7 @@
             "send_port": 0,
             "type": "gtp-c",
             "vrf": {
-                "name": "irx",
-                "type": "apn"
+                "apn": "irx"
             }
         },
         {
@@ -403,8 +392,7 @@
             "send_port": 0,
             "type": "gtp-u",
             "vrf": {
-                "name": "cp",
-                "type": "apn"
+                "apn": "cp"
             }
         }
     ],

--- a/apps/ergw/test/smc_SUITE_data/ggsn_proxy.json
+++ b/apps/ergw/test/smc_SUITE_data/ggsn_proxy.json
@@ -21,8 +21,7 @@
             "prefered_bearer_type": "IPv6",
             "vrfs": [
                 {
-                    "name": "example",
-                    "type": "apn"
+                    "apn": "example"
                 }
             ]
         }
@@ -273,8 +272,7 @@
                         "SGi-LAN"
                     ],
                     "name": {
-                        "name": "sgi",
-                        "type": "apn"
+                        "apn": "sgi"
                     }
                 },
                 {
@@ -282,8 +280,7 @@
                         "Access"
                     ],
                     "name": {
-                        "name": "irx",
-                        "type": "apn"
+                        "apn": "irx"
                     }
                 },
                 {
@@ -291,8 +288,7 @@
                         "CP-Function"
                     ],
                     "name": {
-                        "name": "cp",
-                        "type": "apn"
+                        "apn": "cp"
                     }
                 }
             ]
@@ -366,8 +362,7 @@
             "send_port": 0,
             "type": "gtp-c",
             "vrf": {
-                "name": "remote-irx2",
-                "type": "apn"
+                "apn": "remote-irx2"
             }
         },
         {
@@ -380,8 +375,7 @@
             "send_port": 0,
             "type": "gtp-c",
             "vrf": {
-                "name": "remote-irx",
-                "type": "apn"
+                "apn": "remote-irx"
             }
         },
         {
@@ -394,8 +388,7 @@
             "send_port": 0,
             "type": "gtp-c",
             "vrf": {
-                "name": "irx",
-                "type": "apn"
+                "apn": "irx"
             }
         },
         {
@@ -409,8 +402,7 @@
             "send_port": 0,
             "type": "gtp-u",
             "vrf": {
-                "name": "cp",
-                "type": "apn"
+                "apn": "cp"
             }
         }
     ],

--- a/apps/ergw/test/smc_SUITE_data/pgw.json
+++ b/apps/ergw/test/smc_SUITE_data/pgw.json
@@ -23,8 +23,7 @@
             "prefered_bearer_type": "IPv6",
             "vrfs": [
                 {
-                    "name": "upstream",
-                    "type": "apn"
+                    "apn": "upstream"
                 }
             ]
         },
@@ -43,8 +42,7 @@
             "prefered_bearer_type": "IPv6",
             "vrfs": [
                 {
-                    "name": "upstream",
-                    "type": "apn"
+                    "apn": "upstream"
                 }
             ]
         }
@@ -276,8 +274,7 @@
                         "SGi-LAN"
                     ],
                     "name": {
-                        "name": "sgi",
-                        "type": "apn"
+                        "apn": "sgi"
                     }
                 },
                 {
@@ -285,8 +282,7 @@
                         "Access"
                     ],
                     "name": {
-                        "name": "irx",
-                        "type": "apn"
+                        "apn": "irx"
                     }
                 },
                 {
@@ -294,8 +290,7 @@
                         "CP-Function"
                     ],
                     "name": {
-                        "name": "cp",
-                        "type": "apn"
+                        "apn": "cp"
                     }
                 }
             ]
@@ -352,8 +347,7 @@
             "send_port": 0,
             "type": "gtp-c",
             "vrf": {
-                "name": "irx",
-                "type": "apn"
+                "apn": "irx"
             }
         },
         {
@@ -367,8 +361,7 @@
             "send_port": 0,
             "type": "gtp-u",
             "vrf": {
-                "name": "cp",
-                "type": "apn"
+                "apn": "cp"
             }
         }
     ],

--- a/apps/ergw/test/smc_SUITE_data/pgw_proxy.json
+++ b/apps/ergw/test/smc_SUITE_data/pgw_proxy.json
@@ -20,8 +20,7 @@
             "prefered_bearer_type": "IPv6",
             "vrfs": [
                 {
-                    "name": "example",
-                    "type": "apn"
+                    "apn": "example"
                 }
             ]
         }
@@ -320,8 +319,7 @@
                         "SGi-LAN"
                     ],
                     "name": {
-                        "name": "sgi",
-                        "type": "apn"
+                        "apn": "sgi"
                     }
                 },
                 {
@@ -329,8 +327,7 @@
                         "Access"
                     ],
                     "name": {
-                        "name": "irx",
-                        "type": "apn"
+                        "apn": "irx"
                     }
                 },
                 {
@@ -338,8 +335,7 @@
                         "CP-Function"
                     ],
                     "name": {
-                        "name": "cp",
-                        "type": "apn"
+                        "apn": "cp"
                     }
                 }
             ]
@@ -413,8 +409,7 @@
             "send_port": 0,
             "type": "gtp-c",
             "vrf": {
-                "name": "remote-irx2",
-                "type": "apn"
+                "apn": "remote-irx2"
             }
         },
         {
@@ -427,8 +422,7 @@
             "send_port": 0,
             "type": "gtp-c",
             "vrf": {
-                "name": "remote-irx",
-                "type": "apn"
+                "apn": "remote-irx"
             }
         },
         {
@@ -441,8 +435,7 @@
             "send_port": 0,
             "type": "gtp-c",
             "vrf": {
-                "name": "irx",
-                "type": "apn"
+                "apn": "irx"
             }
         },
         {
@@ -456,8 +449,7 @@
             "send_port": 0,
             "type": "gtp-u",
             "vrf": {
-                "name": "cp",
-                "type": "apn"
+                "apn": "cp"
             }
         }
     ],

--- a/apps/ergw/test/smc_SUITE_data/saegw_s11.json
+++ b/apps/ergw/test/smc_SUITE_data/saegw_s11.json
@@ -23,8 +23,7 @@
             "prefered_bearer_type": "IPv6",
             "vrfs": [
                 {
-                    "name": "upstream",
-                    "type": "apn"
+                    "apn": "upstream"
                 }
             ]
         },
@@ -43,8 +42,7 @@
             "prefered_bearer_type": "IPv6",
             "vrfs": [
                 {
-                    "name": "upstream",
-                    "type": "apn"
+                    "apn": "upstream"
                 }
             ]
         }
@@ -236,8 +234,7 @@
                         "SGi-LAN"
                     ],
                     "name": {
-                        "name": "sgi",
-                        "type": "apn"
+                        "apn": "sgi"
                     }
                 },
                 {
@@ -245,8 +242,7 @@
                         "Access"
                     ],
                     "name": {
-                        "name": "irx",
-                        "type": "apn"
+                        "apn": "irx"
                     }
                 },
                 {
@@ -254,8 +250,7 @@
                         "CP-Function"
                     ],
                     "name": {
-                        "name": "cp",
-                        "type": "apn"
+                        "apn": "cp"
                     }
                 }
             ]
@@ -312,8 +307,7 @@
             "send_port": 0,
             "type": "gtp-c",
             "vrf": {
-                "name": "irx",
-                "type": "apn"
+                "apn": "irx"
             }
         },
         {
@@ -327,8 +321,7 @@
             "send_port": 0,
             "type": "gtp-u",
             "vrf": {
-                "name": "cp",
-                "type": "apn"
+                "apn": "cp"
             }
         }
     ],

--- a/apps/ergw/test/smc_SUITE_data/tdf.json
+++ b/apps/ergw/test/smc_SUITE_data/tdf.json
@@ -20,8 +20,7 @@
             "prefered_bearer_type": "IPv6",
             "vrfs": [
                 {
-                    "name": "sgi",
-                    "type": "apn"
+                    "apn": "sgi"
                 }
             ]
         },
@@ -37,8 +36,7 @@
             "prefered_bearer_type": "IPv6",
             "vrfs": [
                 {
-                    "name": "sgi",
-                    "type": "apn"
+                    "apn": "sgi"
                 }
             ]
         }
@@ -242,8 +240,7 @@
                         "SGi-LAN"
                     ],
                     "name": {
-                        "name": "sgi",
-                        "type": "apn"
+                        "apn": "sgi"
                     }
                 },
                 {
@@ -252,8 +249,7 @@
                         "Access"
                     ],
                     "name": {
-                        "name": "epc",
-                        "type": "apn"
+                        "apn": "epc"
                     }
                 },
                 {
@@ -261,8 +257,7 @@
                         "CP-Function"
                     ],
                     "name": {
-                        "name": "cp",
-                        "type": "apn"
+                        "apn": "cp"
                     }
                 }
             ]
@@ -320,8 +315,7 @@
             "send_port": 0,
             "type": "gtp-u",
             "vrf": {
-                "name": "cp",
-                "type": "apn"
+                "apn": "cp"
             }
         }
     ],


### PR DESCRIPTION
The VRF name is similar to IpAddress as it can contain different
typed values. Instead of using type attribute to overload the
meaning of the name attribute, use per type properties.