### PR TITLE
convert QoS-Information to AVP before putting them in TDV/SDC

### DIFF
--- a/src/ergw_gsn_lib.erl
+++ b/src/ergw_gsn_lib.erl
@@ -301,6 +301,8 @@ init_cev_from_session(Now, SessionOpts) ->
 		     (K, V, M) when K == '3GPP-SGSN-Address';
 				    K == '3GPP-SGSN-IPv6-Address' ->
 			  M#{'SGSN-Address' => [V]};
+		     ('QoS-Information' = K, V, M) ->
+			  M#{K => [ergw_aaa_diameter:qos_from_session(V)]};
 		     (K, V, M) -> M#{K => [V]}
 		  end,
 		  Init, maps:with(Keys, SessionOpts)),

--- a/test/ergw_pgw_test_lib.erl
+++ b/test/ergw_pgw_test_lib.erl
@@ -346,7 +346,7 @@ create_session_request(Base, N,
     IEs0 =
 	[#v2_recovery{restart_counter = RCnt},
 	 #v2_access_point_name{apn = apn(simple)},
-	 #v2_aggregate_maximum_bit_rate{uplink = 48128, downlink = 1704125},
+	 #v2_aggregate_maximum_bit_rate{uplink = 4294968, downlink = 4294968},
 	 #v2_apn_restriction{restriction_type_value = 0},
 	 #v2_bearer_context{
 	    group = [#v2_bearer_level_quality_of_service{


### PR DESCRIPTION
QoS-Information in the session is keep in bps, however that can
overflow the 32bit allowed on some AAA AVPs. Run the values through
the ergw_aaa converter that takes care of the overflow before
initializing TDVs and SDCs with them.