### PR TITLE
rework context inactivity timeout

### DIFF
--- a/apps/ergw/priv/schemas/ergw_config.yaml
+++ b/apps/ergw/priv/schemas/ergw_config.yaml
@@ -134,8 +134,6 @@ components:
           type: array
           items:
             $ref: TS29571_CommonData.yaml#/components/schemas/Ipv6Addr
-        Idle-Timeout:
-          $ref: "#/components/schemas/TimeoutInf"
         MS-Primary-DNS-Server:
           $ref: TS29571_CommonData.yaml#/components/schemas/Ipv4Addr
         MS-Primary-NBNS-Server:
@@ -182,6 +180,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/VrfName"
+        inactivity_timeout:
+          $ref: "#/components/schemas/TimeoutInf"
 
     SAEGwHandler:
       type: object

--- a/apps/ergw/src/ergw_config.erl
+++ b/apps/ergw/src/ergw_config.erl
@@ -228,13 +228,13 @@ config_meta_apns() ->
 	     bearer_type          => atom,
 	     prefered_bearer_type => atom,
 	     ipv6_ue_interface_id => ip6_ifid,
+	     inactivity_timeout   => timeout,
 	     'MS-Primary-DNS-Server'    => ip4_address,
 	     'MS-Secondary-DNS-Server'  => ip4_address,
 	     'MS-Primary-NBNS-Server'   => ip4_address,
 	     'MS-Secondary-NBNS-Server' => ip4_address,
 	     'DNS-Server-IPv6-Address'  => {list, ip6_address},
-	     '3GPP-IPv6-DNS-Servers'    => {list, ip6_address},
-	     'Idle-Timeout'             => timeout
+	     '3GPP-IPv6-DNS-Servers'    => {list, ip6_address}
 	    },
     {map, {apn, apn}, Meta}.
 

--- a/apps/ergw/test/ergw_http_api_SUITE_data/ggsn.json
+++ b/apps/ergw/test/ergw_http_api_SUITE_data/ggsn.json
@@ -9,7 +9,7 @@
     },
     "apns": [
         {
-            "Idle-Timeout": {
+            "inactivity_timeout": {
                 "timeout": 8,
                 "unit": "hour"
             },

--- a/apps/ergw/test/sbi_nbsf_SUITE_data/ipv4.json
+++ b/apps/ergw/test/sbi_nbsf_SUITE_data/ipv4.json
@@ -145,7 +145,7 @@
     },
     "apns":[
         {
-            "Idle-Timeout":{
+            "inactivity_timeout":{
                 "timeout":8,
                 "unit":"hour"
             },
@@ -164,7 +164,7 @@
             ]
         },
         {
-            "Idle-Timeout":{
+            "inactivity_timeout":{
                 "timeout":8,
                 "unit":"hour"
             },
@@ -182,7 +182,7 @@
             ]
         },
         {
-            "Idle-Timeout":{
+            "inactivity_timeout":{
                 "timeout":8,
                 "unit":"hour"
             },
@@ -200,7 +200,7 @@
             ]
         },
         {
-            "Idle-Timeout":{
+            "inactivity_timeout":{
                 "timeout":8,
                 "unit":"hour"
             },
@@ -218,7 +218,7 @@
             ]
         },
         {
-            "Idle-Timeout":{
+            "inactivity_timeout":{
                 "timeout":8,
                 "unit":"hour"
             },

--- a/apps/ergw/test/sbi_nbsf_SUITE_data/ipv6.json
+++ b/apps/ergw/test/sbi_nbsf_SUITE_data/ipv6.json
@@ -145,7 +145,7 @@
     },
     "apns":[
         {
-            "Idle-Timeout":{
+            "inactivity_timeout":{
                 "timeout":8,
                 "unit":"hour"
             },
@@ -164,7 +164,7 @@
             ]
         },
         {
-            "Idle-Timeout":{
+            "inactivity_timeout":{
                 "timeout":8,
                 "unit":"hour"
             },
@@ -182,7 +182,7 @@
             ]
         },
         {
-            "Idle-Timeout":{
+            "inactivity_timeout":{
                 "timeout":8,
                 "unit":"hour"
             },
@@ -200,7 +200,7 @@
             ]
         },
         {
-            "Idle-Timeout":{
+            "inactivity_timeout":{
                 "timeout":8,
                 "unit":"hour"
             },
@@ -218,7 +218,7 @@
             ]
         },
         {
-            "Idle-Timeout":{
+            "inactivity_timeout":{
                 "timeout":8,
                 "unit":"hour"
             },

--- a/apps/ergw/test/smc_SUITE_data/ggsn.json
+++ b/apps/ergw/test/smc_SUITE_data/ggsn.json
@@ -9,7 +9,7 @@
     },
     "apns": [
         {
-            "Idle-Timeout": {
+            "inactivity_timeout": {
                 "timeout": 8,
                 "unit": "hour"
             },
@@ -28,7 +28,7 @@
             ]
         },
         {
-            "Idle-Timeout": {
+            "inactivity_timeout": {
                 "timeout": 8,
                 "unit": "hour"
             },

--- a/apps/ergw/test/smc_SUITE_data/ggsn_proxy.json
+++ b/apps/ergw/test/smc_SUITE_data/ggsn_proxy.json
@@ -10,7 +10,7 @@
     "accept_new": true,
     "apns": [
         {
-            "Idle-Timeout": {
+            "inactivity_timeout": {
                 "timeout": 8,
                 "unit": "hour"
             },

--- a/apps/ergw/test/smc_SUITE_data/pgw.json
+++ b/apps/ergw/test/smc_SUITE_data/pgw.json
@@ -9,7 +9,7 @@
     },
     "apns": [
         {
-            "Idle-Timeout": {
+            "inactivity_timeout": {
                 "timeout": 8,
                 "unit": "hour"
             },
@@ -28,7 +28,7 @@
             ]
         },
         {
-            "Idle-Timeout": {
+            "inactivity_timeout": {
                 "timeout": 8,
                 "unit": "hour"
             },

--- a/apps/ergw/test/smc_SUITE_data/pgw_proxy.json
+++ b/apps/ergw/test/smc_SUITE_data/pgw_proxy.json
@@ -9,7 +9,7 @@
     },
     "apns": [
         {
-            "Idle-Timeout": {
+            "inactivity_timeout": {
                 "timeout": 8,
                 "unit": "hour"
             },

--- a/apps/ergw/test/smc_SUITE_data/saegw_s11.json
+++ b/apps/ergw/test/smc_SUITE_data/saegw_s11.json
@@ -9,7 +9,7 @@
     },
     "apns": [
         {
-            "Idle-Timeout": {
+            "inactivity_timeout": {
                 "timeout": 8,
                 "unit": "hour"
             },
@@ -28,7 +28,7 @@
             ]
         },
         {
-            "Idle-Timeout": {
+            "inactivity_timeout": {
                 "timeout": 8,
                 "unit": "hour"
             },

--- a/apps/ergw/test/smc_SUITE_data/tdf.json
+++ b/apps/ergw/test/smc_SUITE_data/tdf.json
@@ -9,7 +9,7 @@
     },
     "apns": [
         {
-            "Idle-Timeout": {
+            "inactivity_timeout": {
                 "timeout": 8,
                 "unit": "hour"
             },
@@ -25,7 +25,7 @@
             ]
         },
         {
-            "Idle-Timeout": {
+            "inactivity_timeout": {
                 "timeout": 8,
                 "unit": "hour"
             },

--- a/apps/ergw_core/include/ergw.hrl
+++ b/apps/ergw_core/include/ergw.hrl
@@ -111,7 +111,8 @@
 	  charging_identifier    :: non_neg_integer(),
 	  default_bearer_id      :: 'undefined' | non_neg_integer(),
 
-	  'Idle-Timeout'  :: non_neg_integer() | infinity,
+	  idle_timeout           :: non_neg_integer() | infinity,
+	  inactivity_timeout     :: non_neg_integer() | infinity,
 
 	  version                :: 'v1' | 'v2',
 	  pdn_type               :: 'undefined' | 'IPv4' | 'IPv6' | 'IPv4v6' | 'Non-IP',

--- a/apps/ergw_core/src/ergw_apn.erl
+++ b/apps/ergw_core/src/ergw_apn.erl
@@ -50,7 +50,7 @@ get(_, _) ->
 		      {bearer_type, 'IPv4v6'},
 		      {prefered_bearer_type, 'IPv6'},
 		      {ipv6_ue_interface_id, default},
-		      {'Idle-Timeout', 28800000}         %% 8hrs timer in msecs
+		      {inactivity_timeout, 48 * 3600 * 1000}         %% 48hrs timer in msecs
 		     ]).
 
 validate_options({APN0, Value}) when ?is_opts(Value) ->
@@ -118,9 +118,9 @@ validate_apn_option({Opt, Value})
        Opt == 'MS-Primary-NBNS-Server';  Opt == 'MS-Secondary-NBNS-Server';
        Opt == 'DNS-Server-IPv6-Address'; Opt == '3GPP-IPv6-DNS-Servers' ->
     {Opt, ergw_core_config:validate_ip_cfg_opt(Opt, Value)};
-validate_apn_option({'Idle-Timeout', Timer})
+validate_apn_option({Opt = inactivity_timeout, Timer})
   when (is_integer(Timer) andalso Timer > 0)
        orelse Timer =:= infinity->
-    {'Idle-Timeout', Timer};
+    {Opt, Timer};
 validate_apn_option({Opt, Value}) ->
     erlang:error(badarg, [Opt, Value]).

--- a/apps/ergw_core/src/saegw_s11.erl
+++ b/apps/ergw_core/src/saegw_s11.erl
@@ -115,6 +115,16 @@ handle_event(cast, {packet_in, _Socket, _IP, _Port, _Msg}, _State, _Data) ->
     ?LOG(warning, "packet_in not handled (yet): ~p", [_Msg]),
     keep_state_and_data;
 
+handle_event({timeout, context_idle}, check_session_liveness, State,
+	     #{context := Context, pfcp := PCtx} = Data) ->
+    case ergw_pfcp_context:session_liveness_check(PCtx) of
+	ok ->
+	    Actions = context_idle_action([], Context),
+	    {keep_state, Data, Actions};
+	_ ->
+	    delete_context(undefined, cp_inactivity_timeout, State, Data)
+    end;
+
 handle_event(info, _Info, _State, _Data) ->
     keep_state_and_data.
 
@@ -894,8 +904,8 @@ create_session_response(Result, SessionOpts, RequestIEs, EBI,
 
 %% Wrapper for gen_statem state_callback_result Actions argument
 %% Timeout set in the context of a prolonged idle gtpv2 session
-context_idle_action(Actions, #context{'Idle-Timeout' = Timeout})
+context_idle_action(Actions, #context{inactivity_timeout = Timeout})
   when is_integer(Timeout) orelse Timeout =:= infinity ->
-    [{{timeout, context_idle}, Timeout, stop_session} | Actions];
+    [{{timeout, context_idle}, Timeout, check_session_liveness} | Actions];
 context_idle_action(Actions, _) ->
     Actions.

--- a/apps/ergw_core/test/ergw_ggsn_test_lib.erl
+++ b/apps/ergw_core/test/ergw_ggsn_test_lib.erl
@@ -351,6 +351,14 @@ make_request(unsupported, _SubType,
 
 %%%-------------------------------------------------------------------
 
+
+make_response(#gtp{type = update_pdp_context_request, seq_no = SeqNo},
+	      invalid_teid,
+	      #gtpc{remote_control_tei = _}) ->
+    IEs = [#cause{value = context_not_found}],
+    #gtp{version = v1, type = update_pdp_context_response,
+	 tei = 0, seq_no = SeqNo, ie = IEs};
+
 make_response(#gtp{type = update_pdp_context_request, seq_no = SeqNo},
 	      _SubType,
 	      #gtpc{restart_counter = RCnt,

--- a/apps/ergw_core/test/pgw_SUITE.erl
+++ b/apps/ergw_core/test/pgw_SUITE.erl
@@ -204,14 +204,14 @@
 		[{?'APN-EXAMPLE',
 		  [{vrf, sgi},
 		   {ip_pools, [<<"pool-A">>, <<"pool-B">>]},
-		   {'Idle-Timeout', 21600000}]}, % Idle timeout 6 hours
+		   {inactivity_timeout, 21600000}]}, % Idle timeout 6 hours
 		 {[<<"exa">>, <<"mple">>, <<"net">>],
 		  [{vrf, sgi},
 		   {ip_pools, [<<"pool-A">>]}]},
 		 {[<<"APN1">>],
 		  [{vrf, sgi},
 		   {ip_pools, [<<"pool-A">>]},
-		   {'Idle-Timeout', 28800000}]}, % Idle timeout 8 hours
+		   {inactivity_timeout, 28800000}]}, % Idle timeout 8 hours
 		 {[<<"APN2">>, <<"mnc001">>, <<"mcc001">>, <<"gprs">>],
 		  [{vrf, sgi},
 		   {ip_pools, [<<"pool-A">>]}]},
@@ -219,12 +219,12 @@
 		  [{vrf, sgi},
 		   {ip_pools, [<<"pool-A">>]},
 		   {bearer_type, 'IPv6'},
-		   {'Idle-Timeout', infinity}]},
+		   {inactivity_timeout, infinity}]},
 		 {[<<"v4only">>],
 		  [{vrf, sgi},
 		   {ip_pools, [<<"pool-A">>]},
 		   {bearer_type, 'IPv4'},
-		   {'Idle-Timeout', 21600000}]},
+		   {inactivity_timeout, 21600000}]},
 		 {[<<"prefV6">>],
 		  [{vrf, sgi},
 		   {ip_pools, [<<"pool-A">>]},
@@ -991,9 +991,9 @@ init_per_testcase(tdf_app_id, Config) ->
     setup_per_testcase(Config),
     ergw_test_lib:load_aaa_answer_config([{{gx, 'CCR-Initial'}, 'Initial-Gx-TDF-App'}]),
     Config;
-%% gtp 'Idle-Timeout' reduced to 300ms for test purposes
+%% gtp inactivity_timeout reduced to 300ms for test purposes
 init_per_testcase(gtp_idle_timeout, Config) ->
-    ergw_test_lib:set_apn_key('Idle-Timeout', 300),
+    ergw_test_lib:set_apn_key(inactivity_timeout, 300),
     setup_per_testcase(Config),
     Config;
 init_per_testcase(_, Config) ->
@@ -1086,9 +1086,9 @@ end_per_testcase(TestCase, Config)
     ergw_test_sx_up:nat_port_blocks('pgw-u01', sgi, []),
     ergw_test_sx_up:nat_port_blocks('pgw-u01', example, []),
     end_per_testcase(Config);
-%% gtp 'Idle-Timeout' reset to default 28800000ms ~8 hrs
+%% gtp inactivity_timeout reset to default 28800000ms ~8 hrs
 end_per_testcase(gtp_idle_timeout, Config) ->
-    ergw_test_lib:set_apn_key('Idle-Timeout', 28800000),
+    ergw_test_lib:set_apn_key(inactivity_timeout, 28800000),
     end_per_testcase(Config);
 end_per_testcase(_, Config) ->
     end_per_testcase(Config).
@@ -5503,17 +5503,12 @@ gx_invalid_charging_rule(Config) ->
 gtp_idle_timeout() ->
     [{doc, "Checks if the gtp idle timeout is triggered"}].
 gtp_idle_timeout(Config) ->
-    Cntl = whereis(gtpc_client_server),
     {GtpC, _, _} = create_session(Config),
     %% The meck wait timeout (400 ms) has to be more than then the Idle-Timeout
     ok = meck:wait(gtp_context, handle_event,
-		   [{timeout, context_idle}, stop_session, '_', '_'], 400),
+		   [{timeout, context_idle}, '_', '_', '_'], 400),
 
-    %% Timeout triggers a delete_bearer_request towards the S-GW.
-    Req = recv_pdu(Cntl, 5000),
-    ?match(#gtp{type = delete_bearer_request}, Req),
-    Resp = make_response(Req, simple, GtpC),
-    send_pdu(Cntl, GtpC, Resp),
+    delete_session(GtpC),
 
     ?equal([], outstanding_requests()),
 
@@ -5529,7 +5524,7 @@ up_inactivity_timer() ->
 up_inactivity_timer(Config) ->
     CtxKey = #context_key{socket = 'irx-socket', id = {imsi, ?'IMSI', 5}},
     Interim = rand:uniform(1800) + 1800,
-    AAAReply = #{'Acct-Interim-Interval' => Interim},
+    AAAReply = #{'Idle-Timeout' => 1800, 'Acct-Interim-Interval' => Interim},
 
     ok = meck:expect(
 	   ergw_aaa_session, invoke,

--- a/apps/ergw_core/test/pgw_dist_SUITE.erl
+++ b/apps/ergw_core/test/pgw_dist_SUITE.erl
@@ -221,14 +221,14 @@
 		[{?'APN-EXAMPLE',
 		  [{vrf, sgi},
 		   {ip_pools, [<<"pool-A">>, <<"pool-B">>]},
-		   {'Idle-Timeout', 21600000}]}, % Idle timeout 6 hours
+		   {'inactivity_timeout', 21600000}]}, % Idle timeout 6 hours
 		 {[<<"exa">>, <<"mple">>, <<"net">>],
 		  [{vrf, sgi},
 		   {ip_pools, [<<"pool-A">>]}]},
 		 {[<<"APN1">>],
 		  [{vrf, sgi},
 		   {ip_pools, [<<"pool-A">>]},
-		   {'Idle-Timeout', 28800000}]}, % Idle timeout 8 hours
+		   {'inactivity_timeout', 28800000}]}, % Idle timeout 8 hours
 		 {[<<"APN2">>, <<"mnc001">>, <<"mcc001">>, <<"gprs">>],
 		  [{vrf, sgi},
 		   {ip_pools, [<<"pool-A">>]}]},
@@ -236,12 +236,12 @@
 		  [{vrf, sgi},
 		   {ip_pools, [<<"pool-A">>]},
 		   {bearer_type, 'IPv6'},
-		   {'Idle-Timeout', infinity}]},
+		   {'inactivity_timeout', infinity}]},
 		 {[<<"v4only">>],
 		  [{vrf, sgi},
 		   {ip_pools, [<<"pool-A">>]},
 		   {bearer_type, 'IPv4'},
-		   {'Idle-Timeout', 21600000}]},
+		   {'inactivity_timeout', 21600000}]},
 		 {[<<"prefV6">>],
 		  [{vrf, sgi},
 		   {ip_pools, [<<"pool-A">>]},


### PR DESCRIPTION
Decouple the Idle-Timeout from the GTP context inactivity timeout.

Idle-Timeout is now only used for decting periods of no traffic.

Inactivity timeout is a regular check from the CP to UP to check
if the PFCP context still exists.