### PR TITLE
rework context teardown on inactivity to include a proper cause

### DIFF
--- a/apps/ergw_core/src/gtp_context.erl
+++ b/apps/ergw_core/src/gtp_context.erl
@@ -418,9 +418,9 @@ handle_event({call, From},
 handle_event({call, From},
 	     {sx, #pfcp{type = session_report_request,
 			ie = #{report_type := #report_type{upir = 1}}}},
-	     State, #{pfcp := PCtx} = Data0) ->
-    Data = close_context(both, up_inactivity_timeout, State, Data0),
-    {next_state, shutdown, Data, [{reply, From, {ok, PCtx}}]};
+	     State, #{pfcp := PCtx} = Data) ->
+    gen_statem:reply(From, {ok, PCtx}),
+    delete_context(undefined, up_inactivity_timeout, State, Data);
 
 %% Usage Report
 handle_event({call, From},

--- a/apps/ergw_core/src/saegw_s11.erl
+++ b/apps/ergw_core/src/saegw_s11.erl
@@ -743,10 +743,17 @@ send_request(Tunnel, T3, N3, Type, RequestIEs, ReqInfo) ->
 send_request(Tunnel, Src, DstIP, DstPort, T3, N3, Msg, ReqInfo) ->
     gtp_context:send_request(Tunnel, Src, DstIP, DstPort, T3, N3, Msg, ReqInfo).
 
+map_term_cause(TermCause)
+  when TermCause =:= cp_inactivity_timeout;
+       TermCause =:= up_inactivity_timeout ->
+    pdn_connection_inactivity_timer_expires;
+map_term_cause(_TermCause) ->
+    reactivation_requested.
+
 delete_context(From, TermCause, connected, #{left_tunnel := Tunnel} = Data) ->
     Type = delete_bearer_request,
     EBI = 5,
-    RequestIEs0 = [#v2_cause{v2_cause = reactivation_requested},
+    RequestIEs0 = [#v2_cause{v2_cause = map_term_cause(TermCause)},
 		   #v2_eps_bearer_id{eps_bearer_id = EBI}],
     RequestIEs = gtp_v2_c:build_recovery(Type, Tunnel, false, RequestIEs0),
     send_request(Tunnel, ?T3, ?N3, Type, RequestIEs, {From, TermCause}),

--- a/apps/ergw_core/test/saegw_s11_SUITE.erl
+++ b/apps/ergw_core/test/saegw_s11_SUITE.erl
@@ -478,7 +478,7 @@ common() ->
      gx_invalid_charging_rulebase,
      gx_invalid_charging_rule,
      gx_rar_gy_interaction,
-     gtp_idle_timeout,
+     gtp_idle_timeout_pfcp_session_loss,
      up_inactivity_timer].
 
 groups() ->
@@ -602,7 +602,7 @@ init_per_testcase(gx_invalid_charging_rule, Config) ->
     ergw_test_lib:load_aaa_answer_config([{{gx, 'CCR-Initial'}, 'Initial-Gx-Fail-2'}]),
     Config;
 %% gtp inactivity_timeout reduced to 300ms for test purposes
-init_per_testcase(gtp_idle_timeout, Config) ->
+init_per_testcase(gtp_idle_timeout_pfcp_session_loss, Config) ->
     ergw_test_lib:set_apn_key(inactivity_timeout, 300),
     setup_per_testcase(Config),
     Config;
@@ -652,7 +652,7 @@ end_per_testcase(create_session_overload, Config) ->
     end_per_testcase(Config),
     Config;
 %% gtp inactivity_timeout reset to default 28800000ms ~8 hrs
-end_per_testcase(gtp_idle_timeout, Config) ->
+end_per_testcase(gtp_idle_timeout_pfcp_session_loss, Config) ->
     ergw_test_lib:set_apn_key(inactivity_timeout, 28800000),
     end_per_testcase(Config),
     Config;
@@ -2162,15 +2162,30 @@ gx_invalid_charging_rule(Config) ->
     ok.
 
 %%--------------------------------------------------------------------
-gtp_idle_timeout() ->
+gtp_idle_timeout_pfcp_session_loss() ->
     [{doc, "Checks if the gtp idle timeout is triggered"}].
-gtp_idle_timeout(Config) ->
+gtp_idle_timeout_pfcp_session_loss(Config) ->
+    Cntl = whereis(gtpc_client_server),
+
     {GtpC, _, _} = create_session(Config),
     %% The meck wait timeout (400 ms) has to be more than then the Idle-Timeout
     ok = meck:wait(gtp_context, handle_event,
 		   [{timeout, context_idle}, '_', '_', '_'], 400),
 
-    delete_session(GtpC),
+    %% kill the UP session
+    ergw_test_sx_up:reset('pgw-u01'),
+
+    %% wait for session cleanup
+    Req = recv_pdu(Cntl, 5000),
+    ?match(#gtp{type = delete_bearer_request,
+		ie = #{{v2_cause,0} :=
+			   #v2_cause{v2_cause = pdn_connection_inactivity_timer_expires}}},
+	   Req),
+    Resp = make_response(Req, simple, GtpC),
+    send_pdu(Cntl, GtpC, Resp),
+
+    ct:sleep(100),
+    delete_session(not_found, GtpC),
 
     ?equal([], outstanding_requests()),
 
@@ -2184,6 +2199,7 @@ gtp_idle_timeout(Config) ->
 up_inactivity_timer() ->
     [{doc, "Test expiry of the User Plane Inactivity Timer"}].
 up_inactivity_timer(Config) ->
+    Cntl = whereis(gtpc_client_server),
     CtxKey = #context_key{socket = 'irx', id = {imsi, ?'IMSI', 5}},
     Interim = rand:uniform(1800) + 1800,
     AAAReply = #{'Idle-Timeout' => 1800, 'Acct-Interim-Interval' => Interim},
@@ -2201,7 +2217,7 @@ up_inactivity_timer(Config) ->
 		   meck:passthrough([Session, SessionOpts, Procedure, Opts])
 	   end),
 
-    create_session(Config),
+    {GtpC, _, _} = create_session(Config),
 
     {_Handler, Server} = gtp_context_reg:lookup(CtxKey),
     true = is_pid(Server),
@@ -2215,6 +2231,15 @@ up_inactivity_timer(Config) ->
 	   maps:get(user_plane_inactivity_timer, SER#pfcp.ie)),
 
     ergw_test_sx_up:up_inactivity_timer_expiry('pgw-u01', PCtx),
+
+    %% wait for session cleanup
+    Req = recv_pdu(Cntl, 5000),
+    ?match(#gtp{type = delete_bearer_request}, Req),
+    Resp = make_response(Req, simple, GtpC),
+    send_pdu(Cntl, GtpC, Resp),
+
+    ct:sleep(100),
+    delete_session(not_found, GtpC),
 
     ?equal([], outstanding_requests()),
     ok = meck:wait(?HUT, terminate, '_', ?TIMEOUT),


### PR DESCRIPTION
Rework the context inactivity handling to generate a delete GTP
message with a related cause (PDP address inactivity timer expire /
PDN connection inactivity timer expire).