### PR TITLE
Suppress reporting of ergw_cluster startup process termination

### DIFF
--- a/apps/ergw_cluster/src/ergw_cluster.erl
+++ b/apps/ergw_cluster/src/ergw_cluster.erl
@@ -103,7 +103,7 @@ init([]) ->
     process_flag(trap_exit, true),
     Now = erlang:monotonic_time(),
 
-    Pid = proc_lib:spawn_link(fun startup/0),
+    Pid = spawn_link(fun startup/0),
     {ok, startup, #{init => Now, startup => Pid}}.
 
 handle_event({call, From}, wait_till_ready, State, _Data)


### PR DESCRIPTION
At startup of ergw_cluster process it creates a special process to
be sure that Erlang runtime fully started before ergw_cluster may
start to do its job. After that the special process done with its
job we terminate it with exit(ok) and this event is reported to log:

```
2021-08-15T23:11:03.058973+06:00 <0.1050.0> error: crasher: initial call: ergw_cluster:'-fun.startup/0-'/0, pid: <0.1050.0>, 
registered_name: [], exit: {ok,[{ergw_cluster,startup,0,[{file,"/home/alex/work/ergw/apps/ergw_cluster/src/ergw_cluster.erl"},
{line,170}]},{proc_lib,init_p,3,[{file,"proc_lib.erl"},{line,211}]}]}, ancestors: [ergw_cluster,ergw_cluster_sup,<0.1047.0>], 
message_queue_len: 0, messages: [], links: [<0.1049.0>], dictionary: [], trap_exit: false, status: running, heap_size: 376, 
stack_size: 29, reductions: 151; neighbours:
```

According to proc_lib documentation:

> When a process that is started using proc_lib terminates abnormally
  (that is, with another exit reason than normal, shutdown, or {shutdown,Term}),
  a crash report is generated, which is written to terminal by the default
  logger handler setup by Kernel

This commit replaces proc_lib:spawn_link/1 with erlang:spawn_link/1 to get rid
of this report in console. There is no sense to have this report in logs as
anyway the exit signal will be handled by the ergw_cluster process.