### PR TITLE
fix service normalization in NAPTR records from DNS

### DIFF
--- a/apps/ergw_core/src/ergw_inet_res.erl
+++ b/apps/ergw_core/src/ergw_inet_res.erl
@@ -243,7 +243,7 @@ tggp_protocol(List) when is_list(List) ->
 
 normalize_naptr_services(Services) ->
     [Service | Protocols] = string:tokens(Services, ":"),
-    [{tggp_service(Service), tggp_protocol(P)} || P <- Protocols].
+    ordsets:from_list([{tggp_service(Service), tggp_protocol(P)} || P <- Protocols]).
 
 normalize_rr(in, naptr, {Order, Pref, Flag, Services, RegExp, Host}, RR)
   when is_list(Host), is_list(RegExp) ->

--- a/docker/dns-test-server/dns_data/db.test-net-001
+++ b/docker/dns-test-server/dns_data/db.test-net-001
@@ -19,6 +19,7 @@ ns2     IN  A      10.10.4.3
 ns1     IN  AAAA   2001:470:7720:16:250:56ff:fe96:1321
 
 example.apn             IN NAPTR 100 100 "s" "x-3gpp-pgw:x-s8-gtp" "" pgw-list-2.node
+test-01.apn             IN NAPTR 100 100 "a" "x-3gpp-pgw:x-s8-gtp:x-s5-gtp:x-gp:x-gn" "" ergw.ovh.node
 
 pgw-list-2.node         IN SRV 100 100 2123 ergw.ovh.node
 


### PR DESCRIPTION
The normalize service field is supposed to be ordset. The
normalization instead produced an unsort list. The datatype
itself is the same (a list), but the set operations will not
work as expected on the unsorted list.