### PR TITLE
replace simple IP pool free table with LRU implementation

### DIFF
--- a/apps/ergw_core/src/lru.erl
+++ b/apps/ergw_core/src/lru.erl
@@ -1,0 +1,66 @@
+%% Copyright 2021, Travelping GmbH <info@travelping.com>
+
+%% This program is free software; you can redistribute it and/or
+%% modify it under the terms of the GNU General Public License
+%% as published by the Free Software Foundation; either version
+%% 2 of the License, or (at your option) any later version.
+
+%% ets LRU cache for IP pools, scales to at least 2^24 entries.
+
+-module(lru).
+
+-record(lru, {queue, index}).
+
+-export([from_list/1, to_list/1,
+	 pop/1, push/2, take/2,
+	 valid/1, info/1]).
+
+-ignore_xref([?MODULE]).
+
+from_list([{{_, _}}|_] = List) ->
+    Queue = ets:new(entries, [ordered_set]),
+    Index = ets:new(index, [set]),
+
+    IndexList = [{Key, QEntry} || {{_, Key} = QEntry} <- List],
+
+    true = ets:insert(Queue, List),
+    true = ets:insert(Index, IndexList),
+    #lru{queue = Queue, index = Index}.
+
+to_list(#lru{queue = Queue}) ->
+    ets:tab2list(Queue).
+
+pop(#lru{queue = Queue, index = Index}) ->
+    case ets:first(Queue) of
+	{_, Key} = Entry ->
+	    ets:delete(Queue, Entry),
+	    ets:delete(Index, Key),
+	    {ok, Key};
+	'$end_of_table' ->
+	    {error, empty}
+    end.
+
+push(Key, #lru{queue = Queue, index = Index}) ->
+    Now = erlang:monotonic_time(),
+    case ets:insert_new(Index, {Key, Now}) of
+	true ->
+	    ets:insert(Queue, {{Now, Key}}),
+	    ok;
+	false ->
+	    erlang:error(badarg, [Key])
+    end.
+
+take(Key, #lru{queue = Queue, index = Index}) ->
+    case ets:take(Index, Key) of
+	[{_, QEntry}] ->
+	    ets:delete(Queue, QEntry),
+	    ok;
+	_ ->
+	    {error, not_found}
+    end.
+
+valid(#lru{queue = Queue, index = Index}) ->
+    ets:info(Queue, size) =:= ets:info(Index, size).
+
+info(#lru{queue = Queue, index = Index}) ->
+    {ets:info(Queue, size), ets:info(Index, size)}.


### PR DESCRIPTION
Cherry-pick of https://github.com/travelping/ergw/pull/450
___
The free table was effectively acting as a queue (LRU). push and
pop operation where fast, but a direct removal of a single item
did require a full table scan.
For large IP pools, that could lead to unacceptable delays.

The LRU implementation uses two indexes and is much faster when
removing an item from the middle of the queue.