### PR TITLE
Suppress reporting of ergw_cluster startup process termination

### DIFF
--- a/apps/ergw_cluster/src/ergw_cluster.erl
+++ b/apps/ergw_cluster/src/ergw_cluster.erl
@@ -134,7 +134,7 @@ handle_event({call, From}, {start, _}, running, _) ->
 handle_event({call, _}, {start, _}, _State, _) ->
     {keep_state_and_data, [postpone]};
 
-handle_event(info, {'EXIT', Pid, ok}, startup,
+handle_event(info, {'EXIT', Pid, normal}, startup,
 	     #{init := Now, startup := Pid} = Data) ->
     ?LOG(info, "ergw_core: ready to process requests, cluster started in ~w ms",
 	 [erlang:convert_time_unit(erlang:monotonic_time() - Now, native, millisecond)]),
@@ -167,7 +167,7 @@ startup() ->
 	_ ->
 	    init:wait_until_started()
     end,
-    exit(ok).
+    exit(normal).
 
 start_cluster(Config) ->
     %% borrowed from riak_core:standard_join


### PR DESCRIPTION
At startup of ergw_cluster process it creates a special process to
be sure that Erlang runtime fully started before ergw_cluster may
start to do its job. After that the special process done with its
job we terminate it with exit(ok) and this event is reported to log:

```
2021-08-15T23:11:03.058973+06:00 <0.1050.0> error: crasher: initial call: ergw_cluster:'-fun.startup/0-'/0, pid: <0.1050.0>, 
registered_name: [], exit: {ok,[{ergw_cluster,startup,0,[{file,"/home/alex/work/ergw/apps/ergw_cluster/src/ergw_cluster.erl"},
{line,170}]},{proc_lib,init_p,3,[{file,"proc_lib.erl"},{line,211}]}]}, ancestors: [ergw_cluster,ergw_cluster_sup,<0.1047.0>], 
message_queue_len: 0, messages: [], links: [<0.1049.0>], dictionary: [], trap_exit: false, status: running, heap_size: 376, 
stack_size: 29, reductions: 151; neighbours:
```

According to proc_lib documentation:

> When a process that is started using proc_lib terminates abnormally
(that is, with another exit reason than normal, shutdown, or {shutdown,Term}),
a crash report is generated, which is written to terminal by the default
logger handler setup by Kernel

This commit changes `ok` reason to `normal` to suppress this report in console.
There is no sense to have this report in logs as anyway exit signal is handled
by the ergw_cluster process.