### PR TITLE
Fix race condition for gtp_path

### DIFF
--- a/apps/ergw_core/src/gtp_path.erl
+++ b/apps/ergw_core/src/gtp_path.erl
@@ -102,8 +102,7 @@ maybe_new_path(Socket, Version, RemoteIP, Trigger) ->
 	    {ok, Args0} = getopts(),
 	    PeerArgs = get_peer_opts(RemoteIP),
 	    Args = maps:merge(Args0, PeerArgs),
-	    {ok, Path} = gtp_path_sup:new_path(Socket, Version, RemoteIP, Trigger, Args),
-	    Path
+	    gtp_path_reg:lookup_and_create({Socket, Version, RemoteIP, Trigger, Args})
     end.
 
 handle_request(#request{socket = Socket, ip = IP} = ReqKey, #gtp{version = Version} = Msg) ->


### PR DESCRIPTION
Fix race between the path startup from `gtp_path:gateway_nodes/3` called by `ergw_proxy_lib:select_gw/5` and the actual attempt to use that path through `gtp_path:aquire_lease/1`.